### PR TITLE
python-zope-event: fix build with setuptools >= 81

### DIFF
--- a/lang/python/python-zope-event/patches/001-relax-setuptools-version.patch
+++ b/lang/python/python-zope-event/patches/001-relax-setuptools-version.patch
@@ -1,0 +1,11 @@
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -3,7 +3,7 @@
+ 
+ [build-system]
+ requires = [
+-    "setuptools >= 78.1.1,< 81",
++    "setuptools >= 78.1.1",
+     "wheel",
+ ]
+ build-backend = "setuptools.build_meta"

--- a/lang/python/python-zope-event/test.sh
+++ b/lang/python/python-zope-event/test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+[ "$1" = python3-zope-event ] || exit 0
+
+python3 - << 'PYEOF'
+# Verify core API: subscribers list and notify function
+import zope.event
+assert hasattr(zope.event, 'subscribers'), "missing subscribers list"
+assert callable(zope.event.notify), "missing notify()"
+
+# Exercise notify: register a subscriber and fire an event
+received = []
+zope.event.subscribers.append(received.append)
+zope.event.notify("test-event")
+assert received == ["test-event"], f"event not received: {received!r}"
+
+print("python3-zope-event OK")
+PYEOF


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me


**Description:**

The pyproject.toml for zope.event 6.1 specifies a strict build dependency of setuptools>=78.1.1,<81. We currently package setuptools>=81, causing pip to report a missing dependency and fail the build.

Add patch 001-relax-setuptools-version.patch to drop the <81 upper bound, allowing the package to build with any recent setuptools.

Add test.sh to verify the installed version and exercise the core event API (subscribers list, notify(), event dispatch).

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
