### PR TITLE
scapy: update to 2.7.0; add test.sh

### DIFF
--- a/net/scapy/Makefile
+++ b/net/scapy/Makefile
@@ -8,11 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=scapy
-PKG_VERSION:=2.6.1
+PKG_VERSION:=2.7.0
 PKG_RELEASE:=1
 
 PYPI_NAME:=$(PKG_NAME)
-PKG_HASH:=7600d7e2383c853e5c3a6e05d37e17643beebf2b3e10d7914dffcc3bc3c6e6c5
+PKG_HASH:=bfc1ef1b93280aea1ddee53be7f74232aa28ac3d891244d41ee85200d24aa446
+
+PKG_BUILD_DEPENDS:=python-setuptools/host
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 PKG_LICENSE:=GPL-2.0-only

--- a/net/scapy/test.sh
+++ b/net/scapy/test.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+[ "$1" = scapy ] || exit 0
+
+python3 - <<'EOF'
+import scapy
+from scapy.packet import Packet, Raw
+from scapy.fields import ByteField, ShortField
+
+# Test basic packet creation
+pkt = Raw(load=b"hello")
+assert pkt.load == b"hello", f"unexpected: {pkt.load!r}"
+
+# Test that layers are importable
+from scapy.layers.inet import IP, TCP, UDP
+ip = IP(src="192.168.1.1", dst="192.168.1.2")
+assert ip.src == "192.168.1.1"
+assert ip.dst == "192.168.1.2"
+
+# Test packet building
+tcp = TCP(sport=1234, dport=80)
+assert tcp.sport == 1234
+assert tcp.dport == 80
+
+print("scapy OK")
+EOF


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @flyn-org 

**Description:**

Update scapy to version 2.7.0.

Add python-setuptools/host to PKG_BUILD_DEPENDS as the package uses setuptools as its build backend.

Changelog: https://github.com/secdev/scapy/blob/master/doc/scapy/installation.rst

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
