### PR TITLE
domoticz: fix build with Boost >= 1.82 ASIO executor model

### DIFF
--- a/utils/domoticz/patches/002-fix-boost-asio-post-executor.patch
+++ b/utils/domoticz/patches/002-fix-boost-asio-post-executor.patch
@@ -1,0 +1,11 @@
+--- a/tcpserver/TCPServer.cpp
++++ b/tcpserver/TCPServer.cpp
+@@ -59,7 +59,7 @@ void CTCPServerInt::stop()
+ 			// Post a call to the stop function so that server::stop() is safe to call
+ 			// from any thread.
+ 			flghandle_stop_Completed=false;
+-			boost::asio::post([this] { handle_stop(); });
++			boost::asio::post(io_context_, [this] { handle_stop(); });
+ 		}
+ 
+ 		void CTCPServerInt::handle_stop()


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @dwmw2 


**Description:**

boost::asio::post() without an explicit executor fails to compile with Boost >= 1.82 due to changes in the executor model: bare lambdas no longer have an implicit system executor that satisfies the blocking.never requirement.

Pass io_context_ explicitly as the first argument so the handler is dispatched on the correct io_context thread, which is the original intent of the call (making stop() safe to call from any thread).

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [ ] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
