### PR TITLE
[25.12] uacme: bump from 1.7.6 to 1.8.1

### DIFF
--- a/net/uacme/Makefile
+++ b/net/uacme/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=uacme
-PKG_VERSION:=1.7.6
+PKG_VERSION:=1.8.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ndilieto/uacme/tar.gz/upstream/$(PKG_VERSION)?
-PKG_HASH:=d11a86ac2a0dbf285de27dff4193c65f7f3736da3d0480049af50d305940e0d6
+PKG_HASH:=de7588577f8298dcb0d42dfaa9452a918fa692c4e165060207ac22f72fb0425d
 
 PKG_MAINTAINER:=Lucian Cristian <lucian.cristian@gmail.com>
 PKG_LICENSE:=GPL-3.0-or-later


### PR DESCRIPTION

## 📦 Package Details

**Maintainer:** @lucize

**Description:**
while this is part of https://github.com/openwrt/packages/pull/27831 I personally think refactored scripts around it is too big to apply as backport.
So this commit just bumps upstream uacme version, because it have bugfixs (1.8.0 fix broken ARI when complied with musl and 1.8.1 fixs broken ualpn proxying when using mbedtls backend) 
package release it 0 here because version 1 is already used in snapshot and they are too different thing so I think it'd need smaller pkg-release number.

<!-- Briefly describe what this package does or what changes are introduced -->

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.