### PR TITLE
pbr: update to 1.2.2-r14

### DIFF
--- a/net/pbr/Makefile
+++ b/net/pbr/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pbr
 PKG_VERSION:=1.2.2
-PKG_RELEASE:=12
+PKG_RELEASE:=14
 PKG_LICENSE:=AGPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
 

--- a/net/pbr/files/etc/init.d/pbr
+++ b/net/pbr/files/etc/init.d/pbr
@@ -198,6 +198,7 @@ nft_fw4_dump=
 loadEnvironmentFlag=
 loadPackageConfigFlag=
 resolverWorkingFlag=
+resolverStoredHash=
 
 # shellcheck disable=SC1091
 . "${IPKG_INSTROOT}/lib/functions.sh"
@@ -979,7 +980,7 @@ nft_file() {
 			done
 			echo "" >> "$nftTempFile"
 			# Add jump rules from fw4 chains to pbr chains
-			echo "add rule inet $nftTable dstnat jump ${nftPrefix}_dstnat" >> "$nftTempFile"
+			echo "insert rule inet $nftTable dstnat jump ${nftPrefix}_dstnat" >> "$nftTempFile"
 			echo "add rule inet $nftTable mangle_prerouting jump ${nftPrefix}_prerouting" >> "$nftTempFile"
 			echo "add rule inet $nftTable mangle_output jump ${nftPrefix}_output" >> "$nftTempFile"
 			echo "add rule inet $nftTable mangle_forward jump ${nftPrefix}_forward" >> "$nftTempFile"
@@ -1446,7 +1447,7 @@ resolver() {
 					[ "$resolverNewHash" != "$resolverStoredHash" ]
 				;;
 				store_hash)
-					[ -s "$packageDnsmasqFile" ] && resolverStoredHash="$(md5sum "$packageDnsmasqFile" | awk '{ print $1; }')"
+					[ -s "$packageDnsmasqFile" ] && resolverStoredHash="$(md5sum "$packageDnsmasqFile" | awk '{ print $1; }')" || resolverStoredHash=
 					return 0
 				;;
 				wait)
@@ -2801,7 +2802,7 @@ on_interface_reload() {
 
 start_service() {
 	local param="$1"
-	local resolverStoredHash resolverNewHash reloadedIface
+	local reloadedIface
 	local i k
 
 	[ "$param" = 'on_boot' ] && pbrBootFlag=1 && return 0
@@ -2880,6 +2881,7 @@ start_service() {
 
 	case $serviceStartTrigger in
 		on_interface_reload)
+			resolver 'store_hash'
 			output_okn
 			output 1 "Reloading Interface: $reloadedIface "
 			json_add_array 'gateways'


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Dell EMC Edge620, OpenWrt 25.12.1
Run tested: x86_64, Dell EMC Edge620, OpenWrt 25.12.1

Description:
fix: avoid unnecessary dnsmasq restarts (thanks @egc112)
fix: insert, not add dns policies to ensure higher priority than the DNS
     hijack rules (thanks @egc112)

Signed-off-by: Stan Grishin <stangri@melmac.ca>