### PR TITLE
ddns-scripts: better error handling for GCP

### DIFF
--- a/net/ddns-scripts/files/usr/lib/ddns/update_gcp_v1.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/update_gcp_v1.sh
@@ -40,6 +40,15 @@
 . /usr/share/libubox/jshn.sh
 
 
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Returns true if $1 is a JSON error response.
+is_error() {
+	jsonfilter -s "$1" -e "@.error" > /dev/null
+}
+
+
 # Authentication
 # ---------------------------------------------------------------------------
 # The authentication flow works like this:
@@ -139,22 +148,21 @@ get_jwt() {
 }
 
 # Request an access token for the Google Cloud service account.
-get_access_token_raw() {
+get_access_token() {
 	local grant_type="urn:ietf:params:oauth:grant-type:jwt-bearer"
 	local assertion=$(get_jwt)
 
-	${CURL} -v https://oauth2.googleapis.com/token \
-		--data-urlencode 'grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer' \
-		--data-urlencode "assertion=${assertion}" \
-		| jsonfilter -e @.access_token
-}
+	local response=$(
+		${CURL} -v https://oauth2.googleapis.com/token \
+			--data-urlencode "grant_type=${grant_type}" \
+			--data-urlencode "assertion=${assertion}"
+	)
 
-# Get the access token, stripping the trailing dots.
-get_access_token() {
-	# Since tokens may contain internal dots, we only trim the suffix if it
-	# starts with at least 8 dots. (The access token has *many* trailing dots.)
-	local access_token="$(get_access_token_raw)"
-	echo "${access_token%%........*}"
+	if is_error "${response}"; then
+		write_log 12 "${response}"
+	else
+		jsonfilter -s "${response}" -e @.access_token
+	fi
 }
 
 
@@ -209,11 +217,17 @@ patch_record_set() {
 	local url="https://dns.googleapis.com/dns/v1/projects/${project}/managedZones/${zone}/rrsets/${domain}./${record_type}"
 	local record_set=$(format_record_set ${domain} ${record_type} ${ttl} $@)
 
-	${CURL} -v ${url} \
-		-X PATCH \
-		-H "Content-Type: application/json" \
-		-H "Authorization: Bearer ${access_token}" \
-		-d "${record_set}"
+	local response=$(
+		${CURL} -v ${url} \
+			-X PATCH \
+			-H "Content-Type: application/json" \
+			-H "Authorization: Bearer ${access_token}" \
+			-d "${record_set}"
+	)
+
+	if is_error "${response}"; then
+		write_log 12 "${response}"
+	fi
 }
 
 


### PR DESCRIPTION
There are two HTTP requests made by this script. The first is to exchange a JWT for an OAuth access token. The second is to call the Google Cloud DNS API to update the record.

Previously, if either of these requests failed, the failure would be silently ignored and the script would continue as if they succeeded. This makes debugging difficult, e.g. when debuggin an access issue.

With this commit, the HTTP responses are checked to see if they contain an error payload, and if so, the error is logged and the script exits. (Calls to write_log with a level greater than 10 implicitly exit.)

---

## 📦 Package Details

**Maintainer:** @feckert
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

I think @feckert is the maintainer of ddns-scripts, judging from the commit history. Apologies if I got this wrong.

**Description:**

Adds better error handling for the GCP DDNS script.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** OpenWrt 25.12.2 r32802-f505120278 / LuCI (HEAD detached at 067535e) branch 26.082.75780~067535e
- **OpenWrt Target/Subtarget:** mvebu/cortexa9
- **OpenWrt Device:** Linksys WRT3200ACM

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

N/A