### PR TITLE
yt-dlp: bump to 2026.03.17

### DIFF
--- a/multimedia/yt-dlp/Makefile
+++ b/multimedia/yt-dlp/Makefile
@@ -3,11 +3,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=yt-dlp
-PKG_VERSION:=2026.3.3
+PKG_VERSION:=2026.3.17
 PKG_RELEASE:=1
 
 PYPI_NAME:=yt-dlp
-PKG_HASH:=3db7969e3a8964dc786bdebcffa2653f31123bf2a630f04a17bdafb7bbd39952
+PKG_HASH:=ba7aa31d533f1ffccfe70e421596d7ca8ff0bf1398dc6bb658b7d9dec057d2c9
 PYPI_SOURCE_NAME:=yt_dlp
 
 PKG_MAINTAINER:=George Sapkin <george@sapk.in>


### PR DESCRIPTION
**Maintainer:** me

**Description:**

Backport to 25.12:
- #28961

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12.2
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** QEMU/Vadas

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.