### PR TITLE
zabbix: cherry-pick update to 7.0.25 (LTS)

### DIFF
--- a/admin/zabbix/Makefile
+++ b/admin/zabbix/Makefile
@@ -8,14 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zabbix
-
-PKG_VERSION:=7.0.24
+PKG_VERSION:=7.0.25
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://cdn.zabbix.com/zabbix/sources/stable/$(basename $(PKG_VERSION))/ \
 	https://cdn.zabbix.com/zabbix/sources/oldstable/$(basename $(PKG_VERSION))/
-PKG_HASH:=6f8ae990b9b25767e4fffbcb5cc7c455d674e2a392dc21478488a5d1c0e7d597
+PKG_HASH:=3a42e85da9cbd8aadd11bfcbe021f0f9c6caa510f564e37f3ac1046984acb729
 
 PKG_MAINTAINER:=Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>
 PKG_LICENSE:=AGPL-3.0-only


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @danielfdickinson 

**Description:**
Bump version to latest LTS.
(cherry picked from commit 1568fb9816b9611bb786a436d391a7fdfce98692)

---

## 🧪 Run Testing Details

- **OpenWrt Version:** OpenWrt 25.12-SNAPSHOT r32866-99a502bbc4"
- **OpenWrt Target/Subtarget:** bcm27xx/bcm2712
- **OpenWrt Device:** Raspberry Pi 5 Model B Rev 1.0

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
