### PR TITLE
libfastjson: add missing runtime dependency on libm

### DIFF
--- a/libs/libfastjson/Makefile
+++ b/libs/libfastjson/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libfastjson
 PKG_VERSION:=1.2304.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://download.rsyslog.com/libfastjson
@@ -29,6 +29,7 @@ define Package/libfastjson
   SECTION:=libs
   CATEGORY:=Libraries
   TITLE:=A fast JSON library for C
+  DEPENDS:=+USE_GLIBC:libm
   URL:=https://github.com/rsyslog/libfastjson
 endef
 


### PR DESCRIPTION
libfastjson uses `modf()` from libm but does not declare the dependency in its package definition. With `CONFIG_PKG_RELRO_FULL` (BIND_NOW), this can cause the dynamic linker to process libfastjson's relocations before libm's GOT is set up, triggering a crash in libm's IFUNC resolver on PowerPC.

Observed on PowerPC64 BE (e5500) with glibc 2.41, where rsyslogd crashes immediately on startup.

Fixes: https://github.com/openwrt/packages/issues/29160