### PR TITLE
ddns-scripts: fix incorrect option name in updater messages

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.3
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_LICENSE:=GPL-2.0
 

--- a/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_updater.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_updater.sh
@@ -23,7 +23,7 @@ Usage:
 
 Parameters:
  -S SECTION          SECTION to start
-                     use either -N NETWORK or -S SECTION
+                     SECTION is the UCI section name/id to start
 
  -h                  show this help and exit
  -V                  show version and exit
@@ -57,7 +57,7 @@ while getopts ":hv:dn:S:V" OPT; do
 done
 shift $((OPTIND - 1 ))	# OPTIND is 1 based
 
-[ -z "$SECTION_ID" ] && usage_err "option '-N' is missing"
+[ -z "$SECTION_ID" ] && usage_err "option '-S' is missing"
 
 # set file names
 PIDFILE="$ddns_rundir/$SECTION_ID.pid"	# Process ID file


### PR DESCRIPTION
On master, updater help and missing-option text still refer to '-N'. Use '-S' instead so the messages match accepted script options. This is a text-only change; runtime behavior is unchanged.

Fixes: #27737

## 📦 Package Details

**Maintainer:** @feckert

**Description:**
Update wording in `net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_updater.sh`:

- help text: remove incorrect `-N` reference
- missing-option error: `-N` -> `-S`

No parser/runtime logic changes are introduced.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 24.10.4
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** Generic (x86_64 VM)

Manual CLI checks:
- `/usr/lib/ddns/dynamic_dns_updater.sh` -> missing `-S`
- `/usr/lib/ddns/dynamic_dns_updater.sh -h` -> help reflects `-S`
- `/usr/lib/ddns/dynamic_dns_updater.sh -N foo` -> invalid option `-N`
- `/usr/lib/ddns/dynamic_dns_updater.sh -S` -> missing arg for `-S`

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  `make package/<your-package>/refresh V=s`
- [x] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>