### PR TITLE
coredns: fix netlink compat for wgsd plugin

### DIFF
--- a/net/coredns/Makefile
+++ b/net/coredns/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=coredns
 PKG_VERSION:=1.14.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/coredns/coredns.git
@@ -93,6 +93,15 @@ ifeq ($(CONFIG_COREDNS_REQUIRE_GO_GET),y)
 	$(GO_PKG_BUILD_CONFIG_VARS) \
 	$(GO_PKG_VARS) \
 	go get ./...
+endif
+ifeq ($(CONFIG_COREDNS_PLUGIN_WGSD),y)
+	# wgsd -> wgctrl -> genetlink -> netlink v1.6.2 is incompatible with
+	# socket v0.5.x (Sendmsg/Recvmsg gained context.Context); pin to v1.7.2
+	cd $(PKG_BUILD_DIR); \
+	$(GO_GENERAL_BUILD_CONFIG_VARS) \
+	$(GO_PKG_BUILD_CONFIG_VARS) \
+	$(GO_PKG_VARS) \
+	go get github.com/mdlayher/netlink@v1.7.2
 endif
 
 endef


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @vooon 

**Description:**

wgsd (WireGuard Service Discovery plugin) pulls in golang.zx2c4.com/wireguard/wgctrl -> mdlayher/genetlink v1.2.0 -> mdlayher/netlink v1.6.2. This version of netlink calls mdlayher/socket's Sendmsg/Recvmsg with the old API signatures (pre-context.Context, single-return-value Sendmsg), but coredns itself requires mdlayher/socket v0.5.1 which changed these signatures to include context.Context and return (int, error).

Add a go get step that upgrades netlink to v1.7.2 after the wgsd plugin dependencies are pulled in, ensuring the build uses a netlink version compatible with socket v0.5.x.


Should fix:
      https://downloads.openwrt.org/snapshots/faillogs/i386_pentium-mmx/packages/coredns/compile.txt
    
  ```
    ../../../../../dl/go-mod-cache/github.com/mdlayher/netlink@v1.6.2/conn_linux.go:105:9: too many return values
            have (int, error)
            want (error)
    ../../../../../dl/go-mod-cache/github.com/mdlayher/netlink@v1.6.2/conn_linux.go:105:35: not enough arguments in call to c.s.Sendmsg
            have ([]byte, nil, *"golang.org/x/sys/unix".SockaddrNetlink, number)
            want (context.Context, []byte, []byte, "golang.org/x/sys/unix".Sockaddr, int)
    ../../../../../dl/go-mod-cache/github.com/mdlayher/netlink@v1.6.2/conn_linux.go:116:9: too many return values
            have (int, error)
            want (error)
    ../../../../../dl/go-mod-cache/github.com/mdlayher/netlink@v1.6.2/conn_linux.go:116:33: not enough arguments in call to c.s.Sendmsg
            have ([]byte, nil, *"golang.org/x/sys/unix".SockaddrNetlink, number)
            want (context.Context, []byte, []byte, "golang.org/x/sys/unix".Sockaddr, int)
    ../../../../../dl/go-mod-cache/github.com/mdlayher/netlink@v1.6.2/conn_linux.go:127:42: not enough arguments in call to c.s.Recvmsg
            have ([]byte, nil, number)
            want (context.Context, []byte, []byte, int)
    ../../../../../dl/go-mod-cache/github.com/mdlayher/netlink@v1.6.2/conn_linux.go:142:41: not enough arguments in call to c.s.Recvmsg
            have ([]byte, nil, number)
            want (context.Context, []byte, []byte, int)
    github.com/aws/aws-sdk-go-v2/aws/protocol/query
    github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding
    github.com/aws/smithy-go/private/requestcompression
```


---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
