### PR TITLE
podman: update to 5.8.2

### DIFF
--- a/utils/podman/Makefile
+++ b/utils/podman/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=podman
-PKG_VERSION:=5.8.1
+PKG_VERSION:=5.8.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/containers/podman/archive/v$(PKG_VERSION)
-PKG_HASH:=b9540ecb19cfcbcfc40e1b81d39930f688c537d8fd6f11ae56be41f2bf9e97a4
+PKG_HASH:=b20ea65afc5a58ea1cea019bd51a5d84eb9042d25d3eb82c55010c8815732d84
 
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
- adjust Makefile

## 📦 Package Details

**Maintainer:** Oskari Rauta [oskari.rauta@gmail.com](mailto:oskari.rauta@gmail.com)

**Description:** Update Podman to the latest v5.8.2
<!-- Briefly describe what this package does or what changes are introduced -->

---

## 🧪 Run Testing Details

- **OpenWrt Version:** OpenWrt 25.12-SNAPSHOT
- **OpenWrt Target/Subtarget:** X86-64
- **OpenWrt Device:** CncTion Tiger Lake-6L

---

## ✅ Formalities

- [ √ ] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
