### PR TITLE
lua-openssl: fix Lua detection with CMake 4.3

### DIFF
--- a/lang/lua/lua-openssl/Makefile
+++ b/lang/lua/lua-openssl/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=lua-openssl
 PKG_SOURCE_VERSION:=0.11.1
 PKG_VERSION:=$(subst -,.,$(PKG_SOURCE_VERSION))
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/zhaozg/lua-openssl.git
@@ -24,8 +24,8 @@ include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
 
 CMAKE_OPTIONS += \
-	-DLUA_INCLUDE_DIR=$(STAGING_DIR)/usr/include \
-	-DLUA_LIBRARY=$(STAGING_DIR)/usr/lib/liblua.so
+	-DLUAJIT_INCLUDE_DIRS=$(STAGING_DIR)/usr/include \
+	-DLUAJIT_LIBRARY=$(STAGING_DIR)/usr/lib/liblua.so
 
 define Package/lua-openssl
   SUBMENU:=Lua


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @amnonpaz 

**Description:**

FindLuaJIT.cmake uses NO_DEFAULT_PATH and only searches hardcoded luajit-specific paths, so it never finds regular Lua. However if LUAJIT_INCLUDE_DIRS and LUAJIT_LIBRARY are pre-set in the CMake cache, find_path/find_library skip their searches, the module sets LUAJIT_FOUND=ON and also sets LUA_INCLUDE_DIR/LUA_LIBRARIES from those values, and the if(NOT LUAJIT_FOUND) guard skips the broken find_package(Lua REQUIRED) call that fails under CMake 4.3.

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
