### PR TITLE
adguardhome: add enabled option

### DIFF
--- a/net/adguardhome/files/adguardhome.init
+++ b/net/adguardhome/files/adguardhome.init
@@ -27,9 +27,10 @@ start_service() {
 
 	local config_name='config'
 	local config_file config group user verbose work_dir workdir
-	local gc maxprocs memlimit
+	local enabled gc maxprocs memlimit
 
 	uci_validate_section 'adguardhome' 'adguardhome' "$config_name" \
+		'enabled:bool:0' \
 		'gc:uinteger:0' \
 		'group:string:adguardhome' \
 		'config:string' \
@@ -42,6 +43,8 @@ start_service() {
 		'verbose:bool:0' \
 		'workdir:string' \
 		'work_dir:string:/var/lib/adguardhome'
+
+	[ "$enabled" -eq "1" ] || return 1
 
 	# Compatibility with older configs
 	[ -n "$config" ] && config_file="$config"


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @GeorgeSapkin
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->
adguardhome: add enabled option

Related PR: https://github.com/openwrt/luci/pull/8590

---

## 🧪 Run Testing Details

- **OpenWrt Version:** OpenWrt 25.12
- **OpenWrt Target/Subtarget:** X86/64
- **OpenWrt Device:** QEUM

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [X] It can be applied using `git am`
- [X] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [X] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
