### PR TITLE
[24.10] openvpn: update to 2.6.20

### DIFF
--- a/net/openvpn/Makefile
+++ b/net/openvpn/Makefile
@@ -9,14 +9,14 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openvpn
 
-PKG_VERSION:=2.6.19
+PKG_VERSION:=2.6.20
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=\
 	https://build.openvpn.net/downloads/releases/ \
 	https://swupdate.openvpn.net/community/releases/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=13702526f687c18b2540c1a3f2e189187baaa65211edcf7ff6772fa69f0536cf
+PKG_HASH:=952ecee5b911a5353c0a6d40af62a7076c6dea1481ef204ce6d3f10481531315
 
 PKG_MAINTAINER:=
 

--- a/net/openvpn/patches/100-mbedtls-disable-runtime-version-check.patch
+++ b/net/openvpn/patches/100-mbedtls-disable-runtime-version-check.patch
@@ -1,11 +1,15 @@
 --- a/src/openvpn/ssl_mbedtls.c
 +++ b/src/openvpn/ssl_mbedtls.c
-@@ -1611,7 +1611,7 @@ const char *
+@@ -1610,11 +1610,7 @@ get_highest_preference_tls_cipher(char *
+ const char *
  get_ssl_library_version(void)
  {
-     static char mbedtls_version[30];
+-    static char mbedtls_version[30];
 -    unsigned int pv = mbedtls_version_get_number();
-+    unsigned int pv = MBEDTLS_VERSION_NUMBER;
-     snprintf(mbedtls_version, sizeof(mbedtls_version), "mbed TLS %d.%d.%d",
-              (pv>>24)&0xff, (pv>>16)&0xff, (pv>>8)&0xff );
-     return mbedtls_version;
+-    snprintf(mbedtls_version, sizeof(mbedtls_version), "mbed TLS %d.%d.%d",
+-             (pv>>24)&0xff, (pv>>16)&0xff, (pv>>8)&0xff );
+-    return mbedtls_version;
++    return "mbed TLS " MBEDTLS_VERSION_STRING;
+ }
+ 
+ void


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @commodo 

**Description:**
`main` and `25.12` have moved to 2.7.x with the new DCO implementation. Let's keep 24.10 on the previous 2.6.x branch as to not introduce too many changes to the old-stable 24.10 branch.

For changes, see:
https://github.com/OpenVPN/openvpn/blob/v2.6.20/Changes.rst

---

## 🧪 Run Testing Details

- **OpenWrt Version:** `24.10-SNAPSHOT`
- **OpenWrt Target/Subtarget:** `x86_64`
- **OpenWrt Device:** `generic`

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.