### PR TITLE
unzip: refresh patches

### DIFF
--- a/utils/unzip/patches/0001-fix-heap-based-buffer-overflow-in-the-CRC32-verifica.patch
+++ b/utils/unzip/patches/0001-fix-heap-based-buffer-overflow-in-the-CRC32-verifica.patch
@@ -11,8 +11,6 @@ CVE: CVE-2014-8139
  extract.c | 17 ++++++++++++++---
  1 file changed, 14 insertions(+), 3 deletions(-)
 
-diff --git a/extract.c b/extract.c
-index 1acd769..df0fa1c 100644
 --- a/extract.c
 +++ b/extract.c
 @@ -1,5 +1,5 @@
@@ -31,7 +29,7 @@ index 1acd769..df0fa1c 100644
     static ZCONST char Far InvalidComprDataEAs[] =
       " invalid compressed data for EAs\n";
  #  if (defined(WIN32) && defined(NTSD_EAS))
-@@ -2023,7 +2025,8 @@ static int TestExtraField(__G__ ef, ef_len)
+@@ -2023,7 +2025,8 @@ static int TestExtraField(__G__ ef, ef_l
          ebID = makeword(ef);
          ebLen = (unsigned)makeword(ef+EB_LEN);
  
@@ -41,7 +39,7 @@ index 1acd769..df0fa1c 100644
             /* Discovered some extra field inconsistency! */
              if (uO.qflag)
                  Info(slide, 1, ((char *)slide, "%-22s ",
-@@ -2158,11 +2161,19 @@ static int TestExtraField(__G__ ef, ef_len)
+@@ -2158,11 +2161,19 @@ static int TestExtraField(__G__ ef, ef_l
                  }
                  break;
              case EF_PKVMS:
@@ -62,5 +60,3 @@ index 1acd769..df0fa1c 100644
                  break;
              case EF_PKW32:
              case EF_PKUNIX:
--- 
-

--- a/utils/unzip/patches/0002-fix-heap-based-buffer-overflow-in-the-test_compr_eb-.patch
+++ b/utils/unzip/patches/0002-fix-heap-based-buffer-overflow-in-the-test_compr_eb-.patch
@@ -11,11 +11,9 @@ CVE: CVE-2014-8140
  extract.c | 13 ++++++++++---
  1 file changed, 10 insertions(+), 3 deletions(-)
 
-diff --git a/extract.c b/extract.c
-index df0fa1c..ec31e60 100644
 --- a/extract.c
 +++ b/extract.c
-@@ -2232,10 +2232,17 @@ static int test_compr_eb(__G__ eb, eb_size, compr_offset, test_uc_ebdata)
+@@ -2232,10 +2232,17 @@ static int test_compr_eb(__G__ eb, eb_si
      if (compr_offset < 4)                /* field is not compressed: */
          return PK_OK;                    /* do nothing and signal OK */
  
@@ -36,5 +34,3 @@ index df0fa1c..ec31e60 100644
  
      if (
  #ifdef INT_16BIT
--- 
-

--- a/utils/unzip/patches/0003-fix-heap-based-buffer-overflow-in-the-getZip64Data-f.patch
+++ b/utils/unzip/patches/0003-fix-heap-based-buffer-overflow-in-the-getZip64Data-f.patch
@@ -12,11 +12,9 @@ CVE: CVE-2014-8141
  process.c | 68 +++++++++++++++++++++++++++++++++++++++++--------------
  2 files changed, 59 insertions(+), 18 deletions(-)
 
-diff --git a/fileio.c b/fileio.c
-index ba0a1d0..36bfea3 100644
 --- a/fileio.c
 +++ b/fileio.c
-@@ -176,6 +176,8 @@ static ZCONST char Far FilenameTooLongTrunc[] =
+@@ -176,6 +176,8 @@ static ZCONST char Far FilenameTooLongTr
  #endif
  static ZCONST char Far ExtraFieldTooLong[] =
    "warning:  extra field too long (%d).  Ignoring...\n";
@@ -25,7 +23,7 @@ index ba0a1d0..36bfea3 100644
  
  #ifdef WINDLL
     static ZCONST char Far DiskFullQuery[] =
-@@ -2295,7 +2297,12 @@ int do_string(__G__ length, option)   /* return PK-type error code */
+@@ -2295,7 +2297,12 @@ int do_string(__G__ length, option)   /*
              if (readbuf(__G__ (char *)G.extra_field, length) == 0)
                  return PK_EOF;
              /* Looks like here is where extra fields are read */
@@ -39,8 +37,6 @@ index ba0a1d0..36bfea3 100644
  #ifdef UNICODE_SUPPORT
              G.unipath_filename = NULL;
              if (G.UzO.U_flag < 2) {
-diff --git a/process.c b/process.c
-index 1e9a1e1..e3a3f8c 100644
 --- a/process.c
 +++ b/process.c
 @@ -1,5 +1,5 @@
@@ -149,5 +145,3 @@ index 1e9a1e1..e3a3f8c 100644
          ef_buf += (eb_len + EB_HEADSIZE);
          ef_len -= (eb_len + EB_HEADSIZE);
      }
--- 
-

--- a/utils/unzip/patches/0004-fix-out-of-bounds-read-or-write-and-crash.patch
+++ b/utils/unzip/patches/0004-fix-out-of-bounds-read-or-write-and-crash.patch
@@ -10,11 +10,9 @@ CVE: CVE-2014-9636
  extract.c | 9 +++++++++
  1 file changed, 9 insertions(+)
 
-diff --git a/extract.c b/extract.c
-index ec31e60..d816603 100644
 --- a/extract.c
 +++ b/extract.c
-@@ -2228,6 +2228,7 @@ static int test_compr_eb(__G__ eb, eb_size, compr_offset, test_uc_ebdata)
+@@ -2228,6 +2228,7 @@ static int test_compr_eb(__G__ eb, eb_si
      ulg eb_ucsize;
      uch *eb_ucptr;
      int r;
@@ -22,7 +20,7 @@ index ec31e60..d816603 100644
  
      if (compr_offset < 4)                /* field is not compressed: */
          return PK_OK;                    /* do nothing and signal OK */
-@@ -2244,6 +2245,14 @@ static int test_compr_eb(__G__ eb, eb_size, compr_offset, test_uc_ebdata)
+@@ -2244,6 +2245,14 @@ static int test_compr_eb(__G__ eb, eb_si
       ((eb_ucsize > 0L) && (eb_size <= (compr_offset + EB_CMPRHEADLEN))))
          return IZ_EF_TRUNC;             /* no/bad compressed data! */
  
@@ -37,5 +35,3 @@ index ec31e60..d816603 100644
      if (
  #ifdef INT_16BIT
          (((ulg)(extent)eb_ucsize) != eb_ucsize) ||
--- 
-

--- a/utils/unzip/patches/0005-fix-heap-based-buffer-over-read-and-application-cras.patch
+++ b/utils/unzip/patches/0005-fix-heap-based-buffer-over-read-and-application-cras.patch
@@ -10,8 +10,6 @@ CVE: CVE-2015-7696
  crypt.c | 12 +++++++++++-
  1 file changed, 11 insertions(+), 1 deletion(-)
 
-diff --git a/crypt.c b/crypt.c
-index 784e411..a8975f2 100644
 --- a/crypt.c
 +++ b/crypt.c
 @@ -465,7 +465,17 @@ int decrypt(__G__ passwrd)
@@ -33,5 +31,3 @@ index 784e411..a8975f2 100644
          h[n] = (uch)b;
          Trace((stdout, " (%02x)", h[n]));
      }
--- 
-

--- a/utils/unzip/patches/0006-fix-infinite-loop-because-of-an-empty-bzip2-data.patch
+++ b/utils/unzip/patches/0006-fix-infinite-loop-because-of-an-empty-bzip2-data.patch
@@ -10,8 +10,6 @@ CVE: CVE-2015-7697
  extract.c | 6 ++++++
  1 file changed, 6 insertions(+)
 
-diff --git a/extract.c b/extract.c
-index d816603..ad8b3f7 100644
 --- a/extract.c
 +++ b/extract.c
 @@ -2728,6 +2728,12 @@ __GDEF
@@ -27,5 +25,3 @@ index d816603..ad8b3f7 100644
  #if (defined(DLL) && !defined(NO_SLIDE_REDIR))
      if (G.redirect_slide)
          wsize = G.redirect_size, redirSlide = G.redirect_buffer;
--- 
-

--- a/utils/unzip/patches/0007-fix-error-to-prevent-unsigned-overflow.patch
+++ b/utils/unzip/patches/0007-fix-error-to-prevent-unsigned-overflow.patch
@@ -7,11 +7,9 @@ Subject: [PATCH] fix: error to prevent unsigned overflow
  extract.c | 11 ++++++++++-
  1 file changed, 10 insertions(+), 1 deletion(-)
 
-diff --git a/extract.c b/extract.c
-index ad8b3f7..17b201f 100644
 --- a/extract.c
 +++ b/extract.c
-@@ -1257,8 +1257,17 @@ static int extract_or_test_entrylist(__G__ numchunk,
+@@ -1257,8 +1257,17 @@ static int extract_or_test_entrylist(__G
          if (G.lrec.compression_method == STORED) {
              zusz_t csiz_decrypted = G.lrec.csize;
  
@@ -30,5 +28,3 @@ index ad8b3f7..17b201f 100644
              if (G.lrec.ucsize != csiz_decrypted) {
                  Info(slide, 0x401, ((char *)slide,
                    LoadFarStringSmall2(WrnStorUCSizCSizDiff),
--- 
-

--- a/utils/unzip/patches/0008-fix-buffer-overflow-in-the-list_files-function.patch
+++ b/utils/unzip/patches/0008-fix-buffer-overflow-in-the-list_files-function.patch
@@ -10,11 +10,9 @@ CVE: CVE-2014-9913
  list.c | 13 ++++++++++++-
  1 file changed, 12 insertions(+), 1 deletion(-)
 
-diff --git a/list.c b/list.c
-index 15e0011..3a3d1cd 100644
 --- a/list.c
 +++ b/list.c
-@@ -339,7 +339,18 @@ int list_files(__G)    /* return PK-type error code */
+@@ -339,7 +339,18 @@ int list_files(__G)    /* return PK-type
                  G.crec.compression_method == ENHDEFLATED) {
                  methbuf[5] = dtype[(G.crec.general_purpose_bit_flag>>1) & 3];
              } else if (methnum >= NUM_METHODS) {
@@ -34,5 +32,3 @@ index 15e0011..3a3d1cd 100644
              }
  
  #if 0       /* GRR/Euro:  add this? */
--- 
-

--- a/utils/unzip/patches/0009-fix-buffer-overflow-in-the-zi_short-function.patch
+++ b/utils/unzip/patches/0009-fix-buffer-overflow-in-the-zi_short-function.patch
@@ -10,11 +10,9 @@ CVE: CVE-2016-9844
  zipinfo.c | 13 ++++++++++++-
  1 file changed, 12 insertions(+), 1 deletion(-)
 
-diff --git a/zipinfo.c b/zipinfo.c
-index a92bca9..0148255 100644
 --- a/zipinfo.c
 +++ b/zipinfo.c
-@@ -1921,7 +1921,18 @@ static int zi_short(__G)   /* return PK-type error code */
+@@ -1921,7 +1921,18 @@ static int zi_short(__G)   /* return PK-
          ush  dnum=(ush)((G.crec.general_purpose_bit_flag>>1) & 3);
          methbuf[3] = dtype[dnum];
      } else if (methnum >= NUM_METHODS) {   /* unknown */
@@ -34,5 +32,3 @@ index a92bca9..0148255 100644
      }
  
      for (k = 0;  k < 15;  ++k)
--- 
-

--- a/utils/unzip/patches/0010-unix.c-Remove-build-date.patch
+++ b/utils/unzip/patches/0010-unix.c-Remove-build-date.patch
@@ -11,8 +11,6 @@ Bug-Debian: https://bugs.debian.org/782851
  unix/unix.c | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
-diff --git a/unix/unix.c b/unix/unix.c
-index efa97fc..816e3da 100644
 --- a/unix/unix.c
 +++ b/unix/unix.c
 @@ -1705,7 +1705,7 @@ void version(__G)
@@ -24,5 +22,3 @@ index efa97fc..816e3da 100644
        " on ", __DATE__
  #else
        "", ""
--- 
-

--- a/utils/unzip/patches/0011-fix-heap-based-buffer-overflow-in-the-password-prote.patch
+++ b/utils/unzip/patches/0011-fix-heap-based-buffer-overflow-in-the-password-prote.patch
@@ -11,8 +11,6 @@ CVE: CVE-2018-1000035
  fileio.c | 13 +++++++++----
  1 file changed, 9 insertions(+), 4 deletions(-)
 
-diff --git a/fileio.c b/fileio.c
-index 36bfea3..cb05903 100644
 --- a/fileio.c
 +++ b/fileio.c
 @@ -1,5 +1,5 @@
@@ -22,7 +20,7 @@ index 36bfea3..cb05903 100644
  
    See the accompanying file LICENSE, version 2009-Jan-02 or later
    (the contents of which are also included in unzip.h) for terms of use.
-@@ -1582,6 +1582,8 @@ int UZ_EXP UzpPassword (pG, rcnt, pwbuf, size, zfn, efn)
+@@ -1582,6 +1582,8 @@ int UZ_EXP UzpPassword (pG, rcnt, pwbuf,
      int r = IZ_PW_ENTERED;
      char *m;
      char *prompt;
@@ -31,7 +29,7 @@ index 36bfea3..cb05903 100644
  
  #ifndef REENTRANT
      /* tell picky compilers to shut up about "unused variable" warnings */
-@@ -1590,9 +1592,12 @@ int UZ_EXP UzpPassword (pG, rcnt, pwbuf, size, zfn, efn)
+@@ -1590,9 +1592,12 @@ int UZ_EXP UzpPassword (pG, rcnt, pwbuf,
  
      if (*rcnt == 0) {           /* First call for current entry */
          *rcnt = 2;
@@ -47,5 +45,3 @@ index 36bfea3..cb05903 100644
              m = prompt;
          } else
              m = (char *)LoadFarString(PasswPrompt2);
--- 
-


### PR DESCRIPTION
Fixes:
```
2026-04-28T14:55:09.6675796Z '/builder/build_dir/target-aarch64_generic_musl/unzip-6.0/unzip60/patches/0001-fix-heap-based-buffer-overflow-in-the-CRC32-verifica.patch' -> '/feed/utils/unzip/patches/0001-fix-heap-based-buffer-overflow-in-the-CRC32-verifica.patch'
2026-04-28T14:55:09.6707616Z '/builder/build_dir/target-aarch64_generic_musl/unzip-6.0/unzip60/patches/0002-fix-heap-based-buffer-overflow-in-the-test_compr_eb-.patch' -> '/feed/utils/unzip/patches/0002-fix-heap-based-buffer-overflow-in-the-test_compr_eb-.patch'
2026-04-28T14:55:09.6739766Z '/builder/build_dir/target-aarch64_generic_musl/unzip-6.0/unzip60/patches/0003-fix-heap-based-buffer-overflow-in-the-getZip64Data-f.patch' -> '/feed/utils/unzip/patches/0003-fix-heap-based-buffer-overflow-in-the-getZip64Data-f.patch'
2026-04-28T14:55:09.6770773Z '/builder/build_dir/target-aarch64_generic_musl/unzip-6.0/unzip60/patches/0004-fix-out-of-bounds-read-or-write-and-crash.patch' -> '/feed/utils/unzip/patches/0004-fix-out-of-bounds-read-or-write-and-crash.patch'
2026-04-28T14:55:09.6802381Z '/builder/build_dir/target-aarch64_generic_musl/unzip-6.0/unzip60/patches/0005-fix-heap-based-buffer-over-read-and-application-cras.patch' -> '/feed/utils/unzip/patches/0005-fix-heap-based-buffer-over-read-and-application-cras.patch'
2026-04-28T14:55:09.6832719Z '/builder/build_dir/target-aarch64_generic_musl/unzip-6.0/unzip60/patches/0006-fix-infinite-loop-because-of-an-empty-bzip2-data.patch' -> '/feed/utils/unzip/patches/0006-fix-infinite-loop-because-of-an-empty-bzip2-data.patch'
2026-04-28T14:55:09.6863943Z '/builder/build_dir/target-aarch64_generic_musl/unzip-6.0/unzip60/patches/0007-fix-error-to-prevent-unsigned-overflow.patch' -> '/feed/utils/unzip/patches/0007-fix-error-to-prevent-unsigned-overflow.patch'
2026-04-28T14:55:09.6895530Z '/builder/build_dir/target-aarch64_generic_musl/unzip-6.0/unzip60/patches/0008-fix-buffer-overflow-in-the-list_files-function.patch' -> '/feed/utils/unzip/patches/0008-fix-buffer-overflow-in-the-list_files-function.patch'
2026-04-28T14:55:09.6926806Z '/builder/build_dir/target-aarch64_generic_musl/unzip-6.0/unzip60/patches/0009-fix-buffer-overflow-in-the-zi_short-function.patch' -> '/feed/utils/unzip/patches/0009-fix-buffer-overflow-in-the-zi_short-function.patch'
2026-04-28T14:55:09.6958683Z '/builder/build_dir/target-aarch64_generic_musl/unzip-6.0/unzip60/patches/0010-unix.c-Remove-build-date.patch' -> '/feed/utils/unzip/patches/0010-unix.c-Remove-build-date.patch'
2026-04-28T14:55:09.6990350Z '/builder/build_dir/target-aarch64_generic_musl/unzip-6.0/unzip60/patches/0011-fix-heap-based-buffer-overflow-in-the-password-prote.patch' -> '/feed/utils/unzip/patches/0011-fix-heap-based-buffer-overflow-in-the-password-prote.patch'
2026-04-28T14:55:09.7023549Z '/builder/build_dir/target-aarch64_generic_musl/unzip-6.0/unzip60/patches/012-fix-gcc15-build.patch' -> '/feed/utils/unzip/patches/012-fix-gcc15-build.patch'
2026-04-28T14:55:09.7047649Z make[2]: Leaving directory '/feed/utils/unzip'
2026-04-28T14:55:09.7051724Z time: package/feeds/packages_ci/unzip/refresh#1.41#1.81#2.76
2026-04-28T14:55:09.7059428Z make[1]: Leaving directory '/builder'
2026-04-28T14:55:09.7071281Z ##[endgroup]
2026-04-28T14:55:09.7104892Z Dirty patches detected, please refresh and review the diff
```

Discovered in https://github.com/openwrt/packages/pull/28239

Fixes: f9e7e2db94a768d24201df27c4b619e724f95536  ("unzip: add valid patche headers and missing CVE informations")
cc: @feckert 
