### PR TITLE
CI: relax subject and line length checks

### DIFF
--- a/.github/workflows/multi-arch-test-build.yml
+++ b/.github/workflows/multi-arch-test-build.yml
@@ -13,12 +13,15 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - name: HyperStickler
-        uses: georgesapkin/hyperstickler@v1-rc.1
+        uses: georgesapkin/hyperstickler@v1
         with:
           check_branch: false
           check_signoff: true
           feedback_url: 'https://github.com/openwrt/actions-shared-workflows/issues'
           guideline_url: 'https://openwrt.org/submitting-patches#submission_guidelines'
+          max_body_line_len: 100
+          max_subject_len_hard: 80
+          max_subject_len_soft: 60
           # This still needs a fine-grained token related to:
           # https://github.com/openwrt/packages/pull/28011
           # job_step: 2


### PR DESCRIPTION
Relax subject length checks to 60/80 and line length to 100 to match the actions repo.

Link:
- https://github.com/openwrt/actions-shared-workflows/pull/95

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

cc: @commodo @BKPepe @hnyman @wehagy