### PR TITLE
uacme: add support for dalias/calias

### DIFF
--- a/net/uacme/Makefile
+++ b/net/uacme/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=uacme
 PKG_VERSION:=1.8.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ndilieto/uacme/tar.gz/upstream/$(PKG_VERSION)?

--- a/net/uacme/files/dnschalhook.sh
+++ b/net/uacme/files/dnschalhook.sh
@@ -55,11 +55,18 @@ if [ ! -f "$ACMESH_DNSSCIRPT_DIR/$dns.sh" ]; then
 fi
 . /usr/lib/acme/client/dnsapi/$dns.sh
 echo $dns > "$DOMAIN_CONF_DIR/selected_api"
+
+TXTDOMAIN=_acme-challenge.$IDENT
+if [ "$dalias" ]; then
+    TXTDOMAIN=$dalias
+elif [ "$calias" ]; then
+    TXTDOMAIN=_acme-challenge.$calias
+fi
 case "$METHOD" in
     "begin")
         (umask 077 ; touch -a "$DOMAIN_CONF")
         log info logging $DOMAIN_CONF
-        ${dns}_add _acme-challenge.$IDENT $AUTH
+        ${dns}_add $TXTDOMAIN $AUTH
         RESULT=$?
         if [ $RESULT -eq 0 ]; then
             sleep ${dns_wait:-"30s"}
@@ -69,7 +76,7 @@ case "$METHOD" in
         fi
         ;;
     "done"|"failed")
-        ${dns}_rm _acme-challenge.$IDENT $AUTH
+        ${dns}_rm $TXTDOMAIN $AUTH
         exit $?
         ;;
     *)

--- a/net/uacme/files/hook.sh
+++ b/net/uacme/files/hook.sh
@@ -143,12 +143,12 @@ get)
 		export dns
 		set -- "$@" -h "$HOOKDIR/client/dnschalhook.sh"
 		if [ "$dalias" ]; then
-			set -- "$@" --domain-alias "$dalias"
+			export dalias
 			if [ "$calias" ]; then
 				log err "Both domain and challenge aliases are defined. Ignoring the challenge alias."
 			fi
 		elif [ "$calias" ]; then
-			set -- "$@" --challenge-alias "$calias"
+			export calias
 		fi
 		if [ "$dns_wait" ]; then
 			export dns_wait

--- a/net/uacme/files/test.sh
+++ b/net/uacme/files/test.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+case "$1" in
+"uacme")
+    uacme -V 2>&1 | grep "$2"
+    ;;
+"uacme-ualpn")
+    ualpn -V 2>&1 | grep "$2"
+    ;;
+esac


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @lucize
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->
fixes [issues/29164](https://github.com/openwrt/packages/issues/29164)
at before it passed dalias/calias option as command line flag (which uacme doesn't have) so it failed run with that option enabled: 
send it to dns hook script instead and handle there.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** : snapshot
- **OpenWrt Target/Subtarget:** x86_64
- **OpenWrt Device:** kvm vm (with libvirt)

---

## ✅ Formalities

- [V] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

