### PR TITLE
docker: bump to 29.4.1

### DIFF
--- a/utils/containerd/Makefile
+++ b/utils/containerd/Makefile
@@ -1,39 +1,43 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=containerd
-PKG_VERSION:=1.7.22
-PKG_RELEASE:=2
+PKG_VERSION:=2.2.3
+PKG_RELEASE:=1
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 PKG_CPE_ID:=cpe:/a:linuxfoundation:containerd
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/containerd/containerd/tar.gz/v${PKG_VERSION}?
-PKG_HASH:=8c5edde741b7596af63c021429a1212bd616350ed65a7b741eeffc47e27ee9a9
+PKG_HASH:=b97780bde4b01ed3596b0b0c6f55bfb130794a3db4e6fe2e0fc9719244933945
 
 PKG_MAINTAINER:=Gerard Ryan <G.M0N3Y.2503@gmail.com>
 
 PKG_BUILD_DEPENDS:=golang/host dockerd
 PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
-PKG_BUILD_FLAGS:=no-mips16
 
 GO_PKG:=github.com/containerd/containerd
 
 include $(INCLUDE_DIR)/package.mk
 include ../../lang/golang/golang-package.mk
 
+EMPTY:=
+SPACE:= $(EMPTY) $(EMPTY)
+ARCH_DEPENDS:=@($(subst $(SPACE),||,$(strip $(filter-out mips mips64 mipsel mips64el,$(subst ||,$(SPACE),$(patsubst @(%),%,$(GO_ARCH_DEPENDS)))))))
+
 define Package/containerd
   SECTION:=utils
   CATEGORY:=Utilities
   TITLE:=containerd container runtime
   URL:=https://containerd.io/
-  DEPENDS:=$(GO_ARCH_DEPENDS) +btrfs-progs +runc
+  DEPENDS:=$(ARCH_DEPENDS) +btrfs-progs +runc
   MENU:=1
 endef
 
 define Package/containerd/description
-An industry-standard container runtime with an emphasis on simplicity, robustness and portability
+  An industry-standard container runtime with an emphasis on simplicity,
+  robustness and portability.
 endef
 
 GO_PKG_INSTALL_EXTRA:=\
@@ -59,7 +63,7 @@ Build/Compile=$(call Build/Compile/Default)
 
 define Package/containerd/install
 	$(INSTALL_DIR) $(1)/usr/bin/
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/bin/{ctr,containerd,containerd-stress,containerd-shim,containerd-shim-runc-v1,containerd-shim-runc-v2} $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/bin/{ctr,containerd,containerd-stress,containerd-shim-runc-v2} $(1)/usr/bin/
 endef
 
 $(eval $(call BuildPackage,containerd))

--- a/utils/docker/Makefile
+++ b/utils/docker/Makefile
@@ -1,8 +1,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=docker
-PKG_VERSION:=27.3.1
-PKG_RELEASE:=2
+PKG_VERSION:=29.4.1
+PKG_RELEASE:=1
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 
@@ -10,30 +10,33 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_GIT_URL:=github.com/docker/cli
 PKG_GIT_REF:=v$(PKG_VERSION)
 PKG_SOURCE_URL:=https://codeload.$(PKG_GIT_URL)/tar.gz/$(PKG_GIT_REF)?
-PKG_HASH:=df7d44387166d90954e290dfbe0a278649bf71d0e89933615bdc0757580b68e4
-PKG_GIT_SHORT_COMMIT:=ce12230 # SHA1 used within the docker executables
+PKG_HASH:=b45d935ab8f5faff8b0a03eb6c5c658636f47bc8170d892152b8eb57f5931315
+PKG_GIT_SHORT_COMMIT:=055a478 # SHA1 used within the docker executables
 
 PKG_MAINTAINER:=Gerard Ryan <G.M0N3Y.2503@gmail.com>
 
 PKG_BUILD_DEPENDS:=golang/host dockerd
 PKG_BUILD_PARALLEL:=1
-PKG_BUILD_FLAGS:=no-mips16
 
 GO_PKG:=$(PKG_GIT_URL)
 
 include $(INCLUDE_DIR)/package.mk
 include ../../lang/golang/golang-package.mk
 
+EMPTY:=
+SPACE:= $(EMPTY) $(EMPTY)
+ARCH_DEPENDS:=@($(subst $(SPACE),||,$(strip $(filter-out mips mips64 mipsel mips64el,$(subst ||,$(SPACE),$(patsubst @(%),%,$(GO_ARCH_DEPENDS)))))))
+
 define Package/docker
   SECTION:=utils
   CATEGORY:=Utilities
   TITLE:=Docker Community Edition CLI
   URL:=https://www.docker.com/
-  DEPENDS:=$(GO_ARCH_DEPENDS)
+  DEPENDS:=$(ARCH_DEPENDS)
 endef
 
 define Package/docker/description
-The CLI used in the Docker CE and Docker EE products.
+  The CLI used in the Docker CE and Docker EE products.
 endef
 
 GO_PKG_INSTALL_EXTRA:=\
@@ -44,27 +47,24 @@ TAR_OPTIONS:=--strip-components 1 $(TAR_OPTIONS)
 TAR_CMD=$(HOST_TAR) -C $(1) $(TAR_OPTIONS)
 TARGET_LDFLAGS += $(if $(CONFIG_USE_GLIBC),-lc -lgcc_eh)
 
+# Verify PKG_GIT_SHORT_COMMIT
 define Build/Prepare
 	$(Build/Prepare/Default)
 
-	# Verify PKG_GIT_SHORT_COMMIT
-	( \
-		EXPECTED_PKG_GIT_SHORT_COMMIT=$$$$( $(CURDIR)/../dockerd/git-short-commit.sh '$(PKG_GIT_URL)' '$(PKG_GIT_REF)' '$(TMP_DIR)/git-short-commit/$(PKG_NAME)-$(PKG_VERSION)' ); \
-		if [ "$$$${EXPECTED_PKG_GIT_SHORT_COMMIT}" != "$(strip $(PKG_GIT_SHORT_COMMIT))" ]; then \
-			echo "ERROR: Expected 'PKG_GIT_SHORT_COMMIT:=$$$${EXPECTED_PKG_GIT_SHORT_COMMIT}', found 'PKG_GIT_SHORT_COMMIT:=$(strip $(PKG_GIT_SHORT_COMMIT))'"; \
-			exit 1; \
-		fi \
-	)
+	EXPECTED_PKG_GIT_SHORT_COMMIT=$$$$( $(CURDIR)/../dockerd/git-short-commit.sh '$(PKG_GIT_URL)' '$(PKG_GIT_REF)' '$(TMP_DIR)/git-short-commit/$(PKG_NAME)-$(PKG_VERSION)' ); \
+	if [ "$$$${EXPECTED_PKG_GIT_SHORT_COMMIT}" != "$(strip $(PKG_GIT_SHORT_COMMIT))" ]; then \
+		echo "ERROR: Expected 'PKG_GIT_SHORT_COMMIT:=$$$${EXPECTED_PKG_GIT_SHORT_COMMIT}', found 'PKG_GIT_SHORT_COMMIT:=$(strip $(PKG_GIT_SHORT_COMMIT))'"; \
+		exit 1; \
+	fi
 endef
 
 define Build/Compile
-	( \
-		cd $(PKG_BUILD_DIR); \
-		$(GO_PKG_VARS) \
-		GITCOMMIT=$(PKG_GIT_SHORT_COMMIT) \
-		VERSION=$(PKG_VERSION) \
-		./scripts/build/binary; \
-	)
+	cd $(PKG_BUILD_DIR); \
+	$(GO_PKG_VARS) \
+	GITCOMMIT=$(PKG_GIT_SHORT_COMMIT) \
+	VERSION=$(PKG_VERSION) \
+	TARGET=$(PKG_BUILD_DIR)/build \
+	./scripts/build/binary
 endef
 
 define Package/docker/install

--- a/utils/dockerd/Makefile
+++ b/utils/dockerd/Makefile
@@ -1,29 +1,32 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dockerd
-PKG_VERSION:=27.3.1
-PKG_RELEASE:=4
+PKG_VERSION:=29.4.1
+PKG_RELEASE:=1
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 PKG_CPE_ID:=cpe:/a:mobyproject:moby
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_GIT_URL:=github.com/moby/moby
-PKG_GIT_REF:=v$(PKG_VERSION)
+PKG_GIT_REF:=docker-v$(PKG_VERSION)
 PKG_SOURCE_URL:=https://codeload.$(PKG_GIT_URL)/tar.gz/$(PKG_GIT_REF)?
-PKG_HASH:=d18208d9e0b6421307342cdef266193984c97c87177b9262b1113e6e9e7e020e
-PKG_GIT_SHORT_COMMIT:=41ca978 # SHA1 used within the docker executables
+PKG_HASH:=89ef4a0f681ae2c9f7449591243e1e932d86e6086ac3392a47da80c10b1a3d58
+PKG_GIT_SHORT_COMMIT:=6c91b92 # SHA1 used within the docker executables
 
 PKG_MAINTAINER:=Gerard Ryan <G.M0N3Y.2503@gmail.com>
 
 PKG_BUILD_DEPENDS:=golang/host
 PKG_BUILD_PARALLEL:=1
-PKG_BUILD_FLAGS:=no-mips16
 
 GO_PKG:=github.com/docker/docker
 
 include $(INCLUDE_DIR)/package.mk
 include ../../lang/golang/golang-package.mk
+
+EMPTY:=
+SPACE:= $(EMPTY) $(EMPTY)
+ARCH_DEPENDS:=@($(subst $(SPACE),||,$(strip $(filter-out mips mips64 mipsel mips64el,$(subst ||,$(SPACE),$(patsubst @(%),%,$(GO_ARCH_DEPENDS)))))))
 
 define Package/dockerd/config
   source "$(SOURCE)/Config.in"
@@ -34,7 +37,7 @@ define Package/dockerd
   CATEGORY:=Utilities
   TITLE:=Docker Community Edition Daemon
   URL:=https://www.docker.com/
-  DEPENDS:=$(GO_ARCH_DEPENDS) \
+  DEPENDS:=$(ARCH_DEPENDS) \
     +ca-certificates \
     +containerd \
     +iptables \
@@ -47,8 +50,7 @@ define Package/dockerd
     +kmod-nf-ipvs \
     +kmod-veth \
     +tini \
-    +uci-firewall \
-    @!(mips||mips64||mipsel)
+    +uci-firewall
   USERID:=docker:docker
   MENU:=1
 endef
@@ -58,65 +60,45 @@ define Package/dockerd/conffiles
 endef
 
 define Package/dockerd/description
-The Docker CE Engine.
+  The Docker CE Engine.
 endef
 
 TAR_OPTIONS:=--strip-components 1 $(TAR_OPTIONS)
 TAR_CMD=$(HOST_TAR) -C $(1) $(TAR_OPTIONS)
 TARGET_LDFLAGS += $(if $(CONFIG_USE_GLIBC),-lc -lgcc_eh)
 
-# $(1) = path to dependent package 'Makefile'
-# $(2) = relevant dependency '.installer' file
+# $(1) = OpenWrt dependent PKG_NAME
 define EnsureVendoredVersion
-	( \
-		DEP_VER=$$$$( grep --only-matching --perl-regexp '(?<=PKG_VERSION:=)(.*)' "$(1)" ); \
-		VEN_VER=$$$$( grep --only-matching --perl-regexp '(?<=_VERSION:=v)(.*)(?=})' "$(PKG_BUILD_DIR)/hack/dockerfile/install/$(2)" ); \
-		if [ "$$$${VEN_VER}" != "$$$${DEP_VER}" ]; then \
-			echo "ERROR: $(PKG_NAME) Expected 'PKG_VERSION:=$$$${VEN_VER}' in '$(1)', found 'PKG_VERSION:=$$$${DEP_VER}'"; \
-			exit 1; \
-		fi \
-	)
-endef
-
-# $(1) = path to dependent package 'Makefile'
-# $(2) = relevant dependency '.installer' file
-define EnsureVendoredCommit
-	( \
-		DEP_VER=$$$$( grep --only-matching --perl-regexp '(?<=PKG_SOURCE_VERSION:=)(.*)' "$(1)" ); \
-		VEN_VER=$$$$( grep --only-matching --perl-regexp '(?<=_COMMIT:=)(.*)(?=})' "$(PKG_BUILD_DIR)/hack/dockerfile/install/$(2)" ); \
-		if [ "$$$${VEN_VER}" != "$$$${DEP_VER}" ]; then \
-			echo "ERROR: Expected 'PKG_SOURCE_VERSION:=$$$${VEN_VER}' in '$(1)', found 'PKG_SOURCE_VERSION:=$$$${DEP_VER}'"; \
-			exit 1; \
-		fi \
-	)
+	DEP_VER=$$$$( grep --only-matching --perl-regexp '(?<=PKG_VERSION:=)(.*)' "../$(1)/Makefile" ); \
+	VEN_VER=$$$$( grep --only-matching --perl-regexp '(?<=$(call toupper,$(1))_VERSION=v)(.*)' "$(PKG_BUILD_DIR)/Dockerfile" ); \
+	if [ "$$$${VEN_VER}" != "$$$${DEP_VER}" ]; then \
+		echo "ERROR: $(PKG_NAME) Expected 'PKG_VERSION:=$$$${VEN_VER}' in '$(1)', found 'PKG_VERSION:=$$$${DEP_VER}'"; \
+		exit 1; \
+	fi
 endef
 
 define Build/Prepare
 	$(Build/Prepare/Default)
 
 	# Verify dependencies are the vendored version
-	$(call EnsureVendoredVersion,../containerd/Makefile,containerd.installer)
-	$(call EnsureVendoredVersion,../runc/Makefile,runc.installer)
-	$(call EnsureVendoredVersion,../tini/Makefile,tini.installer)
+	$(call EnsureVendoredVersion,containerd)
+	$(call EnsureVendoredVersion,runc)
+	$(call EnsureVendoredVersion,tini)
 
 	# Verify CLI is the same version
-	( \
-		CLI_MAKEFILE="../docker/Makefile"; \
-		CLI_VERSION=$$$$( grep --only-matching --perl-regexp '(?<=PKG_VERSION:=)(.*)' "$$$${CLI_MAKEFILE}" ); \
-		if [ "$$$${CLI_VERSION}" != "$(PKG_VERSION)" ]; then \
-			echo "ERROR: Expected 'PKG_VERSION:=$(PKG_VERSION)' in '$$$${CLI_MAKEFILE}', found 'PKG_VERSION:=$$$${CLI_VERSION}'"; \
-			exit 1; \
-		fi \
-	)
+	CLI_MAKEFILE="../docker/Makefile"; \
+	CLI_VERSION=$$$$( grep --only-matching --perl-regexp '(?<=PKG_VERSION:=)(.*)' "$$$${CLI_MAKEFILE}" ); \
+	if [ "$$$${CLI_VERSION}" != "$(PKG_VERSION)" ]; then \
+		echo "ERROR: Expected 'PKG_VERSION:=$(PKG_VERSION)' in '$$$${CLI_MAKEFILE}', found 'PKG_VERSION:=$$$${CLI_VERSION}'"; \
+		exit 1; \
+	fi
 
 	# Verify PKG_GIT_SHORT_COMMIT
-	( \
-		EXPECTED_PKG_GIT_SHORT_COMMIT=$$$$( $(CURDIR)/git-short-commit.sh '$(PKG_GIT_URL)' '$(PKG_GIT_REF)' '$(TMP_DIR)/git-short-commit/$(PKG_NAME)-$(PKG_VERSION)' ); \
-		if [ "$$$${EXPECTED_PKG_GIT_SHORT_COMMIT}" != "$(strip $(PKG_GIT_SHORT_COMMIT))" ]; then \
-			echo "ERROR: Expected 'PKG_GIT_SHORT_COMMIT:=$$$${EXPECTED_PKG_GIT_SHORT_COMMIT}', found 'PKG_GIT_SHORT_COMMIT:=$(strip $(PKG_GIT_SHORT_COMMIT))'"; \
-			exit 1; \
-		fi \
-	)
+	EXPECTED_PKG_GIT_SHORT_COMMIT=$$$$( $(CURDIR)/git-short-commit.sh '$(PKG_GIT_URL)' '$(PKG_GIT_REF)' '$(TMP_DIR)/git-short-commit/$(PKG_NAME)-$(PKG_VERSION)' ); \
+	if [ "$$$${EXPECTED_PKG_GIT_SHORT_COMMIT}" != "$(strip $(PKG_GIT_SHORT_COMMIT))" ]; then \
+		echo "ERROR: Expected 'PKG_GIT_SHORT_COMMIT:=$$$${EXPECTED_PKG_GIT_SHORT_COMMIT}', found 'PKG_GIT_SHORT_COMMIT:=$(strip $(PKG_GIT_SHORT_COMMIT))'"; \
+		exit 1; \
+	fi
 endef
 
 BUILDTAGS:=
@@ -128,14 +110,12 @@ BUILDTAGS += selinux
 endif
 
 define Build/Compile
-	( \
-		cd $(PKG_BUILD_DIR); \
-		$(GO_PKG_VARS) \
-		DOCKER_GITCOMMIT=$(PKG_GIT_SHORT_COMMIT) \
-		DOCKER_BUILDTAGS='$(BUILDTAGS)' \
-		VERSION=$(PKG_VERSION) \
-		./hack/make.sh binary; \
-	)
+	cd $(PKG_BUILD_DIR); \
+	$(GO_PKG_VARS) \
+	DOCKER_GITCOMMIT=$(PKG_GIT_SHORT_COMMIT) \
+	DOCKER_BUILDTAGS='$(BUILDTAGS)' \
+	VERSION=$(PKG_VERSION) \
+	./hack/make.sh binary
 endef
 
 define Package/dockerd/install

--- a/utils/dockerd/files/etc/config/dockerd
+++ b/utils/dockerd/files/etc/config/dockerd
@@ -31,8 +31,8 @@ config proxies 'proxies'
 # Docker doesn't work well out of the box with fw4. This is because Docker relies on a compatibility layer that
 # naively translates iptables rules. For the best compatibility replace the following dependencies:
 # `firewall4` -> `firewall`
-# `iptables-nft` -> `iptables-legacy`
-# `ip6tables-nft` -> `ip6tables-legacy`
+# `iptables-nft` -> `iptables-zz-legacy`
+# `ip6tables-nft` -> `ip6tables-zz-legacy`
 
 # Docker undermines the fw3 rules. By default all external source IPs are allowed to connect to the Docker host.
 # See https://docs.docker.com/network/iptables/ for more details.

--- a/utils/runc/Makefile
+++ b/utils/runc/Makefile
@@ -1,38 +1,42 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=runc
-PKG_VERSION:=1.1.14
-PKG_RELEASE:=2
+PKG_VERSION:=1.3.5
+PKG_RELEASE:=1
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 PKG_CPE_ID:=cpe:/a:linuxfoundation:runc
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/opencontainers/runc/tar.gz/v${PKG_VERSION}?
-PKG_HASH:=563cf57c38d2e7149234dbe6f63ca0751eb55ef8f586ed12a543dedc1aceba68
+PKG_HASH:=72620f9b0e62d8da80c0c08a6265ab10d24330c544115c30713ba1429bde706d
 
 PKG_MAINTAINER:=Gerard Ryan <G.M0N3Y.2503@gmail.com>
 
 PKG_BUILD_DEPENDS:=golang/host dockerd
 PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
-PKG_BUILD_FLAGS:=no-mips16
 
 GO_PKG:=github.com/opencontainers/runc
 
 include $(INCLUDE_DIR)/package.mk
 include ../../lang/golang/golang-package.mk
 
+EMPTY:=
+SPACE:= $(EMPTY) $(EMPTY)
+ARCH_DEPENDS:=@($(subst $(SPACE),||,$(strip $(filter-out mips mips64 mipsel mips64el,$(subst ||,$(SPACE),$(patsubst @(%),%,$(GO_ARCH_DEPENDS)))))))
+
 define Package/runc
   SECTION:=utils
   CATEGORY:=Utilities
   TITLE:=runc container runtime
   URL:=https://www.opencontainers.org/
-  DEPENDS:=$(GO_ARCH_DEPENDS) +KERNEL_SECCOMP_FILTER:libseccomp
+  DEPENDS:=$(ARCH_DEPENDS) +KERNEL_SECCOMP_FILTER:libseccomp
 endef
 
 define Package/runc/description
-runc is a CLI tool for spawning and running containers according to the OCI specification.
+  runc is a CLI tool for spawning and running containers according to the OCI
+  specification.
 endef
 
 GO_PKG_INSTALL_ALL:=1


### PR DESCRIPTION
**Maintainer:** @G-M0N3Y-2503

**Description:**

Bump Docker to 29.4.1 and bump related packages to the required versions.

Fix build issues and disable building for all MIPS variants due to some upstream MIPS machine code incompatibilities.

Supersedes:
- #25972

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12.2
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** QEMU/Vadas

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.