### PR TITLE
OpenVPN netifd Deep Integration & Configuration Refactoring

### DIFF
--- a/net/openvpn/Makefile
+++ b/net/openvpn/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=openvpn
 
 PKG_VERSION:=2.7.4
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_URL:=\
 	https://build.openvpn.net/downloads/releases/ \
@@ -37,6 +37,7 @@ define Package/openvpn/Default
   SUBMENU:=VPN
   MENU:=1
   DEPENDS:=+kmod-tun \
+	   +@BUSYBOX_CONFIG_ASH_BASH_COMPAT \
 	   +libcap-ng \
 	   +OPENVPN_$(1)_ENABLE_LZO:liblzo \
 	   +OPENVPN_$(1)_ENABLE_LZ4:liblz4 \

--- a/net/openvpn/files/lib/netifd/proto/openvpn.sh
+++ b/net/openvpn/files/lib/netifd/proto/openvpn.sh
@@ -13,6 +13,9 @@
 	init_proto "$@"
 }
 
+CONF_DIR="/var/run"
+CONF_PREFIX="${CONF_DIR}/openvpn."
+
 # Helper to DRY up repeated option handling in init/setup
 option_builder() {
 	# option_builder <action:add|build> <LIST_VAR_NAME> <type>
@@ -92,6 +95,7 @@ option_builder() {
 # Not real config params used by openvpn - only by our proto handler
 PROTO_BOOLS='
 allow_deprecated
+defaultroute
 ipv6
 '
 
@@ -100,6 +104,10 @@ username
 password
 cert_password
 ovpnproto
+'
+
+PROTO_INTS='
+metric
 '
 
 proto_openvpn_init_config() {
@@ -116,6 +124,7 @@ proto_openvpn_init_config() {
 	# Add proto config options - netifd compares these for changes between interface events
 	option_builder add PROTO_BOOLS protobool
 	option_builder add PROTO_STRINGS string
+	option_builder add PROTO_INTS integer
 	option_builder add OPENVPN_BOOLS bool
 	option_builder add OPENVPN_UINTS uinteger
 	option_builder add OPENVPN_INTS integer
@@ -124,11 +133,88 @@ proto_openvpn_init_config() {
 	option_builder add OPENVPN_LIST list
 }
 
+# rewrite_config_line <dst> <old_path> <new_path>
+# Replace a `config <old_path>` line in <dst> with `config <new_path>`.
+# Handles absolute path, relative filename, no quotes / single quotes / double quotes,
+# and optional trailing whitespace.
+rewrite_config_line() {
+	local dst="$1"
+	local old="$2"
+	local new="$3"
+	local fname="${old##*/}"
+
+	# absolute path, three quote styles
+	# and relative filename, three quote styles
+	sed -i \
+		-e "s|^\([[:space:]]*config[[:space:]]\+\)${old}[[:space:]]*$|\1${new}|" \
+		-e "s|^\([[:space:]]*config[[:space:]]\+\)'${old}'[[:space:]]*$|\1${new}|" \
+		-e "s|^\([[:space:]]*config[[:space:]]\+\)\"${old}\"[[:space:]]*$|\1${new}|" \
+		-e "s|^\([[:space:]]*config[[:space:]]\+\)${fname}[[:space:]]*$|\1${new}|" \
+		-e "s|^\([[:space:]]*config[[:space:]]\+\)'${fname}'[[:space:]]*$|\1${new}|" \
+		-e "s|^\([[:space:]]*config[[:space:]]\+\)\"${fname}\"[[:space:]]*$|\1${new}|" \
+		"$dst"
+}
+
+# Recursively copy config files referenced by `config` directives.
+# Updates the `config` paths in the destination file to point to the copies.
+# Appends all copied files to the global CONFIG_FILES variable.
+#
+# Usage: copy_config_recursive <dst_file> <visited>
+#   dst_file: the already-copied config file to scan for `config` lines
+#   visited:  pipe-delimited list of source paths already processed (cycle guard)
+copy_config_recursive() {
+	local dst="$1"
+	local visited="$2"
+	local ref dst_ref fname
+
+	while IFS= read -r ref; do
+		# skip empty lines
+		[ -n "$ref" ] || continue
+		case "$ref" in
+			*"$CONF_PREFIX"*) continue ;;
+		esac
+
+		# expand relative path to absolute using cd_dir
+		case "$ref" in
+			/*) ;;
+			*) ref="$cd_dir/$ref" ;;
+		esac
+
+		# cycle guard
+		case "$visited" in
+			*"|$ref|"*) continue ;;
+		esac
+
+		[ -f "$ref" ] || continue
+
+		fname="${ref##*/}"
+		dst_ref="${CONF_PREFIX}${config}.user_${fname}"
+
+		cp "$ref" "$dst_ref" || {
+			logger -t "openvpn_$config(proto)" -p daemon.err "failed to copy config '$ref' to '$dst_ref'"
+			continue
+		}
+
+		# rewrite the `config` line in the parent file to point to the copy
+		rewrite_config_line "$dst" "$ref" "$dst_ref"
+
+		# accumulate file list
+		CONFIG_FILES="$CONFIG_FILES $dst_ref"
+
+		# recurse
+		copy_config_recursive "$dst_ref" "$visited|$ref|"
+
+	done <<EOF
+$(sed -n "/^[[:space:]]*config[[:space:]]/ { s/^[[:space:]]*config[[:space:]][[:space:]]*//; s/^['\"]//; s/[[:space:]]*['\"][[:space:]]*$//; s/[[:space:]]*$//; p; }" "$dst")
+EOF
+}
+
 proto_openvpn_setup() {
 	local config="$1"
-	local conf_file="/var/run/openvpn.$config.conf"
+	local conf_file="${CONF_PREFIX}$config.conf"
 	local exec_params cd_dir
 
+	mkdir -p "$CONF_DIR"
 	exec_params=
 
 	json_get_var dev_type dev_type
@@ -141,7 +227,7 @@ proto_openvpn_setup() {
 	cd_dir="${config_file%/*}"
 	[ "$cd_dir" = "$config_file" ] && cd_dir="/"
 	append exec_params "--cd $cd_dir"
-	append exec_params "--status /var/run/openvpn.$config.status"
+	append exec_params "--status ${CONF_PREFIX}$config.status"
 	append exec_params "--syslog openvpn_$config"
 	append exec_params "--tmp-dir /tmp"
 
@@ -160,73 +246,29 @@ proto_openvpn_setup() {
 
 	json_get_vars auth_user_pass askpass username password cert_password
 
-	mkdir -p /var/run
-	# combine into --askpass:
-	if [ -n "$cert_password" ]; then
-		cp_file="/var/run/openvpn.$config.pass"
-		umask 077
-		printf '%s\n' "${cert_password:-}" > "$cp_file"
-		umask 022
-		append exec_params "--askpass $cp_file"
-	elif [ -n "$askpass" ]; then
-		append exec_params "--askpass $askpass"
-	fi
-
-	# combine into --auth-user-pass:
-	if [ -n "$username" ] || [ -n "$password" ]; then
-		auth_file="/var/run/openvpn.$config.auth"
-		umask 077
-		printf '%s\n' "${username:-}" "${password:-}" > "$auth_file"
-		umask 022
-		append exec_params "--auth-user-pass $auth_file"
-	elif [ -n "$auth_user_pass" ]; then
-		append exec_params "--auth-user-pass $auth_user_pass"
-	fi
-
 	# Testing option
 	# ${tls_exit:+--tls-exit} \
 
 	# Check 'script_security' option
 	json_get_var script_security script_security
-	[ -z "$script_security" ] && script_security=3
+	[ -z "$script_security" ] && script_security=2
 
-	# Add default hotplug handling if 'script_security' option is equal '3'
-	if [ "$script_security" -eq '3' ]; then
-		local ipv6
+	# Add default hotplug handling if 'script_security' option is ge '2'
+	if [ "$script_security" -ge '2' ]; then
 		local up down route_up route_pre_down
 		local client tls_client tls_server
 		local tls_crypt_v2_verify mode learn_address client_connect
 		local client_crresponse client_disconnect auth_user_pass_verify
 
-		logger -t "openvpn(proto)" \
-			-p daemon.info "Enabled default hotplug processing, as the openvpn configuration 'script_security' is '3'"
-
-		append exec_params "--setenv INTERFACE $config"
-		append exec_params "--script-security 3"
-
 		json_get_vars up down route_up route_pre_down
 		json_get_vars tls_crypt_v2_verify mode learn_address client_connect
 		json_get_vars client_crresponse client_disconnect auth_user_pass_verify
 
-		json_get_vars ipv6
-		#default ipv6 is enabled
-		[ -n "$ipv6" ] || ipv6=1
-		append exec_params "--setenv IPV6 '$ipv6'"
-
 		json_get_vars ifconfig_noexec route_noexec
-		[ -z "$ifconfig_noexec" ] && append exec_params "--ifconfig-noexec"
-		[ -z "$route_noexec" ] && append exec_params "--route-noexec"
 
-		append exec_params "--up '/usr/libexec/openvpn-hotplug'"
 		[ -n "$up" ] && append exec_params "--setenv user_up '$up'"
-
-		append exec_params "--down '/usr/libexec/openvpn-hotplug'"
 		[ -n "$down" ] && append exec_params "--setenv user_down '$down'"
-
-		append exec_params "--route-up '/usr/libexec/openvpn-hotplug'"
 		[ -n "$route_up" ] && append exec_params "--setenv user_route_up '$route_up'"
-
-		append exec_params "--route-pre-down '/usr/libexec/openvpn-hotplug'"
 		[ -n "$route_pre_down" ] && append exec_params "--setenv user_route_pre_down '$route_pre_down'"
 
 		append exec_params "--tls-crypt-v2-verify '/usr/libexec/openvpn-hotplug'"
@@ -260,16 +302,106 @@ proto_openvpn_setup() {
 			json_get_var tls_verify tls_verify
 			[ -n "$tls_verify" ] && append exec_params "--setenv user_tls_verify '$tls_verify'"
 		fi
-	else
-		logger -t "openvpn(proto)" \
-			-p daemon.warn "Default hotplug processing disabled, as the openvpn configuration 'script_security' is less than '3'"
 	fi
 
+	# Write first-phase params to conf_file
 	eval "set -- $exec_params"
 	umask 077
 	printf "%b\n" "${exec_params//--/\\n}" > "$conf_file"
 	umask 022
-	proto_run_command "$config" openvpn --config "$conf_file"
+
+	local CONFIG_FILES="$conf_file"
+	# Copy user config and recursively copy all referenced config files,
+	# rewriting `config` directives to point to the copies in CONF_DIR.
+	local user_conf="${CONF_PREFIX}$config.user.conf"
+	if [ -n "$config_file" -a -e "$config_file" ]; then
+		cp "$config_file" "$user_conf" || {
+			logger -t "openvpn_$config(proto)" -p daemon.err "failed to copy config '$config_file'"
+			return 1
+		}
+		CONFIG_FILES="$CONFIG_FILES $user_conf"
+		copy_config_recursive "$user_conf" ""
+
+		# Update the `config` reference in conf_file to point to the copied user_conf.
+		rewrite_config_line "$conf_file" "$config_file" "$user_conf"
+	fi
+
+	local ipv6 defaultroute metric
+	exec_params=
+
+	# combine into --askpass:
+	if [ -n "$cert_password" ]; then
+		cp_file="${CONF_PREFIX}$config.pass"
+		umask 077
+		printf '%s\n' "${cert_password:-}" > "$cp_file"
+		umask 022
+		append exec_params "--askpass $cp_file"
+	elif [ -n "$askpass" ]; then
+		append exec_params "--askpass $askpass"
+	fi
+
+	# combine into --auth-user-pass:
+	if [ -n "$username" ] || [ -n "$password" ]; then
+		auth_file="${CONF_PREFIX}$config.auth"
+		umask 077
+		printf '%s\n' "${username:-}" "${password:-}" > "$auth_file"
+		umask 022
+		append exec_params "--auth-user-pass $auth_file"
+	elif [ -n "$auth_user_pass" ]; then
+		append exec_params "--auth-user-pass $auth_user_pass"
+	fi
+
+	#Always Override Options
+	append exec_params "--setenv INTERFACE $config"
+	append exec_params "--script-security 3"
+	append exec_params "--ifconfig-noexec"
+	append exec_params "--route-noexec"
+	append exec_params "--up '/usr/libexec/openvpn-hotplug'"
+	append exec_params "--down '/usr/libexec/openvpn-hotplug'"
+	append exec_params "--route-up '/usr/libexec/openvpn-hotplug'"
+	append exec_params "--route-pre-down '/usr/libexec/openvpn-hotplug'"
+	append exec_params "--persist-tun"
+	append exec_params "--persist-key"
+
+	local is_client=0
+	local client_detect_file="${CONF_PREFIX}$config.client_detected"
+	rm -f "$client_detect_file"
+
+	# filter out dup options - applied to all copied config files
+	sed -i \
+		-e "/^[[:space:]]*remote[[:space:]]/w $client_detect_file" \
+		-e '/^[[:space:]]*script-security[[:space:]]*/s/^/# /' \
+		-e '/^[[:space:]]*ifconfig-noexec[[:space:]]*/s/^/# /' \
+		-e '/^[[:space:]]*route-noexec[[:space:]]*/s/^/# /' \
+		-e '/^[[:space:]]*up[[:space:]]/s/^/# /' \
+		-e '/^[[:space:]]*down[[:space:]]/s/^/# /' \
+		-e '/^[[:space:]]*route-up[[:space:]]/s/^/# /' \
+		-e '/^[[:space:]]*route-pre-down[[:space:]]/s/^/# /' \
+		-e '/^[[:space:]]*persist-tun[[:space:]]*/s/^/# /' \
+		-e '/^[[:space:]]*persist-key[[:space:]]*/s/^/# /' \
+		$CONFIG_FILES
+	[ -s "$client_detect_file" ] && {
+		is_client=1
+	}
+	rm -f "$client_detect_file"
+
+	json_get_vars ipv6 defaultroute metric
+	#default ipv6 is enabled
+	[ -n "$ipv6" ] || ipv6=1
+	append exec_params "--setenv IPV6 $ipv6"
+
+	[ -n "$metric" ] && append exec_params "--setenv METRIC $metric"
+
+	if [ "$is_client" = 1 ]; then
+		append exec_params "--redirect-gateway def1 ipv6"
+		[ -n "$defaultroute" ] || defaultroute=1
+		sed -i '/^[[:space:]]*redirect-gateway[[:space:]]*/s/^/# /' $CONFIG_FILES
+	else
+		defaultroute=0
+	fi
+	append exec_params "--setenv DEFAULTROUTE $defaultroute"
+
+	proto_run_command "$config" openvpn $exec_params --config "$conf_file"
 
 	# last param wins; user provided status or syslog supersedes.
 }
@@ -284,12 +416,14 @@ proto_openvpn_renew() {
 
 proto_openvpn_teardown() {
 	local iface="$1"
-	rm -f \
-		"/var/run/openvpn.$iface.conf" \
-		"/var/run/openvpn.$iface.pass" \
-		"/var/run/openvpn.$iface.auth" \
-		"/var/run/openvpn.$iface.status" 
+
 	proto_kill_command "$iface"
+	[ -n "$iface" ] && rm -f "${CONF_PREFIX}${iface}."*
+
+	/usr/libexec/openvpn-hotplug cleanup "$iface"
+
+	proto_init_update "*" 0
+	proto_send_update "$iface"
 }
 
 [ -n "$INCLUDE_ONLY" ] || {

--- a/net/openvpn/files/usr/libexec/openvpn-hotplug
+++ b/net/openvpn/files/usr/libexec/openvpn-hotplug
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+if [ "$1" = "cleanup" ]; then
+	script_type=cleanup
+	INTERFACE="$2"
+fi
+
 [ -z "$script_type" ] && {
 	logger -t "openvpn(proto)" -p daemon.warn "hotplug: variable 'script_type' not found"
 	exit
@@ -10,8 +15,44 @@
 	exit
 }
 
-. /lib/functions.sh
-. /lib/netifd/netifd-proto.sh
+exec 2> >(logger -t "openvpn_$INTERFACE(hotplug)" -p daemon.err)
+
+run_hotplug() {
+	ACTION="$script_type"
+	INSTANCE="$INTERFACE"
+
+	export ACTION
+	export INSTANCE
+	exec /sbin/hotplug-call openvpn "$@"
+}
+
+case "$script_type" in
+	cleanup)
+		. /usr/share/libubox/jshn.sh
+
+		SERVER_ROUTE_IPV4_CLEANUP_CMD=
+		SERVER_ROUTE_IPV6_CLEANUP_CMD=
+		json_data="$(ubus call network.interface."$INTERFACE" status 2>/dev/null)"
+		if json_load "$json_data" 2>/dev/null; then
+			if json_select data 2>/dev/null; then
+				json_get_var SERVER_ROUTE_IPV4_CLEANUP_CMD server_route_ipv4_cleanup_cmd
+				json_get_var SERVER_ROUTE_IPV6_CLEANUP_CMD server_route_ipv6_cleanup_cmd
+				[ -n "$SERVER_ROUTE_IPV4_CLEANUP_CMD" ] && $SERVER_ROUTE_IPV4_CLEANUP_CMD
+				[ -n "$SERVER_ROUTE_IPV6_CLEANUP_CMD" ] && $SERVER_ROUTE_IPV6_CLEANUP_CMD
+			fi
+		fi
+
+		run_hotplug "$@"
+	;;
+	up) ;;
+	*) run_hotplug "$@" ;;
+esac
+
+SERVER_ROUTE_IPV4_CLEANUP_CMD=
+SERVER_ROUTE_IPV6_CLEANUP_CMD=
+MASK_PREFIX=
+CIDR6_ADDR=
+CIDR6_PLEN=
 
 mask2prefix() {
 	local mask="$1"
@@ -31,32 +72,100 @@ mask2prefix() {
 			*)   break     ;;
 		esac
 	done
-	echo "$n"
+	MASK_PREFIX="$n"
 }
 
 parse_cidr6() {
 	local val="$1"
 	local def_plen="$2"
-	local addr="${val%/*}"
-	local plen="${val#*/}"
-	[ "$addr" = "$plen" ] && plen="$def_plen"
-	echo "$addr $plen"
+
+	CIDR6_ADDR="${val%/*}"
+	CIDR6_PLEN="${val#*/}"
+	[ "$CIDR6_ADDR" = "$CIDR6_PLEN" ] && CIDR6_PLEN="$def_plen"
+}
+
+route_path_for_target() {
+	local family="$1"
+	local target="$2"
+	local output key
+
+	route_path_gateway=
+	route_path_dev=
+
+	[ -n "$target" ] || return 1
+
+	output="$(ip "-$family" route get "$target" 2>/dev/null)" || return 1
+
+	set -- $output
+	while [ "$#" -gt 0 ]; do
+		key="$1"
+		case "$key" in
+			via)
+				shift
+				route_path_gateway="$1"
+			;;
+			dev)
+				shift
+				route_path_dev="$1"
+			;;
+		esac
+		[ "$#" -gt 0 ] && shift
+	done
+
+	[ -n "$route_path_gateway$route_path_dev" ]
+}
+
+server_route_exists() {
+	local family="$1"
+	local prefix="$2"
+	local target="$3"
+	local output
+
+	[ -n "$target" ] || return 1
+
+	output="$(ip "-$family" route show "$target/$prefix" ${METRIC:+metric $METRIC} 2>/dev/null)"
+	[ -n "$output" ]
+}
+
+is_openvpn_default_route()
+{
+	case $1 in
+		0.0.0.0/0|\
+		0.0.0.0/1|\
+		128.0.0.0/1|\
+		::/0|\
+		::/1|\
+		8000::/1|\
+		::/3|\
+		2000::/3|\
+		3000::/4|\
+		2000::/4|\
+		fc00::/7)
+			return 0
+	esac
+	return 1
 }
 
 case "$script_type" in
 	up)
-		nohostroute="$(uci_get network "$INTERFACE" nohostroute)"
+		. /lib/functions.sh
+		. /lib/netifd/netifd-proto.sh
+		. /usr/share/libubox/jshn.sh
+
 		proto_init_update "$dev" 1
+
+		[ -n "$tun_mtu" ] && /sbin/ip link set dev $dev mtu $tun_mtu
 
 		[ -n "$ifconfig_local" ] && proto_add_ipv4_address "$ifconfig_local" "${ifconfig_netmask:-255.255.255.255}"
 
-		[ -n "$trusted_ip" ] && {
-			if [ -n "$route_net_gateway" -a "$route_net_gateway" != "0.0.0.0" -a "${nohostroute}" != "1" ]; then
-				proto_add_host_dependency "$INTERFACE" "$trusted_ip"
+		if [ -n "$trusted_ip" -a "$DEFAULTROUTE" = "1" ]; then
+			if route_path_for_target 4 "$trusted_ip" && ! server_route_exists 4 32 "$trusted_ip"; then
+				ip -4 route add $trusted_ip ${route_path_gateway:+via $route_path_gateway} ${route_path_dev:+dev $route_path_dev} ${METRIC:+metric $METRIC}
+				SERVER_ROUTE_IPV4_CLEANUP_CMD="ip -4 route del $trusted_ip ${route_path_gateway:+via $route_path_gateway} ${route_path_dev:+dev $route_path_dev} ${METRIC:+metric $METRIC}"
 			fi
-		}
+		fi
 
-		[ -n "$route_vpn_gateway" ] && proto_add_ipv4_route "0.0.0.0" 0 "$route_vpn_gateway"
+		[ "$DEFAULTROUTE" = "1" ] && [ -n "$route_vpn_gateway" ] && proto_add_ipv4_route "0.0.0.0" 0 "$route_vpn_gateway"
 
 		i=0
 		while :; do
@@ -65,27 +174,26 @@ case "$script_type" in
 			[ -z "$net" ] && break
 			[ -z "$mask" ] && continue
 
-			plen=$(mask2prefix "$mask")
-			proto_add_ipv4_route "$net" "$plen" "$gw"
+			mask2prefix "$mask"
+			is_openvpn_default_route "$net/$MASK_PREFIX" && continue
+
+			proto_add_ipv4_route "$net" "$MASK_PREFIX" "$gw"
 		done
 
 		if [ "$IPV6" = "1" ]; then
 			if [ -n "$ifconfig_ipv6_local" ]; then
-				read -r v6addr v6plen <<-EOF
-					$(parse_cidr6 "$ifconfig_ipv6_local" "${ifconfig_ipv6_netbits:-128}")
-				EOF
-				proto_add_ipv6_address "$v6addr" "$v6plen"
+				parse_cidr6 "$ifconfig_ipv6_local" "${ifconfig_ipv6_netbits:-128}"
+				proto_add_ipv6_address "$CIDR6_ADDR" "$CIDR6_PLEN"
 			fi
 
-			[ -n "$trusted_ip6" ] && {
-				# to detect net_gateway_ipv6, source routing on wan6 has to be disabled
-				# consider removing check for net_gateway_ipv6
-				if [ -n "$net_gateway_ipv6" -a "$net_gateway_ipv6" != "::" -a "${nohostroute}" != "1" ]; then
-					proto_add_host_dependency "$INTERFACE" "$trusted_ip6"
+			if [ -n "$trusted_ip6" -a "$DEFAULTROUTE" = "1" ]; then
+				if route_path_for_target 6 "$trusted_ip6" && ! server_route_exists 6 128 "$trusted_ip6"; then
+					ip -6 route add $trusted_ip6 ${route_path_gateway:+via $route_path_gateway} ${route_path_dev:+dev $route_path_dev} ${METRIC:+metric $METRIC}
+					SERVER_ROUTE_IPV6_CLEANUP_CMD="ip -6 route del $trusted_ip6 ${route_path_gateway:+via $route_path_gateway} ${route_path_dev:+dev $route_path_dev} ${METRIC:+metric $METRIC}"
 				fi
-			}
+			fi
 
-			[ -n "$ifconfig_ipv6_remote" ] && proto_add_ipv6_route "::" 0 "$ifconfig_ipv6_remote"
+			[ "$DEFAULTROUTE" = "1" ] && [ -n "$ifconfig_ipv6_remote" ] && proto_add_ipv6_route "::" 0 "$ifconfig_ipv6_remote"
 
 			i=0
 			while :; do
@@ -93,14 +201,12 @@ case "$script_type" in
 				eval "net=\$route_ipv6_network_$i gw=\$route_ipv6_gateway_$i"
 				[ -z "$net" ] && break
 
-				read -r v6net v6plen <<-EOF
-					$(parse_cidr6 "$net" 128)
-				EOF
-				proto_add_ipv6_route "$v6net" "$v6plen" "$gw"
+				parse_cidr6 "$net" 128
+				is_openvpn_default_route "$CIDR6_ADDR/$CIDR6_PLEN" && continue
+
+				proto_add_ipv6_route "$CIDR6_ADDR" "$CIDR6_PLEN" "$gw"
 			done
 		fi
-
-		[ -n "$tun_mtu" ] && json_add_int mtu "$tun_mtu"
 
 		i=0
 		while :; do
@@ -117,18 +223,15 @@ case "$script_type" in
 			esac
 		done
 
-		proto_send_update "$INTERFACE"
-	;;
+		proto_add_data
+		json_add_string "daemon_pid" "$daemon_pid"
+		json_add_string "ifname" "$dev"
+		[ -n "$SERVER_ROUTE_IPV4_CLEANUP_CMD" ] && json_add_string "server_route_ipv4_cleanup_cmd" "$SERVER_ROUTE_IPV4_CLEANUP_CMD"
+		[ -n "$SERVER_ROUTE_IPV6_CLEANUP_CMD" ] && json_add_string "server_route_ipv6_cleanup_cmd" "$SERVER_ROUTE_IPV6_CLEANUP_CMD"
+		proto_close_data
 
-	down)
-		proto_init_update "$dev" 0
 		proto_send_update "$INTERFACE"
 	;;
 esac
 
-ACTION="$script_type"
-INSTANCE="$INTERFACE"
-
-export ACTION="$ACTION"
-export INSTANCE="$INSTANCE"
-exec /sbin/hotplug-call openvpn "$@"
+run_hotplug "$@"


### PR DESCRIPTION
# 🚀 OpenVPN netifd Deep Integration & Configuration Refactoring

## 📑 Overview
This update introduces a series of major refactoring and enhancements to the OpenVPN module within the OpenWrt/netifd environment. The core objectives are to **improve the robustness of network and routing management**, **implement sandbox protection for user configurations**, and **fix known defects in the interface lifecycle (e.g., ineffective MTU settings)**.

By forcibly taking over underlying network configuration and introducing a smarter configuration parser, this commit thoroughly resolves conflicts between OpenVPN's built-in routing mechanisms and OpenWrt's system-level network manager (`netifd`).

---

## ✨ Key Improvements & Features

### 1. Configuration "Sandboxing" & Safe Parsing
* **Protecting Original User Files:** The script no longer directly modifies user-provided configuration files. Instead, it recursively copies the main configuration file and all sub-configurations included via the `config` directive into the `/var/run` ramdisk (`CONF_DIR`) for centralized, safe management.
* **Support for Nested Includes & Path Rewriting:** Introduced the `copy_config_recursive` and `rewrite_config_line` helper functions. These safely handle nested `config` directives, automatically resolve absolute/relative paths, manage quotes and trailing whitespace, and incorporate a strict **circular include prevention** mechanism.
* **Global Option Filtering & Deduplication:** The `sed` filtering of conflicting options (e.g., `up`/`down`, `script-security`) now spans across all associated configuration files (the `CONFIG_FILES` glob). This completely eliminates duplicate parameter warnings during OpenVPN startup.

### 2. Routing Control & Deep netifd Integration
* **Delegating Routing Authority:** Forcibly injects `--ifconfig-noexec`, `--route-noexec`, and the `hotplug` scripts via command-line arguments. This delegates all IP and routing states entirely to `netifd`, ensuring the system's native routing table and Multi-WAN (`mwan3`) strategies are respected.
* **Filtering Server-Pushed Preemptive Routes:** Added the `is_openvpn_default_route` helper in the `hotplug` script to actively ignore global default routes pushed by the VPN server (e.g., `0.0.0.0/1`). This prevents server configurations from breaking the client's local routing policies.
* **Smart Default Route Injection:** Introduced the `defaultroute` proto option. For client mode configurations, the script automatically injects `--redirect-gateway def1 ipv6`.
* **Preventing Routing Loops:** The script dynamically calculates the true outbound route path to the VPN server endpoint and stores the precise route deletion commands in `ubus`. This prevents routing loops caused by default gateway shifts.

### 3. Interface Lifecycle & State Tracking
* **Fixing MTU Setup:** Removed the previously ineffective `json_add_int mtu` call. Replaced it with an explicit `ip link set dev <tun> mtu <val>` executed during the `up` phase (prior to address configuration), ensuring the MTU is correctly applied at the kernel level.
* **Improved Ubus State Exposure:** Saves the `daemon_pid` and the actual device name (`ifname`) into the interface's `ubus` data during the `up` phase, making it easier for external tools to track OpenVPN states.
* **Cleaner Teardown Process:**
  * Reordered the shutdown sequence: the process is now terminated via `proto_kill_command` *before* file cleanup begins, preventing read/write errors during teardown.
  * Explicitly invokes the `cleanup` phase of the `hotplug` script to execute precise route removal.
  * Leverages the sandboxing mechanism by using a glob pattern (`rm -f ${CONF_PREFIX}$iface.*`) to clean up all related temporary configuration files in a single step.

### 4. Additional Stability Enhancements
* **Connection Persistence:** Forcibly enables `persist-tun` and `persist-key`. This ensures the virtual interface is not destroyed during reconnections and prevents permission errors when OpenVPN attempts to re-read certificates after dropping privileges.
* **Easier Debugging:** Redirected the standard error output (`stderr`) of `openvpn-hotplug` to `syslog` (tagged with the interface name), significantly lowering the difficulty of troubleshooting network script failures.
* **Version Bump:** Upgraded `PKG_RELEASE` to 3 in the Makefile.