### PR TITLE
miniupnpd: add ext_allow_private_ipv4

### DIFF
--- a/net/miniupnpd/Makefile
+++ b/net/miniupnpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=miniupnpd
 PKG_VERSION:=2.3.9
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_URL:=https://github.com/miniupnp/miniupnp/releases/download/miniupnpd_$(subst .,_,$(PKG_VERSION))
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz

--- a/net/miniupnpd/files/miniupnpd.init
+++ b/net/miniupnpd/files/miniupnpd.init
@@ -61,7 +61,7 @@ upnpd() {
 	local external_iface external_iface6 external_zone external_ip internal_iface
 	local upload download log_output port config_file serial_number model_number
 	local use_stun stun_host stun_port uuid notify_interval presentation_url
-	local upnp_lease_file upnp_lease_file6 ipv6_disable
+	local upnp_lease_file upnp_lease_file6 ipv6_disable ext_allow_private_ipv4
 
 	local enabled
 	config_get_bool enabled config enabled 1
@@ -88,6 +88,7 @@ upnpd() {
 	config_get upnp_lease_file config upnp_lease_file
 	config_get upnp_lease_file6 config upnp_lease_file6
 	config_get ipv6_disable config ipv6_disable 0
+	config_get ext_allow_private_ipv4 config ext_allow_private_ipv4 0
 
 	local conf ifname ifname6
 
@@ -140,6 +141,7 @@ upnpd() {
 		upnpd_write_bool igdv1 0 force_igd_desc_v1
 		upnpd_write_bool use_stun 0 ext_perform_stun
 		upnpd_write_bool ipv6_disable $ipv6_disable
+		upnpd_write_bool ext_allow_private_ipv4 $ext_allow_private_ipv4
 
 		[ "$use_stun" -eq 0 ] || {
 			[ -n "$stun_host" ] && echo "ext_stun_host=$stun_host"


### PR DESCRIPTION
miniupnpd 2.3.9 allows enable forwarding for private IPs by use 'ext_allow_private_ipv4=yes'.

Link: https://github.com/miniupnp/miniupnp/blob/f83b5e2e21aa8dfa393ff80ea287ac4fca1a4df1/miniupnpd/Changelog.txt#L51

Link: https://github.com/miniupnp/miniupnp/blob/f83b5e2e21aa8dfa393ff80ea287ac4fca1a4df1/miniupnpd/miniupnpd.conf#L24

## 📦 Package Details

**Maintainer:** @commodo 
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** N100

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
