### PR TITLE
libgpiod: Make Python bindings optional

### DIFF
--- a/libs/libgpiod/Makefile
+++ b/libs/libgpiod/Makefile
@@ -23,6 +23,8 @@ PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
 PYTHON3_PKG_BUILD:=0
 
+PKG_BUILD_DEPENDS:=PACKAGE_python3-gpiod:python-setuptools/host
+
 include $(INCLUDE_DIR)/package.mk
 include ../../lang/python/python3-package.mk
 

--- a/libs/libgpiod/Makefile
+++ b/libs/libgpiod/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libgpiod
 PKG_VERSION:=2.1.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/software/libs/libgpiod/
@@ -90,7 +90,7 @@ define Package/python3-gpiod
   SUBMENU:=Python
   TITLE:=Python bindings for libgpiod
   URL:=https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git
-  DEPENDS:=+python3-light +libgpiod
+  DEPENDS:=+PACKAGE_python3-gpiod:python3-light +libgpiod
 endef
 
 define Package/python3-gpiod/description


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @mhei 

**Description:**
python3-gpiod causes python3-light to be built even if not selected, which can be avoided by making the dependency conditional`.

How to test:
1. Select gpiod-tools
2. `make package/libgpiod/compile`

Without the changes: python3 (and bluez) get built as dependencies
With the changes: python3 is not built

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 9247eb400241cd2b6f3ec141744b560dcf59c8db
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** openwrt-one

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.