### PR TITLE
telegraf: update to 1.38.3

### DIFF
--- a/utils/telegraf/Makefile
+++ b/utils/telegraf/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=telegraf
-PKG_VERSION:=1.38.2
+PKG_VERSION:=1.38.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/influxdata/telegraf/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=8f67651b9ff690593b57a8ff7703dbf9764bb1a356433503a4d9a27a69d26321
+PKG_HASH:=83a8119b09830eb7d9167563add221335d0f59a22499919741ed539697a6fa45
 
 PKG_MAINTAINER:=Niklas Thorild <niklas@thorild.se>
 PKG_LICENSE:=MIT

--- a/utils/telegraf/Makefile
+++ b/utils/telegraf/Makefile
@@ -4,7 +4,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=telegraf
 PKG_VERSION:=1.38.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/influxdata/telegraf/tar.gz/v$(PKG_VERSION)?
@@ -24,7 +24,7 @@ GO_PKG_LDFLAGS_X := \
   github.com/influxdata/telegraf/internal.Version=$(PKG_VERSION) \
   github.com/influxdata/telegraf/internal.Branch=HEAD
 
-ifeq ($(CONFIG_mips)$(CONFIG_mipsel),y)
+ifneq ($(filter arm mips mipsel,$(ARCH)),)
   TARGET_LDFLAGS += -static
 endif
 


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me

**Description:**
- Update Telegraf to v1.38.3
- Fix "2.44 assertion fail elf32-arm.c:9910" build error by also including ARM builds to use the -static LDFLAG
---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** LXC container

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.