### PR TITLE
sed: update to v4.10

### DIFF
--- a/utils/sed/Makefile
+++ b/utils/sed/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sed
-PKG_VERSION:=4.9
+PKG_VERSION:=4.10
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNU/sed
-PKG_HASH:=6e226b732e1cd739464ad6862bd1a1aba42d7982922da7a53519631d24975181
+PKG_HASH:=b8e72182b2ec96a3574e2998c47b7aaa64cc20ce000d8e9ac313cc07cecf28c7
 
 PKG_MAINTAINER:=Russell Senior <russell@personaltelco.net>
 PKG_LICENSE:=GPL-3.0-or-later
@@ -43,7 +43,13 @@ endef
 
 CONFIGURE_ARGS += \
 	--disable-acl \
+	--disable-xattr \
 	--without-selinux
+
+define Build/Compile
+	sed -i 's/SUBDIRS = po . gnulib-tests/SUBDIRS = po ./' $(PKG_BUILD_DIR)/Makefile
+	$(call Build/Compile/Default,)
+endef
 
 define Package/sed/install
 	$(INSTALL_DIR) $(1)/usr/libexec


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @RussellSenior 

**Description:**

sed: update to v4.10
    
update to version v4.10, disable building gnulib-tests to avoid compilation errors.
    
Add --disable-xattr to CONFIGURE_ARGS to avoid linking an unneeded dependency.
    
Changes in sed since v4.9, from NEWS:

From NEWS:

** Bug fixes

  sed 's/a/b/g' (and other global substitutions) now works on input
  lines longer than 2GB. Previously, matches beyond the 2^31 byte offset
  would evoke a "panic" (exit 4).
  [bug present since the beginning]

  'sed --follow-symlinks -i' no longer has a TOCTOU race that could let
  an attacker swap a symlink between resolution and open, causing sed to
  read attacker-chosen content and write it to the original target.
  [bug introduced in sed 4.1e]

  sed no longer falsely matches when back-references are combined with
  optional groups (.?) and the $ anchor.  For example, this no longer
  falsely matches the empty string at beginning of line:
    $ echo ab | sed -E 's/^(.?)(.?).?\2\1$/X/'
    Xab
  [bug present since "the beginning"]

  In --posix mode, sed no longer mishandles backslash escapes (\n,
  \t, \a, etc.) after a named character class like [[:alpha:]].
  For example, 's/^A\n[[:alpha:]]\n*/XXX/' would fail to match the
  trailing newline, treating \n as a literal backslash and an 'n'
  rather than a newline.  This happened when an earlier backslash
  escape in the same regex had already been converted, shifting the
  in-place normalization buffer.
  [bug introduced in sed 4.9]

  sed --debug no longer crashes when a label (":") command is compiled
  before the --debug option is processed, e.g., sed -f<(...) --debug.
  [bug introduced in sed 4.7 with --debug]

  sed no longer rejects the documented GNU extension 'a**' (equivalent
  to 'a*') in Basic Regular Expression (BRE) mode.  Previously, this
  worked only with -E (ERE mode), even though grep has always accepted
  it in BRE mode.
  [bug present since "the beginning"]

  sed no longer rejects "\c[" in regular expressions
  [bug present since the beginning]

  'sed --follow-symlinks -i' no longer mishandles an operand that is a
  short symbolic link to a long symbolic link to a file.
  [bug introduced in sed 4.9]

  Fix some some longstanding but unlikely integer overflows.
  Internally, 'sed' now more often prefers signed integer arithmetic,
  which can be checked automatically via 'gcc -fsanitize=undefined'.

** Changes in behavior

  In the default C locale, diagnostics now quote 'like this' (with
  apostrophes) instead of `like this' (with a grave accent and an
  apostrophe).  This tracks the GNU coding standards.

  'sed --posix' now warns about uses of backslashes in the 's' command
  that are handled by GNU sed but are not portable to other
  implementations.

** Build-related

  builds no longer fail on platforms without the <getopt.h> header or
  getopt_long function. 
  [bug introduced in sed 4.9]

---

## 🧪 Run Testing Details

- **OpenWrt Version:** Snapshot
- **OpenWrt Target/Subtarget:** airoha
- **OpenWrt Device:** gemtek,w1700k-ubi

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [x] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
