### PR TITLE
prosody: fix PKG_HASH for 0.12.4

### DIFF
--- a/net/prosody/Makefile
+++ b/net/prosody/Makefile
@@ -13,7 +13,7 @@ PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://prosody.im/downloads/source
-PKG_HASH:=1dc0c3dcebdf26e579aff3c320d72e93495e295b832dd37163447d8a71c34ff1
+PKG_HASH:=47d712273c2f29558c412f6cdaec073260bbc26b7dda243db580330183d65856
 
 PKG_MAINTAINER:=Thomas Heil <heil@terminal-consulting.de>
 PKG_LICENSE:=MIT/X11


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:**

**Description:**

The prosody.im upstream updated the 0.12.4 tarball in-place, changing its content without bumping the version. Update PKG_HASH to match the currently published tarball.

Fixes: f4d305b73 ("prosody: update to 0.12.4")

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [ ] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
