### PR TITLE
snowflake: update to 2.13.1

### DIFF
--- a/net/snowflake/Makefile
+++ b/net/snowflake/Makefile
@@ -1,13 +1,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=snowflake
-PKG_VERSION:=2.11.0
+PKG_VERSION:=2.13.1
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/snowflake.git
 PKG_SOURCE_VERSION:=v$(PKG_VERSION)
-PKG_MIRROR_HASH:=527006b3d71134267fac3a8c86be71a99bf7dbb2f969916c60f16bec8c245294
+PKG_MIRROR_HASH:=07994854c321e9b26d954901d1f009d9d453d4ba6fac0ef6b7b8a9f0014df5e0
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
ChangeLog: https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/snowflake/-/commit/a0ee1083550fb4e91e17b9b5942fa8a64ff37272

## 📦 Package Details

**Maintainer:** @PolynomialDivision

**Description:**
snowflake: update to 2.13.1
---

## 🧪 Run Testing Details

- **OpenWrt Version: 25.12.2**
- **OpenWrt Target/Subtarget: mediatek/filogic**
- **OpenWrt Device: OpenWrt One**

---

## ✅ Formalities

- [Y] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
