### PR TITLE
kea: fix kea-libs dependencies

### DIFF
--- a/net/kea/Makefile
+++ b/net/kea/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=kea
 PKG_VERSION:=3.0.2
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://ftp.isc.org/isc/kea/$(PKG_VERSION)
@@ -63,7 +63,7 @@ endef
 define Package/kea-libs
 	$(call Package/kea/Default)
 	TITLE+=Libraries
-	DEPENDS:=+libopenssl +log4cplus +boost
+	DEPENDS:=+libopenssl +libstdcpp +log4cplus-any +boost
 endef
 define Package/kea-libs/description
 		Kea required Libraries.


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me, @nmeyerhans 

**Description:**
Include libstdc++ and log4cplus libraries.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** `HEAD`
- **OpenWrt Target/Subtarget:** `x86_64/generic`
- **OpenWrt Device:** `pc-engines-apu6`

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
