### PR TITLE
nebula: bump version to 1.10.3

### DIFF
--- a/net/nebula/Makefile
+++ b/net/nebula/Makefile
@@ -4,12 +4,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nebula
-PKG_VERSION:=1.9.7
+PKG_VERSION:=1.10.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/slackhq/nebula/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=b8ca239c6c728deadbb28927c5332e4abf0466121d76616827adbaabbba32d05
+PKG_HASH:=12972f5a1dc37b89dff6af91685f7f7eb643b7f75da760c036d1e8d850387e54
 
 PKG_MAINTAINER:=Yuxi Yang <i@bgme.me>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
changelog: https://github.com/slackhq/nebula/compare/v1.9.7...v1.10.3

## 📦 Package Details

**Maintainer:** @yingziwu
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:** Bump nebula version to 1.10.3
<!-- Briefly describe what this package does or what changes are introduced -->

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.