### PR TITLE
ocserv: bump to v1.4.1

### DIFF
--- a/net/ocserv/Makefile
+++ b/net/ocserv/Makefile
@@ -8,14 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ocserv
-PKG_VERSION:=1.3.0
-PKG_RELEASE:=3
+PKG_VERSION:=1.4.1
+PKG_RELEASE:=1
 PKG_BUILD_FLAGS:=no-mips16
 
 PKG_BUILD_DIR :=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.infradead.org/ocserv/download/
-PKG_HASH:=5c562c3ea1032065ef43d6075e5722f94ce6a7a780d6a2b4c6d54c1ce3921965
+PKG_HASH:=54a0e036421ef81556d5a573f13e123166e8fa9679e9a0877f5ef0c472128553
 
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=COPYING
@@ -88,6 +88,10 @@ endif
 
 ifndef CONFIG_OCSERV_LIBOATH
 CONFIGURE_ARGS += --without-liboath
+endif
+
+ifeq ($(ARCH),arm)                                              
+TARGET_CFLAGS += -flax-vector-conversions
 endif
 
 define Package/ocserv/conffiles


### PR DESCRIPTION

* Version 1.4.1 (released 2026-02-28)
- [SECURITY] Fixed authentication bypass (medium severity) when using
  certificate authentication with cert-user-oid set to SAN(rfc822name):
  a client presenting a valid CA-signed certificate without the expected
  RFC822 SAN field could authenticate using password credentials alone,
  bypassing the intended certificate-to-username binding. Requires the
  attacker to possess both a valid CA-signed certificate and valid user
  credentials (694)
- The bundled inih was updated to r62.
- The bundled protobuf-c was updated to 1.5.2.
- Fixed a bug where session timeout could be bypassed by reconnecting
  (e.g., closing/opening laptop lid) (599)
- occtl: 'show user' command now includes a 'Session started at:' field,
  indicating when the VPN session was established
- occtl: Fix column misalignment in ban command outputs
- occtl: Fix 'show ip bans' may produce invalid JSON (683)
- Handle dotted client hostnames (e.g., .local) by stripping the domain suffix
- Renamed `min-reauth-time` configuration option to `ban-time` to better reflect
  its purpose (676). This option defines the duration (in seconds) for which
  an IP address is banned after exceeding the maximum allowed `max-ban-score`.
  Default is 300 seconds (5 minutes).
- Fixed ocserv-worker process title
- Fixed ignored udp-port in vhost (612)

* Version 1.4.0 (released 2026-01-04)
- The bundled llhtp was updated to 9.3.0.
- The bundled protobuf-c was updated to 1.5.1.
- Fixed issues with PAM authentication when combined with pam_sssd (618)
- Enhanced the seccomp filters to address issue in testing (627)
- Fixed "unexpected URL" errors for Cisco AnyConnect clients
- Fixed the 'ping-leases' option, which was broken since version 1.1.1
- Fixed maximum MTU tracking in server statistics
- Fixed 'iroute' option processing to handle multiple routes (625)
- Fixed session accounting for roaming users (674)
- occtl: fix invalid JSON output in `occtl -j show iroutes` (661)
- occtl: fix regression with trailing commas in `occtl -j show sessions` (669)
- occtl: fix missing column headers in 'show ip bans' output (677)
- occtl: 'show ip bans' no longer shows expired bans (675)
- Fixed DTLS not working with systemd socket activation (647)
- Fixed a bug in the ban timer logic that could prevent IP addresses
  from being banned or cause premature unbans (678)
- Session statistics are now reported at consistent intervals
  for RADIUS compatibility (630)
- Single form to enter username and password (551)

ping @nmav 