### PR TITLE
domoticz: fix build and add test.sh

### DIFF
--- a/libs/boost/Makefile
+++ b/libs/boost/Makefile
@@ -13,7 +13,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=boost
 PKG_VERSION:=1.90.0
 PKG_SOURCE_VERSION:=1_90_0
-PKG_RELEASE:=1
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)_$(PKG_SOURCE_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://archives.boost.io/release/$(PKG_VERSION)/source @SF/$(PKG_NAME)/$(PKG_NAME)/$(PKG_VERSION)
@@ -336,7 +336,7 @@ define DefineBoostLibrary
 endef
 
 $(eval $(call DefineBoostLibrary,atomic))
-$(eval $(call DefineBoostLibrary,charconv,,,,libquadmath))
+$(eval $(call DefineBoostLibrary,charconv,,,,$(if $(filter i386 x86_64 powerpc powerpc64,$(ARCH)),libquadmath)))
 $(eval $(call DefineBoostLibrary,chrono))
 $(eval $(call DefineBoostLibrary,cobalt,container context date_time,,,libopenssl))
 $(eval $(call DefineBoostLibrary,container))

--- a/utils/domoticz/Makefile
+++ b/utils/domoticz/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=domoticz
 PKG_VERSION:=2025.2
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/domoticz/domoticz/tar.gz/$(PKG_VERSION)?
@@ -21,7 +21,7 @@ PKG_LICENSE_FILES:=License.txt
 PKG_CPE_ID:=cpe:/a:domoticz:domoticz
 
 PKG_BUILD_DEPENDS:=python3 minizip cereal boost jwt-cpp
-PKG_BUILD_FLAGS:=no-mips16 lto
+PKG_BUILD_FLAGS:=no-mips16
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk

--- a/utils/domoticz/patches/002-fix-boost-asio-post-executor.patch
+++ b/utils/domoticz/patches/002-fix-boost-asio-post-executor.patch
@@ -1,0 +1,11 @@
+--- a/tcpserver/TCPServer.cpp
++++ b/tcpserver/TCPServer.cpp
+@@ -59,7 +59,7 @@ namespace tcp {
+ 			// Post a call to the stop function so that server::stop() is safe to call
+ 			// from any thread.
+ 			flghandle_stop_Completed=false;
+-			boost::asio::post([this] { handle_stop(); });
++			boost::asio::post(io_context_, [this] { handle_stop(); });
+ 		}
+ 
+ 		void CTCPServerInt::handle_stop()

--- a/utils/domoticz/test.sh
+++ b/utils/domoticz/test.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+case "$1" in
+	domoticz)
+		[ -x /usr/bin/domoticz ] || exit 1
+		;;
+esac

--- a/utils/openzwave/test.sh
+++ b/utils/openzwave/test.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+case "$1" in
+	openzwave)
+		[ -x /usr/bin/MinOZW ] || exit 1
+		;;
+esac


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:**  @dwmw2


**Description:**

boost::asio::post() without an explicit executor fails to compile with Boost >= 1.82 due to changes in the executor model: bare lambdas no longer have an implicit system executor that satisfies the blocking.never requirement.

Pass io_context_ explicitly as the first argument so the handler is dispatched on the correct io_context thread, which is the original intent of the call (making stop() safe to call from any thread).

Add test.sh
domoticz is a daemon requiring a database and network port; it does not implement a --version flag. Verify the binary is present and executable.

Disable LTO to fix link failure on i386 with musl fortify Suggested via https://github.com/openwrt/packages/pull/29239 Also tested.

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [ ] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
