### PR TITLE
openvpn: add kmod-ovpn-backports dependency

### DIFF
--- a/net/openvpn/Config-mbedtls.in
+++ b/net/openvpn/Config-mbedtls.in
@@ -31,7 +31,7 @@ config OPENVPN_mbedtls_ENABLE_IPROUTE2
 config OPENVPN_mbedtls_ENABLE_DCO
 	depends on !OPENVPN_mbedtls_ENABLE_IPROUTE2
 	bool "Enable support for data channel offload"
-	default y if !OPENVPN_mbedtls_ENABLE_IPROUTE2
+	default n if OPENVPN_mbedtls_ENABLE_IPROUTE2
 	help
 	  enable data channel offload support
 	  using the ovpn-dco-v2 kernel module

--- a/net/openvpn/Config-openssl.in
+++ b/net/openvpn/Config-openssl.in
@@ -35,7 +35,7 @@ config OPENVPN_openssl_ENABLE_IPROUTE2
 config OPENVPN_openssl_ENABLE_DCO
 	depends on !OPENVPN_openssl_ENABLE_IPROUTE2
 	bool "Enable support for data channel offload"
-	default y if !OPENVPN_openssl_ENABLE_IPROUTE2
+	default n if OPENVPN_openssl_ENABLE_IPROUTE2
 	help
 	  enable data channel offload support
 	  using the ovpn-dco-v2 kernel module

--- a/net/openvpn/Config-wolfssl.in
+++ b/net/openvpn/Config-wolfssl.in
@@ -40,7 +40,7 @@ config OPENVPN_wolfssl_ENABLE_IPROUTE2
 config OPENVPN_wolfssl_ENABLE_DCO
 	depends on !OPENVPN_wolfssl_ENABLE_IPROUTE2
 	bool "Enable support for data channel offload"
-	default y if !OPENVPN_wolfssl_ENABLE_IPROUTE2
+	default n if OPENVPN_wolfssl_ENABLE_IPROUTE2
 	select WOLFSSL_HAS_OPENVPN
 	help
 	  enable data channel offload support

--- a/net/openvpn/Makefile
+++ b/net/openvpn/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=openvpn
 
 PKG_VERSION:=2.7.1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_URL:=\
 	https://build.openvpn.net/downloads/releases/ \
@@ -42,6 +42,7 @@ define Package/openvpn/Default
 	   +OPENVPN_$(1)_ENABLE_LZ4:liblz4 \
 	   +OPENVPN_$(1)_ENABLE_IPROUTE2:ip \
 	   +OPENVPN_$(1)_ENABLE_DCO:libnl-genl \
+	   +OPENVPN_$(1)_ENABLE_DCO:kmod-ovpn-backports \
 	   $(3)
   VARIANT:=$(1)
   PROVIDES:=openvpn openvpn-crypto


### PR DESCRIPTION
openvpn: revert kmod-ovpn-backports dependency

With openwrt/openwrt@f7d6e73, kmod-ovpn-backports can now be built correctly. add this dependency enables DCO.

Link: openwrt/packages@01fafd69e

Link: https://github.com/openwrt/packages/pull/27910
## 📦 Package Details

**Maintainer:** @commodo

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** N100

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
