### PR TITLE
adguardhome: Added ujail dependency

### DIFF
--- a/net/adguardhome/Makefile
+++ b/net/adguardhome/Makefile
@@ -4,7 +4,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adguardhome
 PKG_VERSION:=0.107.74
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/AdguardTeam/AdGuardHome/tar.gz/v$(PKG_VERSION)?
@@ -42,7 +42,7 @@ define Package/adguardhome
 	CATEGORY:=Network
 	TITLE:=Network-wide ads and trackers blocking DNS server
 	URL:=https://github.com/AdguardTeam/AdGuardHome
-	DEPENDS:=$(GO_ARCH_DEPENDS) +ca-bundle
+	DEPENDS:=$(GO_ARCH_DEPENDS) +ca-bundle +procd-ujail
 	USERID:=adguardhome=853:adguardhome=853
 endef
 


### PR DESCRIPTION
In order to create a proper jail, we net the procd-ujail package. Otherwise, AdGuardHome will run as unprivileged process, and will not be able to listen on ports below 1024.

## 📦 Package Details

**Maintainer:** @GeorgeSapkin @hnyman 

**Description:**
See commit message. 

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 080ba512a182
- **OpenWrt Target/Subtarget:** MediaTek ARM / MT798X
- **OpenWrt Device:** Cudy TR3000 v1

---

## ✅ Formalities

- [ ] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ x] It can be applied using `git am`
- [x ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ x] It is structured in a way that it is potentially upstreamable
