### PR TITLE
[25.12] lpac update to 2.3.0

### DIFF
--- a/utils/lpac/Config.in
+++ b/utils/lpac/Config.in
@@ -3,7 +3,7 @@ menu "Configuration"
 
 config LPAC_WITH_PCSC
 	bool "Include APDU PCSC Backend support"
-	default n
+	default y
 	help
 	  Compile LPAC with APDU PCSC Backend support.
 

--- a/utils/lpac/Config.in
+++ b/utils/lpac/Config.in
@@ -1,5 +1,4 @@
 menu "Configuration"
-	depends on PACKAGE_lpac
 
 config LPAC_WITH_PCSC
 	bool "Include APDU PCSC Backend support"

--- a/utils/lpac/Makefile
+++ b/utils/lpac/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lpac
-PKG_VERSION:=2.2.1
-PKG_RELEASE:=2
+PKG_VERSION:=2.3.0
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/estkme-group/lpac/tar.gz/refs/tags/v$(PKG_VERSION)?
-PKG_HASH:=3d87080a625b10430eebb82f89e2d24e16a84a8435a9c40b3718fd88c82028ba
+PKG_HASH:=661dffbd1e9e5732dab4a0bb0a9837d4906c8c66bd748bda262fe3e8d3e420f6
 
 PKG_MAINTAINER:=David Bauer <david.bauer@uniberg.com>
 PKG_LICENSE:=AGPL-3.0-only LGPL-2.0-only
@@ -23,10 +23,11 @@ define Package/lpac
   CATEGORY:=Utilities
   TITLE:=eUICC eSIM LPA written in C
   DEPENDS:= \
+    +libcurl \
     +LPAC_WITH_PCSC:libpcsclite \
     +LPAC_WITH_PCSC:pcscd \
     +LPAC_WITH_MBIM:libmbim \
-    +libcurl
+    +LPAC_WITH_UQMI:uqmi
   URL:=https://github.com/estkme-group/lpac
 endef
 

--- a/utils/lpac/files/lpac.sh
+++ b/utils/lpac/files/lpac.sh
@@ -23,18 +23,18 @@ fi
 if [ "$APDU_BACKEND" = "at" ]; then
     AT_DEVICE="$(uci_get lpac at device /dev/ttyUSB2)"
     AT_DEBUG="$(uci_get lpac at debug 0)"
-    export AT_DEVICE="$AT_DEVICE"
-    export AT_DEBUG="$AT_DEBUG"
+    export LPAC_APDU_AT_DEVICE="$AT_DEVICE"
+    export LPAC_APDU_AT_DEBUG="$AT_DEBUG"
 elif [ "$APDU_BACKEND" = "uqmi" ]; then
     UQMI_DEV="$(uci_get lpac uqmi device /dev/cdc-wdm0)"
     UQMI_DEBUG="$(uci_get lpac uqmi debug 0)"
-    export LPAC_QMI_DEV="$UQMI_DEV"
-    export LPAC_QMI_DEBUG="$UQMI_DEBUG"
+    export LPAC_APDU_QMI_DEVICE="$UQMI_DEV"
+    export LPAC_APDU_UQMI_DEBUG="$UQMI_DEBUG"
 elif [ "$APDU_BACKEND" = "mbim" ]; then
     MBIM_DEVICE="$(uci_get lpac mbim device /dev/cdc-wdm0)"
     MBIM_PROXY="$(uci_get lpac mbim proxy 1)"
-    export MBIM_DEVICE="$MBIM_DEVICE"
-    export MBIM_USE_PROXY="$MBIM_PROXY"
+    export LPAC_APDU_MBIM_DEVICE="$MBIM_DEVICE"
+    export LPAC_APDU_MBIM_USE_PROXY="$MBIM_PROXY"
 fi
 
 export LPAC_CUSTOM_ISD_R_AID="$CUSTOM_ISD_R_AID"

--- a/utils/lpac/patches/0001-driver-add-uqmi-backend.patch
+++ b/utils/lpac/patches/0001-driver-add-uqmi-backend.patch
@@ -27,8 +27,8 @@ Signed-off-by: David Bauer <david.bauer@uniberg.com>
 
 --- a/driver/CMakeLists.txt
 +++ b/driver/CMakeLists.txt
-@@ -52,6 +52,9 @@ if(LPAC_WITH_APDU_AT)
-     target_sources(euicc-drivers PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/apdu/at.c)
+@@ -62,6 +62,9 @@ if(LPAC_WITH_APDU_AT_WIN32)
+     )
  endif()
  
 +set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DLPAC_WITH_APDU_UQMI")
@@ -325,19 +325,19 @@ Signed-off-by: David Bauer <david.bauer@uniberg.com>
 +extern const struct euicc_driver driver_apdu_uqmi;
 --- a/driver/driver.c
 +++ b/driver/driver.c
-@@ -26,6 +26,9 @@
+@@ -28,6 +28,9 @@
  #ifdef LPAC_WITH_APDU_AT
- #include "driver/apdu/at.h"
+ #    include "driver/apdu/at.h"
  #endif
 +#ifdef LPAC_WITH_APDU_UQMI
 +#include "driver/apdu/uqmi.h"
 +#endif
  #ifdef LPAC_WITH_HTTP_CURL
- #include "driver/http/curl.h"
+ #    include "driver/http/curl.h"
  #endif
-@@ -51,6 +54,9 @@ static const struct euicc_driver *driver
- #ifdef LPAC_WITH_APDU_AT
-     &driver_apdu_at,
+@@ -59,6 +62,9 @@ static const struct euicc_driver *driver
+ #ifdef LPAC_WITH_APDU_AT_WIN32
+     &driver_apdu_at_win32,
  #endif
 +#ifdef LPAC_WITH_APDU_UQMI
 +    &driver_apdu_uqmi,


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** David Bauer <david.bauer@uniberg.com>

**Description:**
Backported PRs via **cherry-pick**:
- https://github.com/openwrt/packages/pull/29044
- https://github.com/openwrt/packages/pull/29130

Tested on **Huasifei WH3000 Pro**, **T99W175**, **luci-app-epm** and **lpac 2.3.0** and the problem with eSIM iteractions is gone. 
All necessary operations are working: switch profiles, download & purge profiles, restart modem interface via AT command after switching eSIM profile.

Also, have waited some time before making for backporting PRs.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12.2 Stable
- **OpenWrt Target/Subtarget:** Mediatek/flogic
- **OpenWrt Device:** Huasifei WH3000 Pro

---