### PR TITLE
mpd: enabled dsd for mpd-full variant

### DIFF
--- a/sound/mpd/Makefile
+++ b/sound/mpd/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mpd
 PKG_VERSION:=0.23.16
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.musicpd.org/download/mpd/0.23
@@ -118,7 +118,6 @@ MESON_ARGS += \
 	-Dtcp=true \
 	-Dipv6=$(if $(CONFIG_IPV6),en,dis)abled \
 	-Dlocal_socket=true \
-	-Ddsd=false \
 	-Ddatabase=true \
 	-Dlibmpdclient=enabled \
 	-Dneighbor=false \
@@ -181,6 +180,7 @@ ifeq ($(BUILD_VARIANT),full)
   MESON_ARGS += \
 	-Dupnp=npupnp \
 	-Dmms=enabled \
+	-Ddsd=true \
 	-Dsoundcloud=enabled \
 	-Dffmpeg=enabled \
 	-Dmad=$(if $(CONFIG_BUILD_PATENTED),dis,en)abled \
@@ -207,6 +207,7 @@ ifeq ($(BUILD_VARIANT),mini)
   MESON_ARGS += \
 	-Dupnp=disabled \
 	-Dmms=disabled \
+	-Ddsd=false \
 	-Dsoundcloud=disabled \
 	-Dffmpeg=disabled \
 	-Dmad=enabled \


### PR DESCRIPTION
Fixes: #29281

## 📦 Package Details

**Maintainer:** @commodo 

**Description:**
mpd natively supports DSD streams and can work with DACs with DSD support on Linux. But full version in OpenWRT is built with `dsd=false` config. Chaged it to `true` for the `mpd-full`.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12.2
- **OpenWrt Target/Subtarget:** rockchip/armv8
- **OpenWrt Device:** NanoPi R4S

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
