### PR TITLE
sqlite3: bump to 3.53.0

### DIFF
--- a/libs/sqlite3/Makefile
+++ b/libs/sqlite3/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sqlite
-PKG_VERSION:=3520000
+PKG_VERSION:=3530000
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-autoconf-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.sqlite.org/2026/
-PKG_HASH:=f6b50b0c103392af32a8be15b2b9d25959de9a00a70c3979128aafeaa5338b3f
+PKG_HASH:=851e9b38192fe2ceaa65e0baa665e7fa06230c3d9bd1a6a9662d02380d73365a
 
 PKG_CPE_ID:=cpe:/a:sqlite:sqlite
 PKG_LICENSE:=blessing


### PR DESCRIPTION
**Maintainer:**

**Description:**

Backport to 24.10:
- #29125 

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 24.10.6
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** QEMU/Vadas

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.