### PR TITLE
prometheus-node-exporter-lua: expose node_os_info

### DIFF
--- a/utils/prometheus-node-exporter-lua/Makefile
+++ b/utils/prometheus-node-exporter-lua/Makefile
@@ -4,7 +4,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=prometheus-node-exporter-lua
-PKG_VERSION:=2026.05.08
+PKG_VERSION:=2026.05.09
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Etienne CHAMPETIER <champetier.etienne@gmail.com>

--- a/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/openwrt.lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/openwrt.lua
@@ -12,13 +12,22 @@ local labels = {
     target = b.release.target
 }
 
+local os_info = {
+    id = string.lower(b.release.distribution),
+    name = b.release.distribution,
+    pretty_name = b.release.distribution .. " " .. b.release.version,
+    version = b.release.version,
+    version_id = b.release.version,
+    build_id = b.release.revision,
+}
+
 local b = nil
 local u = nil
 local ubus = nil
 
 local function scrape()
     metric("node_openwrt_info", "gauge", labels, 1)
+    metric("node_os_info", "gauge", os_info, 1)
 end
 
 return { scrape = scrape }
-


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @champtar

**Description:**
the original node_exporter exposes a node_os_info metric with a set of data about the system [1] which is then used by several dashboards.

openwrt.lua already exposes OS info, but using the node_openwrt_info metric requires changes to existing dashboards, and would require more complex lookups when there are non-OpenWrt hosts in the overview too.

as we've already called ubus and fetched the data, we can expose it in two formats easily.

[1] https://github.com/prometheus/node_exporter/blob/d6d0e710bb7daf07a2743fde060f0d5f32c565f3/collector/os_release.go#L190-L192

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12.2
- **OpenWrt Target/Subtarget:** bcm27xx/bcm2711
- **OpenWrt Device:** Raspberry Pi Compute Module 4 Rev 1.0

But should work everywhere else too, that's just the env I tested the change in :)

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
