### PR TITLE
python-installer: use --prefix for install-path

### DIFF
--- a/lang/python/python3-host-build.mk
+++ b/lang/python/python3-host-build.mk
@@ -57,8 +57,7 @@ define Py3Host/Install/Installer
 		$(HOST_BUILD_DIR), \
 		-m installer \
 			--overwrite-existing \
-			--destdir "$(1)" \
-			--prefix "" \
+			--prefix "$(1)" \
 			"$(PYTHON3_HOST_BUILD_DIR)"/openwrt-build/$(PYTHON3_HOST_WHEEL_NAME)-$(PYTHON3_HOST_WHEEL_VERSION)-*.whl \
 			, \
 		$(PYTHON3_HOST_INSTALL_VARS) \


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me

**Description:**

Fixes https://github.com/openwrt/packages/issues/29177 Tested locally.

Fix provided by @xuanranran

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [ ] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
