### PR TITLE
[23.05] openwisp-config to 1.2.1 and openwisp-monitoring to 0.3.0

### DIFF
--- a/admin/openwisp-config/Makefile
+++ b/admin/openwisp-config/Makefile
@@ -5,14 +5,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openwisp-config
-PKG_VERSION:=1.2.0
+PKG_VERSION:=1.2.1
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Federico Capoano <f.capoano@openwisp.io>
 PKG_LICENSE:=GPL-3.0-or-later
 
 PKG_SOURCE_URL:=https://github.com/openwisp/openwisp-config.git
-PKG_MIRROR_HASH:=30258c3ef4895fbf6e4fed8caee9d0dfbf05aebebd52604d75febac1a11d78bd
+PKG_MIRROR_HASH:=f709f3aaf2e9ad61b2df378b7e6cfae7050d5f1d8c4c4bc038e92809c843c4b7
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_VERSION:=$(PKG_VERSION)
 

--- a/admin/openwisp-config/Makefile
+++ b/admin/openwisp-config/Makefile
@@ -5,14 +5,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openwisp-config
-PKG_VERSION:=1.1.0
-PKG_RELEASE:=2
+PKG_VERSION:=1.2.0
+PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Federico Capoano <f.capoano@openwisp.io>
 PKG_LICENSE:=GPL-3.0-or-later
 
 PKG_SOURCE_URL:=https://github.com/openwisp/openwisp-config.git
-PKG_MIRROR_HASH:=18aac13395b2b78d87a50bcc9ab962ff12ab041ec032c214c34d3de3ac67f10a
+PKG_MIRROR_HASH:=30258c3ef4895fbf6e4fed8caee9d0dfbf05aebebd52604d75febac1a11d78bd
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_VERSION:=$(PKG_VERSION)
 
@@ -47,7 +47,8 @@ define Package/openwisp-config/install
 		$(1)/etc/init.d \
 		$(1)/etc/config \
 		$(1)/usr/lib/openwisp-config \
-		$(1)/usr/lib/lua/openwisp
+		$(1)/usr/lib/lua/openwisp \
+		$(1)/etc/hotplug.d/iface
 
 	$(INSTALL_BIN) \
 		$(PKG_BUILD_DIR)/openwisp-config/files/openwisp.agent \
@@ -59,6 +60,9 @@ define Package/openwisp-config/install
 
 	$(INSTALL_CONF) $(PKG_BUILD_DIR)/openwisp-config/files/openwisp.config \
 		$(1)/etc/config/openwisp
+
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/openwisp-config/files/openwisp.hotplug \
+		$(1)/etc/hotplug.d/iface/90-openwisp-config
 
 	$(INSTALL_BIN) \
 		$(PKG_BUILD_DIR)/openwisp-config/files/sbin/openwisp-reload-config \

--- a/admin/openwisp-monitoring/Config.in
+++ b/admin/openwisp-monitoring/Config.in
@@ -1,4 +1,5 @@
 menu "netjson-monitoring Configuration"
+	depends on PACKAGE_netjson-monitoring
 
 config NETJSON_MONITORING_IWINFO
 	bool "Enable rpcd-mod-iwinfo"

--- a/admin/openwisp-monitoring/Makefile
+++ b/admin/openwisp-monitoring/Makefile
@@ -5,15 +5,26 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openwisp-monitoring
+<<<<<<< HEAD
 PKG_VERSION:=0.2.0
 PKG_RELEASE:=3
+=======
+PKG_VERSION:=0.3.0
+PKG_RELEASE:=1
+>>>>>>> 74e6bcc01 (openwisp-monitoring: upgrade to 0.3.0)
 
 PKG_MAINTAINER:=Federico Capoano <support@openwisp.io>
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_LICENSE_FILES:=LICENSE
 
+PKG_CONFIG_DEPENDS:=CONFIG_NETJSON_MONITORING_IWINFO
+
 PKG_SOURCE_URL:=https://github.com/openwisp/openwrt-openwisp-monitoring.git
+<<<<<<< HEAD
 PKG_MIRROR_HASH:=aad91b9a1cd08e23782a4f55e27c6af5502f1dff1e91cf10bcd6d99d939641f0
+=======
+PKG_MIRROR_HASH:=a7778b0de1b560abf5bf5b8e6e45313fe58309a66438f3c9e043adc8f0248c04
+>>>>>>> 74e6bcc01 (openwisp-monitoring: upgrade to 0.3.0)
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_VERSION:=$(PKG_VERSION)
 PKGARCH:=all


### PR DESCRIPTION
Backport of:

- #27751 (openwisp-config 1.2.0)
- #29115 (openwisp-config 1.2.1)
- #27754 (openwisp-montoring 0.3.0)

Due to time constraint we couldn't update the openwisp packages on OpenWrt 23.05 before, but I thought it would be good to do it, better late than never.