### PR TITLE
libs/faux, utils/klish3: add new packages

### DIFF
--- a/libs/faux/Makefile
+++ b/libs/faux/Makefile
@@ -1,0 +1,74 @@
+#
+# Copyright (C) 2026 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=faux
+PKG_VERSION:=2.2.1
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/pkun/faux.git
+PKG_SOURCE_DATE:=2025-10-20
+PKG_SOURCE_VERSION:=532d1cb79b65de0227020a39ecd48deb78ac2867
+PKG_MIRROR_HASH:=777eb62d489970e0e6a796f9d250712d89ab4ece9691128e940e646c797d72da
+
+PKG_MAINTAINER:=Dharmik Parmar <dharmikparmar2004@yahoo.com>
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=LICENCE
+
+PKG_FIXUP:=autoreconf
+PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/libfaux
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=Auxiliary utility library used by klish3
+  URL:=https://github.com/pkun/faux
+  DEPENDS:=+libpthread
+endef
+
+define Package/libfaux/description
+ The faux library contains assorted helper APIs for memory, strings,
+ event loops, async I/O and utility wrappers.
+endef
+
+define Package/faux-utils
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=Utilities from faux library
+  URL:=https://github.com/pkun/faux
+  DEPENDS:=+libfaux
+endef
+
+define Package/faux-utils/description
+ Utility binaries shipped by the faux project.
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/faux $(1)/usr/include/
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libfaux.so* $(1)/usr/lib/
+endef
+
+define Package/libfaux/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libfaux.so* $(1)/usr/lib/
+endef
+
+define Package/faux-utils/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/faux-file2c $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/faux-getch $(1)/usr/bin/
+endef
+
+$(eval $(call BuildPackage,libfaux))
+$(eval $(call BuildPackage,faux-utils))

--- a/libs/faux/Makefile
+++ b/libs/faux/Makefile
@@ -1,0 +1,67 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=faux
+PKG_VERSION:=2.2.1
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/pkun/faux.git
+PKG_SOURCE_DATE:=2025-10-20
+PKG_SOURCE_VERSION:=532d1cb79b65de0227020a39ecd48deb78ac2867
+PKG_MIRROR_HASH:=777eb62d489970e0e6a796f9d250712d89ab4ece9691128e940e646c797d72da
+
+PKG_MAINTAINER:=Dharmik Parmar <dharmikparmar2004@yahoo.com>
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=LICENCE
+
+PKG_FIXUP:=autoreconf
+PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/libfaux
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=Auxiliary utility library used by klish3
+  URL:=https://github.com/pkun/faux
+  DEPENDS:=+libpthread
+endef
+
+define Package/libfaux/description
+ The faux library contains assorted helper APIs for memory, strings,
+ event loops, async I/O and utility wrappers.
+endef
+
+define Package/faux-utils
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=Utilities from faux library
+  URL:=https://github.com/pkun/faux
+  DEPENDS:=+libfaux
+endef
+
+define Package/faux-utils/description
+ Utility binaries shipped by the faux project.
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/faux $(1)/usr/include/
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libfaux.so* $(1)/usr/lib/
+endef
+
+define Package/libfaux/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libfaux.so* $(1)/usr/lib/
+endef
+
+define Package/faux-utils/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/faux-file2c $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/faux-getch $(1)/usr/bin/
+endef
+
+$(eval $(call BuildPackage,libfaux))
+$(eval $(call BuildPackage,faux-utils))

--- a/utils/klish3/Makefile
+++ b/utils/klish3/Makefile
@@ -1,0 +1,183 @@
+#
+# Copyright (C) 2026 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=klish3
+PKG_VERSION:=3.2.0
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/pkun/klish.git
+PKG_SOURCE_DATE:=2026-01-15
+PKG_SOURCE_VERSION:=8046c594cc14e4a28f37b885d0af20a7c875e7a1
+PKG_MIRROR_HASH:=3c691c3a1215263f8ef092e48dc45cc942f112cbbf7bf77d8c820d90451d33ca
+
+PKG_FIXUP:=autoreconf
+PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
+
+PKG_MAINTAINER:=Dharmik Parmar <dharmikparmar2004@yahoo.com>
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=LICENCE
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/libklish3
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=Klish v3 core shared library
+  URL:=https://github.com/pkun/klish
+  DEPENDS:=+libfaux +libxml2 +libpthread
+endef
+
+define Package/libklish3/description
+ Core shared library for Klish v3.
+endef
+
+define Package/libtinyrl3
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=Klish v3 tiny readline shared library
+  URL:=https://github.com/pkun/klish
+  DEPENDS:=+libfaux +libxml2 +libpthread
+endef
+
+define Package/libtinyrl3/description
+ Tiny readline-style shared library used by Klish v3.
+endef
+
+define Package/klish3-db-libxml2
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=Klish v3 XML database backend plugin
+  URL:=https://github.com/pkun/klish
+  DEPENDS:=+libklish3 +libxml2
+endef
+
+define Package/klish3-db-libxml2/description
+ XML-backed database plugin for Klish v3.
+endef
+
+define Package/klish3-db-ischeme
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=Klish v3 in-memory schema database backend plugin
+  URL:=https://github.com/pkun/klish
+  DEPENDS:=+libklish3
+endef
+
+define Package/klish3-db-ischeme/description
+ In-memory schema database backend plugin for Klish v3.
+endef
+
+define Package/klish3-plugin-klish
+  SECTION:=utils
+  CATEGORY:=Utilities
+  SUBMENU:=Shells
+  TITLE:=Klish v3 built-in command plugin
+  URL:=https://github.com/pkun/klish
+  DEPENDS:=+libklish3
+endef
+
+define Package/klish3-plugin-klish/description
+ Built-in command plugin for Klish v3.
+endef
+
+define Package/klish3-plugin-script
+  SECTION:=utils
+  CATEGORY:=Utilities
+  SUBMENU:=Shells
+  TITLE:=Klish v3 script plugin
+  URL:=https://github.com/pkun/klish
+  DEPENDS:=+libklish3
+endef
+
+define Package/klish3-plugin-script/description
+ Script execution plugin for Klish v3.
+endef
+
+define Package/klish3
+  SECTION:=utils
+  CATEGORY:=Utilities
+  SUBMENU:=Shells
+  TITLE:=Kommand Line Interface Shell v3
+  URL:=https://github.com/pkun/klish
+  DEPENDS:=+libklish3 +libtinyrl3 +klish3-db-libxml2 +klish3-db-ischeme +klish3-plugin-klish +klish3-plugin-script
+  CONFLICTS:=klish klish-xml-files
+endef
+
+define Package/klish3/description
+ Klish v3 is a framework for implementing Cisco-like or Juniper-like
+ command line interfaces.
+ This package ships the klish and klishd binaries along with default
+ runtime configuration.
+endef
+
+CONFIGURE_ARGS += \
+	--with-libxml2=yes \
+	--with-roxml=no \
+	--with-expat=no \
+	--with-lua=no
+
+define Package/klish3/conffiles
+/etc/klish/klish.conf
+/etc/klish/klishd.conf
+/etc/klish/xml/example.xml
+endef
+
+define Package/libklish3/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libklish.so* $(1)/usr/lib/
+endef
+
+define Package/libtinyrl3/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libtinyrl.so* $(1)/usr/lib/
+endef
+
+define Package/klish3-db-libxml2/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libklish-db-libxml2.so* $(1)/usr/lib/
+endef
+
+define Package/klish3-db-ischeme/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libklish-db-ischeme.so* $(1)/usr/lib/
+endef
+
+define Package/klish3-plugin-klish/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libklish-plugin-klish.so* $(1)/usr/lib/
+endef
+
+define Package/klish3-plugin-script/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libklish-plugin-script.so* $(1)/usr/lib/
+endef
+
+define Package/klish3/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/klish $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/klishd $(1)/usr/bin/
+
+	$(INSTALL_DIR) $(1)/etc/klish/xml
+	$(INSTALL_CONF) ./files/etc/klish/klish.conf $(1)/etc/klish/
+	$(INSTALL_CONF) ./files/etc/klish/klishd.conf $(1)/etc/klish/
+	$(INSTALL_CONF) ./files/etc/klish/xml/example.xml $(1)/etc/klish/xml/
+
+	$(INSTALL_DIR) $(1)/usr/share/klish
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/klish.xsd $(1)/usr/share/klish/
+endef
+
+$(eval $(call BuildPackage,libklish3))
+$(eval $(call BuildPackage,libtinyrl3))
+$(eval $(call BuildPackage,klish3-db-libxml2))
+$(eval $(call BuildPackage,klish3-db-ischeme))
+$(eval $(call BuildPackage,klish3-plugin-klish))
+$(eval $(call BuildPackage,klish3-plugin-script))
+$(eval $(call BuildPackage,klish3))

--- a/utils/klish3/Makefile
+++ b/utils/klish3/Makefile
@@ -1,0 +1,176 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=klish3
+PKG_VERSION:=3.2.0
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/pkun/klish.git
+PKG_SOURCE_DATE:=2026-01-15
+PKG_SOURCE_VERSION:=8046c594cc14e4a28f37b885d0af20a7c875e7a1
+PKG_MIRROR_HASH:=3c691c3a1215263f8ef092e48dc45cc942f112cbbf7bf77d8c820d90451d33ca
+
+PKG_FIXUP:=autoreconf
+PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
+
+PKG_MAINTAINER:=Dharmik Parmar <dharmikparmar2004@yahoo.com>
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=LICENCE
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/libklish3
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=Klish v3 core shared library
+  URL:=https://github.com/pkun/klish
+  DEPENDS:=+libfaux +libxml2 +libpthread
+endef
+
+define Package/libklish3/description
+ Core shared library for Klish v3.
+endef
+
+define Package/libtinyrl3
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=Klish v3 tiny readline shared library
+  URL:=https://github.com/pkun/klish
+  DEPENDS:=+libfaux +libxml2 +libpthread
+endef
+
+define Package/libtinyrl3/description
+ Tiny readline-style shared library used by Klish v3.
+endef
+
+define Package/klish3-db-libxml2
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=Klish v3 XML database backend plugin
+  URL:=https://github.com/pkun/klish
+  DEPENDS:=+libklish3 +libxml2
+endef
+
+define Package/klish3-db-libxml2/description
+ XML-backed database plugin for Klish v3.
+endef
+
+define Package/klish3-db-ischeme
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=Klish v3 in-memory schema database backend plugin
+  URL:=https://github.com/pkun/klish
+  DEPENDS:=+libklish3
+endef
+
+define Package/klish3-db-ischeme/description
+ In-memory schema database backend plugin for Klish v3.
+endef
+
+define Package/klish3-plugin-klish
+  SECTION:=utils
+  CATEGORY:=Utilities
+  SUBMENU:=Shells
+  TITLE:=Klish v3 built-in command plugin
+  URL:=https://github.com/pkun/klish
+  DEPENDS:=+libklish3
+endef
+
+define Package/klish3-plugin-klish/description
+ Built-in command plugin for Klish v3.
+endef
+
+define Package/klish3-plugin-script
+  SECTION:=utils
+  CATEGORY:=Utilities
+  SUBMENU:=Shells
+  TITLE:=Klish v3 script plugin
+  URL:=https://github.com/pkun/klish
+  DEPENDS:=+libklish3
+endef
+
+define Package/klish3-plugin-script/description
+ Script execution plugin for Klish v3.
+endef
+
+define Package/klish3
+  SECTION:=utils
+  CATEGORY:=Utilities
+  SUBMENU:=Shells
+  TITLE:=Kommand Line Interface Shell v3
+  URL:=https://github.com/pkun/klish
+  DEPENDS:=+libklish3 +libtinyrl3 +klish3-db-libxml2 +klish3-db-ischeme +klish3-plugin-klish +klish3-plugin-script
+  CONFLICTS:=klish klish-xml-files
+endef
+
+define Package/klish3/description
+ Klish v3 is a framework for implementing Cisco-like or Juniper-like
+ command line interfaces.
+ This package ships the klish and klishd binaries along with default
+ runtime configuration.
+endef
+
+CONFIGURE_ARGS += \
+	--with-libxml2=yes \
+	--with-roxml=no \
+	--with-expat=no \
+	--with-lua=no
+
+define Package/klish3/conffiles
+/etc/klish/klish.conf
+/etc/klish/klishd.conf
+/etc/klish/xml/example.xml
+endef
+
+define Package/libklish3/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libklish.so* $(1)/usr/lib/
+endef
+
+define Package/libtinyrl3/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libtinyrl.so* $(1)/usr/lib/
+endef
+
+define Package/klish3-db-libxml2/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libklish-db-libxml2.so* $(1)/usr/lib/
+endef
+
+define Package/klish3-db-ischeme/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libklish-db-ischeme.so* $(1)/usr/lib/
+endef
+
+define Package/klish3-plugin-klish/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libklish-plugin-klish.so* $(1)/usr/lib/
+endef
+
+define Package/klish3-plugin-script/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libklish-plugin-script.so* $(1)/usr/lib/
+endef
+
+define Package/klish3/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/klish $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/klishd $(1)/usr/bin/
+
+	$(INSTALL_DIR) $(1)/etc/klish/xml
+	$(INSTALL_CONF) ./files/etc/klish/klish.conf $(1)/etc/klish/
+	$(INSTALL_CONF) ./files/etc/klish/klishd.conf $(1)/etc/klish/
+	$(INSTALL_CONF) ./files/etc/klish/xml/example.xml $(1)/etc/klish/xml/
+
+	$(INSTALL_DIR) $(1)/usr/share/klish
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/klish.xsd $(1)/usr/share/klish/
+endef
+
+$(eval $(call BuildPackage,libklish3))
+$(eval $(call BuildPackage,libtinyrl3))
+$(eval $(call BuildPackage,klish3-db-libxml2))
+$(eval $(call BuildPackage,klish3-db-ischeme))
+$(eval $(call BuildPackage,klish3-plugin-klish))
+$(eval $(call BuildPackage,klish3-plugin-script))
+$(eval $(call BuildPackage,klish3))

--- a/utils/klish3/files/etc/klish/klish.conf
+++ b/utils/klish3/files/etc/klish/klish.conf
@@ -1,0 +1,12 @@
+# OpenWrt default config for /etc/klish/klish.conf.
+# Used by the klish client utility.
+
+# Default Unix socket used to reach klishd.
+#UnixSocketPath=/tmp/klish-unix-socket
+
+# BusyBox less does not support GNU less flags like -I -X -K -R.
+# Keep pager defaults compatible with OpenWrt base images.
+Pager="/usr/bin/less -EFN~"
+
+# Enable or disable pager usage globally.
+#UsePager=y

--- a/utils/klish3/files/etc/klish/klishd.conf
+++ b/utils/klish3/files/etc/klish/klishd.conf
@@ -1,0 +1,9 @@
+# Template for config file /etc/klish/klishd.conf. It is used by the klishd daemon.
+
+# klishd uses a UNIX domain socket to receive connections. It will create a
+# filesystem entry to allow clients to find the connection point. By default,
+# klishd uses the /tmp/klish-unix-socket path.
+#UnixSocketPath=/tmp/klish-unix-socket
+
+DBs=libxml2
+DB.libxml2.XMLPath=/etc/klish/xml/

--- a/utils/klish3/files/etc/klish/xml/example.xml
+++ b/utils/klish3/files/etc/klish/xml/example.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<KLISH
+xmlns="https://klish.libcode.org/klish3"
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+xsi:schemaLocation="https://klish.libcode.org/klish3 /usr/share/klish/klish.xsd">
+
+<PLUGIN name="klish"/>
+
+<PLUGIN name="script"/>
+
+
+<PTYPE name="STRING">
+<ACTION sym="STRING@klish"/>
+</PTYPE>
+
+
+<VIEW name="main">
+
+<HOTKEY key="^Z" cmd="exit"/>
+
+<PROMPT name="prompt">
+<ACTION sym="prompt">%u@%h&gt; </ACTION>
+</PROMPT>
+
+<COMMAND name="exit" help="Exit view">
+<ACTION sym="nav">pop</ACTION>
+<ACTION sym="printl">Exiting klish session</ACTION>
+</COMMAND>
+
+<COMMAND name="cmd" help="Clear settings">
+<COMMAND name="first" help="Clear settings"/>
+<ACTION sym="printl">test</ACTION>
+</COMMAND>
+
+<COMMAND name="comm" value="command" help="Clear settings">
+<ACTION sym="printl">test2</ACTION>
+</COMMAND>
+
+<COMMAND name="ls" help="List path">
+<PARAM name="path" ptype="/STRING" help="Path"/>
+<ACTION sym="script">
+echo "${path}"
+ls "${path}"
+</ACTION>
+</COMMAND>
+
+<COMMAND name="pytest" help="Test for Python script">
+<ACTION sym="script">#!/usr/bin/python3
+import os
+print('ENV', os.getenv("KLISH_COMMAND"))
+</ACTION>
+</COMMAND>
+
+</VIEW>
+
+</KLISH>

--- a/utils/klish3/patches/100-fix-stdio-macro-collision.patch
+++ b/utils/klish3/patches/100-fix-stdio-macro-collision.patch
@@ -1,0 +1,28 @@
+--- a/klish/ksession/kcontext.c
++++ b/klish/ksession/kcontext.c
+@@ -4,7 +4,10 @@
+ #include <assert.h>
+ #include <sys/types.h>
+ #include <unistd.h>
+-
++#undef stdin
++#undef stdout
++#undef stderr
++
+ #include <faux/str.h>
+ #include <faux/conv.h>
+ #include <faux/list.h>
+--- a/klish/ksession/kexec.c
++++ b/klish/ksession/kexec.c
+@@ -14,7 +14,10 @@
+ #include <termios.h>
+ #include <signal.h>
+ #include <errno.h>
+-
++#undef stdin
++#undef stdout
++#undef stderr
++
+ #include <faux/list.h>
+ #include <faux/buf.h>
+ #include <faux/eloop.h>

--- a/utils/klish3/patches/100-fix-stdio-macro-collision.patch
+++ b/utils/klish3/patches/100-fix-stdio-macro-collision.patch
@@ -1,0 +1,24 @@
+--- a/klish/ksession/kcontext.c
++++ b/klish/ksession/kcontext.c
+@@ -4,6 +4,9 @@
+ #include <assert.h>
+ #include <sys/types.h>
+ #include <unistd.h>
++#undef stdin
++#undef stdout
++#undef stderr
+ 
+ #include <faux/str.h>
+ #include <faux/conv.h>
+--- a/klish/ksession/kexec.c
++++ b/klish/ksession/kexec.c
+@@ -14,6 +14,9 @@
+ #include <termios.h>
+ #include <signal.h>
+ #include <errno.h>
++#undef stdin
++#undef stdout
++#undef stderr
+ 
+ #include <faux/list.h>
+ #include <faux/buf.h>

--- a/utils/klish3/test-version.sh
+++ b/utils/klish3/test-version.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+# shellcheck shell=busybox
+
+# klish reports an internal client help version, not the package release:
+# "Version : 1.0.0" for the 3.2.0 upstream release.
+package_name="${PKG_NAME:-$1}"
+
+case "$package_name" in
+klish3|\
+libklish3|\
+libtinyrl3|\
+klish3-db-libxml2|\
+klish3-db-ischeme|\
+klish3-plugin-klish|\
+klish3-plugin-script)
+	exit 0
+	;;
+*)
+	echo "Untested package: $package_name" >&2
+	exit 1
+	;;
+esac


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** : N/A (new packages in this PR)
**Description:**

This PR adds 2 new packages:

- `libs/faux`:
  - `libfaux` shared library
  - `faux-utils` helper tools
  - `Build/InstallDev` support so dependent packages can compile against faux headers/libs

- `utils/klish3`:
  - adds Klish v3 (`klish`, `klishd`) as a separate package from legacy `klish` (v2)
  - has OpenWrt default runtime files under `/etc/klish`
  - installs XML schema under `/usr/share/klish/klish.xsd`
  - includes one build-fix patch for stdio macro collision (`stdin/stdout/stderr`) with OpenWrt toolchain

`klish3` is intentionally packaged separately because v3 has major architecture/runtime differences and is not a drop-in replacement for `klish` (v2).

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 24.10.4
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** Generic x86_64 VM

Built IPKs:
- `libfaux_2.2.1-r1_x86_64.ipk`
- `faux-utils_2.2.1-r1_x86_64.ipk`
- `klish3_3.2.0-r1_x86_64.ipk`

Basic runtime check on VM:
- `klishd` starts
- `klish` starts and reads XML config from `/etc/klish/xml`

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/feeds/packages/klish3/refresh V=s