### PR TITLE
zoneinfo: updated to 2026b release

### DIFF
--- a/utils/zoneinfo/Makefile
+++ b/utils/zoneinfo/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zoneinfo
-PKG_VERSION:=2026a
+PKG_VERSION:=2026b
 PKG_RELEASE:=1
 
 #As i couldn't find real license used "Public Domain"
@@ -19,14 +19,14 @@ PKG_LICENSE:=Public-Domain
 PKG_SOURCE:=tzdata$(PKG_VERSION).tar.gz
 PKG_SOURCE_CODE:=tzcode$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.iana.org/time-zones/repository/releases
-PKG_HASH:=77b541725937bb53bd92bd484c0b43bec8545e2d3431ee01f04ef8f2203ba2b7
+PKG_HASH:=114543d9f19a6bfeb5bca43686aea173d38755a3db1f2eec112647ae92c6f544
 
 include $(INCLUDE_DIR)/package.mk
 
 define Download/tzcode
    FILE=$(PKG_SOURCE_CODE)
    URL=$(PKG_SOURCE_URL)
-   HASH:=f80a17a2eddd2b54041f9c98d75b0aa8038b016d7c5de72892a146d9938740e1
+   HASH:=37e9ed8427f5d3521c22fc58e293cbfb043d70eedf1003870b33f363f61ca344
 endef
 
 $(eval $(call Download,tzcode))


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me

**Description:**

  Briefly:

     British Columbia moved to permanent -07 on 2026-03-09.
     Some more overflow bugs have been fixed in zic.

   Changes to future timestamps

     British Columbia’s 2026-03-08 spring forward was its last
     foreseeable clock change, as it moved to permanent -07 thereafter.
     (Thanks to Arthur David Olson.)  Although the change to permanent
     -07 legally took place on 2026-03-09, temporarily model the change
     to occur on 2026-11-01 at 02:00 instead.  This works around a
     limitation in CLDR v48.2 (2026-03-17).  This temporary hack is
     planned to be removed after CLDR is fixed.

   Changes to code

     zic no longer mishandles a last transition to a new time type.

     zic no longer overflows a buffer when generating a TZ string like
     "PST-167:59:58PDT-167:59:59,M11.5.6/-167:59:59,M12.5.6/-167:59:59",
     which can occur with adversarial input.  (Thanks to Naveed Khan.)

     zic no longer generates a longer TZif file than necessary when
     an earlier time zone abbreviation is a suffix of a later one.
     As a nice side effect, zic no longer overflows a buffer when given
     a long series of abbreviations, each a suffix of the next.
     (Buffer overflow reported by Arthur Chan.)

     zic no longer overflows an int when processing input like ‘Zone
     Ouch 2147483648:00:00 - LMT’.  The int overflow can lead to buffer
     overflow in adversarial cases.  (Thanks to Naveed Khan.)

     zic now checks for signals more often.
---

## 🧪 Run Testing Details

- **OpenWrt Version:** OpenWRT master
- **OpenWrt Target/Subtarget:**  TI OMAP3/4/AM33xx, default
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.