### PR TITLE
lua-openssl: fix CMake Lua detection in build

### DIFF
--- a/lang/lua/lua-openssl/Makefile
+++ b/lang/lua/lua-openssl/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=lua-openssl
 PKG_SOURCE_VERSION:=0.11.1
 PKG_VERSION:=$(subst -,.,$(PKG_SOURCE_VERSION))
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/zhaozg/lua-openssl.git
@@ -23,13 +23,17 @@ PKG_LICENSE_FILES:=LICENSE
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
 
+CMAKE_OPTIONS += \
+	-DLUA_INCLUDE_DIR=$(STAGING_DIR)/usr/include \
+	-DLUA_LIBRARY=$(STAGING_DIR)/usr/lib/liblua.so
+
 define Package/lua-openssl
   SUBMENU:=Lua
   SECTION:=lang
   CATEGORY:=Languages
   TITLE:=Lua openSSL binding
   URL:=http://github.com/zhaozg/lua-openssl
-  DEPENDS:=+lua +libopenssl +librt
+  DEPENDS:=+liblua +libopenssl +librt
 endef
 
 define Package/lua-openssl/description


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @amnonpaz 

**Description:**

The CMakeLists.txt first tries FindLuaJIT.cmake which uses NO_DEFAULT_PATH with hardcoded host paths, so it always fails in cross-compilation. The fallback find_package(Lua REQUIRED) may also fail to find a flat sysroot layout where lua.h lives at /usr/include/lua.h rather than a versioned subdirectory.

Explicitly pass LUA_INCLUDE_DIR and LUA_LIBRARY to CMake to bypass both finders, and depend on +liblua (the library package) instead of +lua to ensure Build/InstallDev runs and Lua headers are present in the staging directory before this package builds.

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
