### PR TITLE
domoticz: disable LTO (for breaking the build)

### DIFF
--- a/utils/domoticz/Makefile
+++ b/utils/domoticz/Makefile
@@ -21,7 +21,7 @@ PKG_LICENSE_FILES:=License.txt
 PKG_CPE_ID:=cpe:/a:domoticz:domoticz
 
 PKG_BUILD_DEPENDS:=python3 minizip cereal boost jwt-cpp
-PKG_BUILD_FLAGS:=no-mips16 lto
+PKG_BUILD_FLAGS:=no-mips16
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk


### PR DESCRIPTION


## 📦 Package Details

**Maintainer:** @dwmw2 

**Description:**
Sometime in Dec 2025, domoticz's package started to fail to build after a dependency update.  The root of the problem is LTO, seemingly in combination with usage of -D_FORTIFY_SOURCE=1. LTO doesn't seem to be actively tested in domoticz's development anymore, so it is probably best to disable it. (Unless someone else has a better suggestion!) 
See https://github.com/openwrt/packages/issues/29004

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12.2
- **OpenWrt Target/Subtarget:** ipq40xx/chromium
- **OpenWrt Device:** Google Wifi (gale) 
(Compiled into an image and run on a device, and checked for basic functionality.)

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.