### PR TITLE
libre2: update to 2025-11-05

### DIFF
--- a/libs/libre2/Makefile
+++ b/libs/libre2/Makefile
@@ -1,13 +1,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=re2
-PKG_RELEASE:=2
+PKG_VERSION:=2025.11.05
+PKG_RELEASE:=1
 
-PKG_SOURCE_PROTO:=git
-PKG_SOURCE_URL:=https://github.com/google/re2
-PKG_SOURCE_DATE:=2023-02-01
-PKG_SOURCE_VERSION:=b025c6a3ae05995660e3b882eb3277f4399ced1a
-PKG_MIRROR_HASH:=b473f4fd10d9f0afd65d409cf11dd1fd7b4010cfa4e07cfc99d33e382390baef
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://github.com/google/re2/archive/refs/tags/
+PKG_SOURCE_URL_FILE:=2025-11-05.tar.gz
+PKG_HASH:=87f6029d2f6de8aa023654240a03ada90e876ce9a4676e258dd01ea4c26ffd67
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-2025-11-05
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=BSD-3-Clause
@@ -21,7 +22,7 @@ include $(INCLUDE_DIR)/cmake.mk
 define Package/re2
   SECTION:=libs
   CATEGORY:=Libraries
-  DEPENDS:=+libstdcpp
+  DEPENDS:=+libstdcpp +abseil-cpp
   TITLE:=RE2 - C++ regular expression library
   URL:=https://github.com/google/re2
   ABI_VERSION:=10


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me

**Description:**

Bump to latest upstream snapshot (2025-11-05). re2 uses date-based versioning from git. This brings roughly two years of upstream improvements including performance optimisations, bug fixes, and C++17/20 compatibility improvements.

Reference:
https://github.com/google/re2/commits/main

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
