### PR TITLE
prosody: fix build, bump to to 0.12.6 and add test.sh

### DIFF
--- a/net/prosody/Makefile
+++ b/net/prosody/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=prosody
-PKG_VERSION:=0.12.4
+PKG_VERSION:=0.12.6
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://prosody.im/downloads/source
-PKG_HASH:=47d712273c2f29558c412f6cdaec073260bbc26b7dda243db580330183d65856
+PKG_HASH:=e06db3cfa8811d0b9fa7713a3b430189f62a1f90e6a4940771b1e16ce64e8e44
 
 PKG_MAINTAINER:=Thomas Heil <heil@terminal-consulting.de>
 PKG_LICENSE:=MIT/X11
@@ -48,7 +48,7 @@ endef
 TARGET_CFLAGS += $(FPIC)
 TARGET_LDFLAGS += -shared
 
-MAKE_FLAGS += LD="$(TARGET_CC)"
+MAKE_FLAGS += LD="$(TARGET_CC)" TARGET="../util/"
 
 define Build/Configure
 	# this is *NOT* GNU autoconf stuff
@@ -57,6 +57,7 @@ define Build/Configure
 		--with-lua="$(STAGING_DIR_HOSTPKG)" \
 		--with-lua-include="$(STAGING_DIR)/usr/include" \
 		--with-lua-lib="$(STAGING_DIR)/usr/lib" \
+		--idn-library=idn \
 		--cflags="$(TARGET_CFLAGS)" \
 		--ldflags="$(TARGET_LDFLAGS)" \
 		--c-compiler="$(CC)" \
@@ -84,8 +85,6 @@ define Package/prosody/install
 	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/prosody/modules/*.lua $(1)/usr/lib/prosody/modules/
 	$(INSTALL_DIR) $(1)/usr/lib/prosody/modules/adhoc
 	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/prosody/modules/adhoc/*.lua $(1)/usr/lib/prosody/modules/adhoc/
-	$(INSTALL_DIR) $(1)/usr/lib/prosody/modules/mod_s2s
-	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/prosody/modules/mod_s2s/*.lua $(1)/usr/lib/prosody/modules/mod_s2s/
 	$(INSTALL_DIR) $(1)/usr/lib/prosody/modules/muc
 	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/prosody/modules/muc/*.lua $(1)/usr/lib/prosody/modules/muc/
 	$(INSTALL_DIR) $(1)/usr/lib/prosody/modules/mod_pubsub
@@ -107,6 +106,10 @@ define Package/prosody/install
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/prosody/util/*.so $(1)/usr/lib/prosody/util/
 	$(INSTALL_DIR) $(1)/usr/lib/prosody/util/sasl
 	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/prosody/util/sasl/*.lua $(1)/usr/lib/prosody/util/sasl/
+	$(INSTALL_DIR) $(1)/usr/lib/prosody/util/human
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/prosody/util/human/*.lua $(1)/usr/lib/prosody/util/human/
+	$(INSTALL_DIR) $(1)/usr/lib/prosody/util/prosodyctl
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/prosody/util/prosodyctl/*.lua $(1)/usr/lib/prosody/util/prosodyctl/
 	#$(CP) $(PKG_INSTALL_DIR)/usr/lib/prosody/util/sasl/*.so $(1)/usr/lib/prosody/util/sasl/
 endef
 

--- a/net/prosody/test.sh
+++ b/net/prosody/test.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+case "$1" in
+	prosody)
+		grep -qF "$2" /usr/lib/prosody/prosody.version || exit 1
+		;;
+esac


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** Thomas Heil

**Description:**

mod_s2s was refactored into a single mod_s2s.lua in the flat modules directory in 0.12.x; remove the obsolete subdirectory install rule that caused the package build to fail.

Also add util/human/ and util/prosodyctl/ which are new subdirectories in 0.12.x not covered by the previous install rules.

Force libidn instead of ICU for stringprep

prosody's configure script auto-detects stringprep backends and prefers ICU when available, generating -DUSE_STRINGPREP_ICU and including <unicode/usprep.h>. The OpenWrt SDK staging directory does not provide ICU development headers, so the build fails with:

  encodings.c:271:10: fatal error: unicode/usprep.h: No such file or directory

The Makefile DEPENDS already declares +libidn. Pass --with-idn=idn to explicitly select the libidn backend, which is available in the staging directory.

Also, pass TARGET="../util/" to MAKE_FLAGS. OpenWrt has it's own TARGET env var which clobbers the 'TARGET' var from prosody's build (specified as 'TARGET?=../util/')

Adding a test.sh to check for the correct version (since prosody mostly has lua scripts).


---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
