### PR TITLE
Add corosync qdevice

### DIFF
--- a/libs/libqb/Makefile
+++ b/libs/libqb/Makefile
@@ -1,0 +1,51 @@
+# Copyright (C) 2025-2026 S Shaikh <sshaikh@hotmail.com>
+# Copyright (C) 2026 Sven Kirmess <sven.kirmess@kzone.ch>
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=libqb
+PKG_VERSION:=2.0.10
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
+PKG_SOURCE_URL:=https://github.com/ClusterLabs/libqb/releases/download/v$(PKG_VERSION)/
+PKG_HASH:=326a69fb5b2ee4479f0db4f98d10d670ad0798b5ded8c4cfd585b765fd8941e8
+PKG_FIXUP:=autoreconf
+PKG_INSTALL:=1
+
+PKG_MAINTAINER:=S Shaikh <sshaikh@hotmail.com>, Sven Kirmess <sven.kirmess@kzone.ch>
+PKG_LICENSE:=LGPL-2.1-or-later
+PKG_LICENSE_FILES:=COPYING
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/libqb
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=High performance client server reusable library
+  URL:=https://github.com/ClusterLabs/libqb
+endef
+
+define Package/libqb/description
+  libqb provides high-performance, reusable features for client/server
+  architecture, including IPC, logging, and ringbuffer. Used by Corosync
+  and other cluster software.
+endef
+
+CONFIGURE_ARGS += --disable-man
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include/qb
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/include/qb/* $(1)/usr/include/qb
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/lib*.so* $(1)/usr/lib/
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/*.pc $(1)/usr/lib/pkgconfig
+endef
+
+define Package/libqb/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/lib*.so.* $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,libqb))

--- a/libs/libqb/test-version.sh
+++ b/libs/libqb/test-version.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# shellcheck shell=busybox
+
+case "$PKG_NAME" in
+libqb)
+	# Shared libraries, no executable to check
+	exit 0
+	;;
+
+*)
+	echo "Untested package: $PKG_NAME" >&2
+	exit 1
+	;;
+esac

--- a/net/corosync-qdevice/Makefile
+++ b/net/corosync-qdevice/Makefile
@@ -1,0 +1,66 @@
+# Copyright (C) 2025-2026 S Shaikh <sshaikh@hotmail.com>
+# Copyright (C) 2026 Sven Kirmess <sven.kirmess@kzone.ch>
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=corosync-qdevice
+PKG_VERSION:=3.0.4
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://github.com/corosync/corosync-qdevice/releases/download/v$(PKG_VERSION)/
+PKG_HASH:=c2821329ed1efd6bf8f82e2878f75ca66889439d27c788785fd0ccc972ac307c
+PKG_FIXUP:=autoreconf
+PKG_INSTALL:=1
+
+PKG_MAINTAINER:=S Shaikh <sshaikh@hotmail.com>, Sven Kirmess <sven.kirmess@kzone.ch>
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=LICENSE
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/corosync-qdevice
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=Corosync QNetd - quorum device daemon
+  URL:=https://github.com/corosync/corosync-qdevice
+  DEPENDS:=+libcorosync +libnss +nss-utils +bash
+endef
+
+define Package/corosync-qdevice/description
+  corosync-qnetd daemon providing an additional vote to Corosync/Proxmox
+  clusters, allowing a 2-node cluster to maintain quorum when one node fails.
+
+  NOTE: Proxmox VE users need openssh-sftp-server installed on this
+  OpenWrt device before running 'pvecm qdevice setup' on the Proxmox node.
+  It can be removed afterwards.
+endef
+
+CONFIGURE_ARGS += \
+  --with-bash=/bin/bash \
+  --disable-qdevices
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/share/pkgconfig
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/share/pkgconfig/corosync-qdevice.pc $(1)/usr/share/pkgconfig
+endef
+
+define Package/corosync-qdevice/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/corosync-qnetd $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/corosync-qnetd-tool $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/corosync-qnetd-certutil $(1)/usr/bin/
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/corosync-qdevice.init $(1)/etc/init.d/corosync-qdevice
+	$(INSTALL_DIR) $(1)/etc/uci-defaults
+	$(INSTALL_DATA) ./files/corosync-qdevice.uci-defaults $(1)/etc/uci-defaults/corosync-qdevice
+endef
+
+define Package/corosync-qdevice/postinst
+#!/bin/sh
+if [ -z "$${IPKG_INSTROOT}" ] && [ ! -f "/etc/corosync/qnetd/nssdb/cert9.db" ]; then
+	/usr/bin/corosync-qnetd-certutil -i || true
+fi
+endef
+
+$(eval $(call BuildPackage,corosync-qdevice))

--- a/net/corosync-qdevice/files/corosync-qdevice.init
+++ b/net/corosync-qdevice/files/corosync-qdevice.init
@@ -1,0 +1,12 @@
+#!/bin/sh /etc/rc.common
+
+START=99
+STOP=99
+USE_PROCD=1
+
+start_service() {
+	procd_open_instance
+	procd_set_param command /usr/bin/corosync-qnetd -f
+	procd_set_param respawn
+	procd_close_instance
+}

--- a/net/corosync-qdevice/files/corosync-qdevice.uci-defaults
+++ b/net/corosync-qdevice/files/corosync-qdevice.uci-defaults
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+[ -f /etc/corosync/qnetd/nssdb/cert9.db ] || /usr/bin/corosync-qnetd-certutil -i
+
+exit 0

--- a/net/corosync-qdevice/patches/0001-configure-add-with-bash-option.patch
+++ b/net/corosync-qdevice/patches/0001-configure-add-with-bash-option.patch
@@ -1,0 +1,36 @@
+From 9946ee9e065dbcaddc3b5a0b33859a25569b1526 Mon Sep 17 00:00:00 2001
+From: Sven Kirmess <sven.kirmess@kzone.ch>
+Date: Fri, 8 May 2026 10:17:15 +0200
+Subject: [PATCH] configure: add --with-bash option
+
+... for cross-compilation
+
+AC_PATH_PROG finds bash on the build host, which differs from the
+target system path in cross-compilation environments. Add
+--with-bash=PATH to allow explicitly specifying the bash path on
+the target system.
+
+When not specified, the existing auto-detection behaviour is
+unchanged.
+
+Signed-off-by: Sven Kirmess <sven.kirmess@kzone.ch>
+Reviewed-by: Jan Friesse <jfriesse@redhat.com>
+---
+ configure.ac | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+--- a/configure.ac
++++ b/configure.ac
+@@ -79,7 +79,11 @@ AC_PROG_LN_S
+ AC_PROG_INSTALL
+ AC_PROG_MAKE_SET
+ PKG_PROG_PKG_CONFIG
+-AC_PATH_PROG([BASHPATH], [bash])
++AC_ARG_WITH([bash],
++  [AS_HELP_STRING([--with-bash=PATH],
++    [path to bash on the target system @<:@default=auto-detect@:>@])],
++  [BASHPATH="$withval"],
++  [AC_PATH_PROG([BASHPATH], [bash])])
+ AC_CHECK_PROGS([GROFF], [groff])
+ 
+ # Checks for typedefs.

--- a/net/corosync-qdevice/patches/0002-initialize-ca.patch
+++ b/net/corosync-qdevice/patches/0002-initialize-ca.patch
@@ -1,0 +1,39 @@
+From 2d1989d27da618a40e6340c7c9ffe8708f1cc067 Mon Sep 17 00:00:00 2001
+From: Sven Kirmess <sven.kirmess@kzone.ch>
+Date: Fri, 8 May 2026 00:00:00 +0200
+Subject: [PATCH] fix CA initialization for musl/busybox compatibility
+
+- chown --reference=: GNU coreutils only, not available in Busybox; the
+  target directory is always owned by root on OpenWrt, so this is a no-op
+- ps -elf / w: GNU ps flags and the w command are not available on
+  Busybox/OpenWrt; seed the noise file from /dev/urandom instead
+- sha1sum: not compiled into Busybox by default; use sha256sum which is
+  available in Busybox by default instead
+
+Signed-off-by: Sven Kirmess <sven.kirmess@kzone.ch>
+---
+ qdevices/corosync-qnetd-certutil.sh | 6 ++----
+ 1 file changed, 2 insertions(+), 4 deletions(-)
+
+--- a/qdevices/corosync-qnetd-certutil.sh
++++ b/qdevices/corosync-qnetd-certutil.sh
+@@ -62,9 +62,7 @@ usage() {
+ }
+ 
+ chown_ref_cfgdir() {
+-    if [ "$UID" == "0" ];then
+-        chown --reference="$CONFIG_DIR" "$@" 2>/dev/null || chown "$(stat -f "%u:%g" "$CONFIG_DIR")" "$@" 2>/dev/null || return $?
+-    fi
++    : # All files owned by root on OpenWrt, nothing to do
+ }
+ 
+ # get_perm [directory]
+@@ -83,7 +81,7 @@ create_new_noise_file() {
+     if [ ! -e "$noise_file" ];then
+         echo "Creating new noise file $noise_file"
+ 
+-        (ps -elf; date; w) | sha1sum | (read sha_sum rest; echo $sha_sum) > "$noise_file"
++        dd if=/dev/urandom bs=1024 count=1 2>/dev/null | sha256sum | (read sha_sum rest; echo $sha_sum) > "$noise_file"
+ 
+         chown_ref_cfgdir "$noise_file"
+         chmod "$(get_perm)" "$noise_file"

--- a/net/corosync-qdevice/test.sh
+++ b/net/corosync-qdevice/test.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+case "$1" in
+corosync-qdevice)
+	corosync-qnetd -v 2>&1 | grep -F "$2"
+	;;
+esac

--- a/net/corosync/Makefile
+++ b/net/corosync/Makefile
@@ -1,0 +1,74 @@
+# Copyright (C) 2025-2026 S Shaikh <sshaikh@hotmail.com>
+# Copyright (C) 2026 Sven Kirmess <sven.kirmess@kzone.ch>
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=corosync
+PKG_VERSION:=3.1.10
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://github.com/corosync/corosync/releases/download/v$(PKG_VERSION)/
+PKG_HASH:=be361c827f99b215b3bd3fa2fb071c03dac6831c2a351963d938caef62604bc8
+PKG_FIXUP:=autoreconf
+PKG_INSTALL:=1
+
+PKG_MAINTAINER:=S Shaikh <sshaikh@hotmail.com>, Sven Kirmess <sven.kirmess@kzone.ch>
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=LICENSE
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/libcorosync
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=Corosync cluster libraries
+  URL:=https://corosync.github.io/corosync/
+  DEPENDS:=+kronosnet +libqb
+endef
+
+define Package/libcorosync/description
+  Shared libraries for Corosync cluster engine, including libcorosync_common,
+  libcfg, libcmap, libcpg, libquorum, libsam, and libvotequorum.
+endef
+
+define Package/corosync
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=Corosync cluster engine
+  URL:=https://corosync.github.io/corosync/
+  DEPENDS:=+libcorosync
+endef
+
+define Package/corosync/description
+  Corosync cluster engine daemon and management tools, providing reliable
+  messaging, membership, and quorum for high-availability clusters.
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include/corosync
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/include/corosync/* $(1)/usr/include/corosync/
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/lib*.so* $(1)/usr/lib/
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/*.pc $(1)/usr/lib/pkgconfig
+endef
+
+define Package/libcorosync/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/lib*.so.* $(1)/usr/lib/
+endef
+
+define Package/corosync/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/corosync $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/corosync-cfgtool $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/corosync-cmapctl $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/corosync-cpgtool $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/corosync-keygen $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/corosync-notifyd $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/corosync-quorumtool $(1)/usr/sbin/
+endef
+
+$(eval $(call BuildPackage,libcorosync))
+$(eval $(call BuildPackage,corosync))

--- a/net/kronosnet/Makefile
+++ b/net/kronosnet/Makefile
@@ -1,0 +1,226 @@
+# Copyright (C) 2025-2026 S Shaikh <sshaikh@hotmail.com>
+# Copyright (C) 2026 Sven Kirmess <sven.kirmess@kzone.ch>
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=kronosnet
+PKG_VERSION:=1.35
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
+PKG_SOURCE_URL:=https://github.com/kronosnet/kronosnet/releases/download/v$(PKG_VERSION)/
+PKG_HASH:=e980d57a75c9ae9ca4ba2826cd3b02bcbc6463a32aaac0d0ab8eb0b6b5df8d0a
+PKG_FIXUP:=autoreconf
+PKG_INSTALL:=1
+
+PKG_BUILD_DEPENDS:=libqb
+
+PKG_MAINTAINER:=S Shaikh <sshaikh@hotmail.com>, Sven Kirmess <sven.kirmess@kzone.ch>
+PKG_LICENSE:=LGPL-2.1-or-later
+PKG_LICENSE_FILES:=COPYING.libraries
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/kronosnet
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=kronosnet - multipoint-to-multipoint network link aggregation
+  URL:=https://github.com/kronosnet/kronosnet
+  DEPENDS:=+libnl
+endef
+
+define Package/kronosnet/description
+  kronosnet (knet) is a network abstraction layer designed for High
+  Availability use cases. It provides multipoint-to-multipoint communication
+  with link aggregation, redundancy, and optional compression/encryption.
+  Used as the transport layer by Corosync.
+endef
+
+define Package/kronosnet-compress-lz4
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=kronosnet LZ4 compression backend
+  URL:=https://github.com/kronosnet/kronosnet
+  DEPENDS:=+kronosnet +liblz4
+endef
+
+define Package/kronosnet-compress-lz4/description
+  LZ4 compression backend plugin for kronosnet.
+endef
+
+define Package/kronosnet-compress-lz4hc
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=kronosnet LZ4HC compression backend
+  URL:=https://github.com/kronosnet/kronosnet
+  DEPENDS:=+kronosnet +liblz4
+endef
+
+define Package/kronosnet-compress-lz4hc/description
+  LZ4HC compression backend plugin for kronosnet.
+endef
+
+define Package/kronosnet-compress-zlib
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=kronosnet zlib compression backend
+  URL:=https://github.com/kronosnet/kronosnet
+  DEPENDS:=+kronosnet +zlib
+endef
+
+define Package/kronosnet-compress-zlib/description
+  zlib compression backend plugin for kronosnet.
+endef
+
+define Package/kronosnet-compress-lzo2
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=kronosnet LZO compression backend
+  URL:=https://github.com/kronosnet/kronosnet
+  DEPENDS:=+kronosnet +liblzo
+endef
+
+define Package/kronosnet-compress-lzo2/description
+  LZO compression backend plugin for kronosnet.
+endef
+
+define Package/kronosnet-compress-lzma
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=kronosnet LZMA compression backend
+  URL:=https://github.com/kronosnet/kronosnet
+  DEPENDS:=+kronosnet +liblzma
+endef
+
+define Package/kronosnet-compress-lzma/description
+  LZMA compression backend plugin for kronosnet.
+endef
+
+define Package/kronosnet-compress-bzip2
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=kronosnet bzip2 compression backend
+  URL:=https://github.com/kronosnet/kronosnet
+  DEPENDS:=+kronosnet +bzip2
+endef
+
+define Package/kronosnet-compress-bzip2/description
+  bzip2 compression backend plugin for kronosnet.
+endef
+
+define Package/kronosnet-compress-zstd
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=kronosnet Zstandard compression backend
+  URL:=https://github.com/kronosnet/kronosnet
+  DEPENDS:=+kronosnet +libzstd
+endef
+
+define Package/kronosnet-compress-zstd/description
+  Zstandard compression backend plugin for kronosnet.
+endef
+
+define Package/kronosnet-crypto-nss
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=kronosnet NSS crypto backend
+  URL:=https://github.com/kronosnet/kronosnet
+  DEPENDS:=+kronosnet +libnss +nspr
+endef
+
+define Package/kronosnet-crypto-nss/description
+  NSS crypto backend plugin for kronosnet. Required for encrypted
+  Corosync cluster communication using Mozilla NSS.
+endef
+
+define Package/kronosnet-crypto-openssl
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=kronosnet OpenSSL crypto backend
+  URL:=https://github.com/kronosnet/kronosnet
+  DEPENDS:=+kronosnet +libopenssl
+endef
+
+define Package/kronosnet-crypto-openssl/description
+  OpenSSL crypto backend plugin for kronosnet. Required for encrypted
+  Corosync cluster communication using OpenSSL.
+endef
+
+CONFIGURE_ARGS += \
+  --disable-man \
+  --disable-hardening \
+  --disable-wireshark-dissector \
+  --enable-crypto-nss \
+  --enable-crypto-openssl
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include/
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/include/* $(1)/usr/include/
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/lib*.so* $(1)/usr/lib/
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/*.pc $(1)/usr/lib/pkgconfig
+	$(INSTALL_DIR) $(1)/usr/lib/kronosnet
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/kronosnet/*.so* $(1)/usr/lib/kronosnet
+endef
+
+define Package/kronosnet/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/lib*.so.* $(1)/usr/lib/
+endef
+
+define Package/kronosnet-compress-lz4/install
+	$(INSTALL_DIR) $(1)/usr/lib/kronosnet
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/kronosnet/compress_lz4.so $(1)/usr/lib/kronosnet/
+endef
+
+define Package/kronosnet-compress-lz4hc/install
+	$(INSTALL_DIR) $(1)/usr/lib/kronosnet
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/kronosnet/compress_lz4hc.so $(1)/usr/lib/kronosnet/
+endef
+
+define Package/kronosnet-compress-zlib/install
+	$(INSTALL_DIR) $(1)/usr/lib/kronosnet
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/kronosnet/compress_zlib.so $(1)/usr/lib/kronosnet/
+endef
+
+define Package/kronosnet-compress-lzo2/install
+	$(INSTALL_DIR) $(1)/usr/lib/kronosnet
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/kronosnet/compress_lzo2.so $(1)/usr/lib/kronosnet/
+endef
+
+define Package/kronosnet-compress-lzma/install
+	$(INSTALL_DIR) $(1)/usr/lib/kronosnet
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/kronosnet/compress_lzma.so $(1)/usr/lib/kronosnet/
+endef
+
+define Package/kronosnet-compress-bzip2/install
+	$(INSTALL_DIR) $(1)/usr/lib/kronosnet
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/kronosnet/compress_bzip2.so $(1)/usr/lib/kronosnet/
+endef
+
+define Package/kronosnet-compress-zstd/install
+	$(INSTALL_DIR) $(1)/usr/lib/kronosnet
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/kronosnet/compress_zstd.so $(1)/usr/lib/kronosnet/
+endef
+
+define Package/kronosnet-crypto-nss/install
+	$(INSTALL_DIR) $(1)/usr/lib/kronosnet
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/kronosnet/crypto_nss.so $(1)/usr/lib/kronosnet/
+endef
+
+define Package/kronosnet-crypto-openssl/install
+	$(INSTALL_DIR) $(1)/usr/lib/kronosnet
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/kronosnet/crypto_openssl.so $(1)/usr/lib/kronosnet/
+endef
+
+$(eval $(call BuildPackage,kronosnet))
+$(eval $(call BuildPackage,kronosnet-compress-lz4))
+$(eval $(call BuildPackage,kronosnet-compress-lz4hc))
+$(eval $(call BuildPackage,kronosnet-compress-zlib))
+$(eval $(call BuildPackage,kronosnet-compress-lzo2))
+$(eval $(call BuildPackage,kronosnet-compress-lzma))
+$(eval $(call BuildPackage,kronosnet-compress-bzip2))
+$(eval $(call BuildPackage,kronosnet-compress-zstd))
+$(eval $(call BuildPackage,kronosnet-crypto-nss))
+$(eval $(call BuildPackage,kronosnet-crypto-openssl))


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @skirmess, @sshaikh

**Description:**
Adds 4 new packages providing Corosync cluster infrastructure and the
`corosync-qnetd` quorum device daemon. These allow a 2-node Proxmox VE
(or other Corosync-based) cluster to maintain quorum when one node fails.

Packages added (in dependency order):
- `libs/libqb` – high-performance IPC/logging library
- `net/kronosnet` – network transport layer for Corosync (+ crypto subpackages)
- `net/corosync` – cluster engine split into `libcorosync` + `corosync`
- `net/corosync-qdevice` – quorum device daemon (`corosync-qnetd`)

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12.2
- **OpenWrt Target/Subtarget:** ath79/nand
- **OpenWrt Device:** GL.iNet GL-AR300M16 (MIPS 24Kc)

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
