### PR TITLE
ip-timezone: add new package

### DIFF
--- a/utils/ip-timezone/Makefile
+++ b/utils/ip-timezone/Makefile
@@ -1,0 +1,46 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=ip-timezone
+PKG_VERSION:=1.0.0
+PKG_RELEASE:=1
+
+PKG_MAINTAINER:=Renn Akaza <openwrt.org-ip-timezone@akaza.ren>
+PKG_LICENSE:=GPL-3.0-or-later
+PKG_LICENSE_FILES:=LICENSE
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/ip-timezone
+	SECTION:=utils
+	CATEGORY:=Utilities
+	TITLE:=Auto set timezone by IP
+	PKGARCH:=all
+	DEPENDS:=+zoneinfo-all
+endef
+
+define Package/ip-timezone/description
+Hotplug script to ipmatically configure the timezone UCI settings based on the IP address.
+
+The user needs to set their own endpoint to get the IANA timezone string, e.g.:
+	uci set ip-timezone.config.endpoint="https://domain.tld/timezone"
+	uci commit ip-timezone
+
+The endpoint is expected to respond GET requests by a plaintext one-line IANA timezone string, e.g. "Europe/London".
+The endpoint can be verified by directly accessing the its URL from a browser by the address bar.
+endef
+
+define Build/Compile
+endef
+
+define Package/collectd/conffiles
+/etc/config/ip-timezone
+endef
+
+define Package/ip-timezone/install
+	$(INSTALL_DIR) $(1)/etc/hotplug.d/iface/
+	$(INSTALL_DATA) ./files/99-ip-timezone $(1)/etc/hotplug.d/iface/
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_CONF) ./files/ip-timezone.config $(1)/etc/config/ip-timezone
+endef
+
+$(eval $(call BuildPackage,ip-timezone))

--- a/utils/ip-timezone/files/99-ip-timezone
+++ b/utils/ip-timezone/files/99-ip-timezone
@@ -1,0 +1,94 @@
+#!/bin/sh
+
+if [ "${INTERFACE}" = "loopback" ]; then
+    exit 0
+fi
+if [ "${ACTION}" != "ifup" ] && [ "${ACTION}" != "ifupdate" ]; then
+    exit 0
+fi
+if [ "${ACTION}" = "ifupdate" ] && [ -z "${IFUPDATE_ADDRESSES}" ] && [ -z "${IFUPDATE_DATA}" ]; then
+    exit 0
+fi
+
+log() {
+    logger -t "ip-timezone" "$@"
+}
+
+log_info() {
+    log -p user.info "$*"
+}
+
+log_error() {
+    log -p user.err "$*"
+}
+
+get_posix_timezone() {
+    iana_timezone=$1
+    tail -n1 /usr/share/zoneinfo/${iana_timezone}
+}
+
+get_country_code() {
+    iana_timezone=$1
+    awk -F '\t' -v tz="${iana_timezone}" '$3 == tz { print $1; exit }' /usr/share/zoneinfo/zone.tab
+}
+
+update_wifi_country() {
+    iana_timezone=$1
+    country_code="$(get_country_code "${iana_timezone}")"
+    if [ -z "${country_code}" ]; then
+        log_error "Invalid timezone"
+        return 1
+    fi
+
+    wifi_country_updated=0
+    for device in $(uci show wireless | grep "=wifi-device" | cut -d= -f1); do
+        # Only update when 1. config entry exists 2. country code is different
+        current_country="$(uci -q get "${device}.country")"
+        if [ $? -eq 0 ] && [ "${current_country}" != "${country_code}" ]; then
+            log_info "Updating wifi country code for ${device} to ${country_code}"
+            uci set "${device}.country=${country_code}"
+            wifi_country_updated=1
+        fi
+    done
+
+    if [ "${wifi_country_updated}" -eq 1 ]; then
+        uci commit wireless
+        wifi reload
+    fi
+}
+
+endpoint="$(uci -q get ip-timezone.config.endpoint)"
+if [ $? -ne 0 ]; then
+    log_error "Endpoint not set"
+    exit 1
+fi
+
+for i in {1..5}; do
+    timezone_iana="$(wget --timeout=5 -qO- "${endpoint}")" && break || sleep 1
+done
+
+if [ -z "${timezone_iana}" ]; then
+    log_error "Failed to get timezone"
+    exit 1
+fi
+
+timezone_posix="$(get_posix_timezone "${timezone_iana}")"
+if [ -z "${timezone_posix}" ]; then
+    log_error "Invalid timezone"
+    exit 1
+fi
+
+if [ "${timezone_iana}" != "$(uci -q get system.@system[0].zonename)" ] || [ "${timezone_posix}" != "$(uci -q get system.@system[0].timezone)" ]; then
+    log_info "Updating timezone, IANA: ${timezone_iana}, POSIX: ${timezone_posix}"
+    uci set system.@system[0].zonename="${timezone_iana}"
+    uci set system.@system[0].timezone="${timezone_posix}"
+    uci commit system
+    /etc/init.d/system reload
+    /etc/init.d/cron restart
+else
+    exit 0
+fi
+
+if [ "$(uci -q get ip-timezone.config.update_wifi_country)" != "0" ]; then
+    update_wifi_country "${timezone_iana}"
+fi

--- a/utils/ip-timezone/files/ip-timezone.config
+++ b/utils/ip-timezone/files/ip-timezone.config
@@ -1,0 +1,3 @@
+config ip-timezone 'config'
+    option endpoint 'https://example.com/timezone'
+    option update_wifi_country '0'


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** none, new package

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->
A hotplug script to auto set the timezone based on the IP address. It doesn't bring the endpoint by default to avoid promoting any service, so the user will need to set their own at `ip-timezone.config.endpoint`. Triggered once when the device is online.

I tested with `https://ipinfo.io/timezone`. It works on both rebooting and restarting the interface.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12.2
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** OpenWrt One

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
