### PR TITLE
glib2: split package into separate libraries (V2)

### DIFF
--- a/libs/glib2/Makefile
+++ b/libs/glib2/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=glib2
 PKG_VERSION:=2.82.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=glib-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNOME/glib/$(basename $(PKG_VERSION))
@@ -33,12 +33,66 @@ include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
 include $(INCLUDE_DIR)/meson.mk
 
-define Package/glib2
+define Package/glib2/default
   SECTION:=libs
   CATEGORY:=Libraries
-  DEPENDS:=$(ICONV_DEPENDS) $(INTL_DEPENDS) +zlib +libpthread +libffi +libattr +libpcre2
-  TITLE:=glib 2.0
   URL:=http://www.gtk.org/
+endef
+
+define Package/glib2-core
+$(call Package/glib2/default)
+  TITLE:=GLib 2.0 core library
+  DEPENDS:=$(ICONV_DEPENDS) $(INTL_DEPENDS) +libattr +libpcre2
+endef
+
+define Package/glib2-gmodule
+$(call Package/glib2/default)
+  TITLE:=GLib 2.0 gmodule library
+  DEPENDS:=+glib2-core
+endef
+
+define Package/glib2-gthread
+$(call Package/glib2/default)
+  TITLE:=GLib 2.0 gthread library
+  DEPENDS:=+glib2-core
+endef
+
+define Package/glib2-gobject
+$(call Package/glib2/default)
+  TITLE:=GLib 2.0 gobject library
+  DEPENDS:=+glib2-core +libffi
+endef
+
+define Package/glib2-gio
+$(call Package/glib2/default)
+  TITLE:=GLib 2.0 gio library
+  DEPENDS:=+glib2-core +glib2-gobject +glib2-gmodule +zlib +libffi
+endef
+
+define Package/glib2
+$(call Package/glib2/default)
+  TITLE:=Full GLib 2.0 library
+  DEPENDS:=+glib2-gthread +glib2-gio
+endef
+
+define Package/glib2-core/description
+  Common code and core library for GLib library of C routines
+endef
+
+define Package/glib2-gmodule/description
+  GLib library module functions
+endef
+
+define Package/glib2-gthread/description
+  GLib library thread functions
+endef
+
+define Package/glib2-gobject/description
+  GLib library object functions
+endef
+
+define Package/glib2-gio/description
+  GLib library io functions
 endef
 
 define Package/glib2/description
@@ -122,12 +176,44 @@ define Build/InstallDev
 		$(1)/usr/share/glib-2.0/
 endef
 
-define Package/glib2/install
+define Package/glib2-core/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) \
-		$(PKG_INSTALL_DIR)/usr/lib/*.so* \
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libglib-2.0.so* \
 		$(1)/usr/lib/
 endef
 
+define Package/glib2-gmodule/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgmodule-2.0.so* \
+		$(1)/usr/lib
+endef
+
+define Package/glib2-gthread/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgthread-2.0.so* \
+		$(1)/usr/lib
+endef
+
+define Package/glib2-gobject/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgobject-2.0.so* \
+		$(1)/usr/lib
+endef
+
+define Package/glib2-gio/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgio-2.0.so* \
+		$(1)/usr/lib
+endef
+
+define Package/glib2/install
+	:
+endef
+
 $(eval $(call HostBuild))
+$(eval $(call BuildPackage,glib2-core))
+$(eval $(call BuildPackage,glib2-gmodule))
+$(eval $(call BuildPackage,glib2-gthread))
+$(eval $(call BuildPackage,glib2-gobject))
+$(eval $(call BuildPackage,glib2-gio))
 $(eval $(call BuildPackage,glib2))


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @tripolar 

**Description:**

The original split commit (6bb0d6bd2) had a typo: the glib2 meta-package used 'DEPENDS:+glib2-gthread +glib2-gio' (missing '='), which caused the meta-package to have no effective dependencies. This meant packages declaring '+glib2' did not get the sub-packages installed, causing build failures.

This re-applies the split with 'DEPENDS:=+glib2-gthread +glib2-gio', after the revert in commit 9e3d09838

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
