### PR TITLE
quectel-cm: add connection manager support for Quectel

### DIFF
--- a/net/quectel-cm/Makefile
+++ b/net/quectel-cm/Makefile
@@ -1,0 +1,44 @@
+#
+# Copyright (C) 2026 Philip Prindeville <philipp@redfish-solutions.com>
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=quectel-cm
+PKG_VERSION:=1.6.0.24
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/kmilo17pet/quectel-cm.git
+PKG_MIRROR_HASH:=49f6681f7825aca4e607ffdb4a61e92864dfffc91d404a2f51404a92ef7518d7
+PKG_SOURCE_DATE:=2025-08-05
+PKG_SOURCE_VERSION:=2c623ffc8a1a8a7054b695956eb343e37b04727b
+
+PKG_MAINTAINER:=Philip Prindeville <philipp@redfish-solutions.com>
+
+PKG_LICENSE:=GPL-2.0
+PKG_LICENSE_FILES:=NOTICE
+
+PKG_CPE_ID:=cpe:/a:quectel-cm:quectel-cm
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/quectel-cm
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=Quectel Connect Manager tool
+  DEPENDS:=+libpthread +librt
+  URL:=https://github.com/kmilo17pet/quectel-cm.git
+endef
+
+define Package/quectel-cm/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/quectel-qmi-proxy $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/quectel-mbim-proxy $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/quectel-CM $(1)/usr/bin/
+endef
+
+$(eval $(call BuildPackage,quectel-cm))

--- a/net/quectel-cm/patches/900-fix-macro-noise.patch
+++ b/net/quectel-cm/patches/900-fix-macro-noise.patch
@@ -1,0 +1,13 @@
+--- a/mbim-cm.c
++++ b/mbim-cm.c
+@@ -1574,7 +1574,9 @@ static int mbim_status_code(MBIM_MESSAGE
+         if (pCmdDone) { mbim_dump(&pCmdDone->MessageHeader, (mbim_verbose == 0)); } \
+         mbim_free(pRequest); mbim_free(pCmdDone); \
+         mbim_debug("%s:%d err=%d, Status=%d", __func__, __LINE__, err, _status); \
+-        if (err) return err; if (_status) return _status; return 8888; \
++        if (err) return err; \
++        if (_status) return _status; \
++        return 8888; \
+     } \
+ } while(0)
+ 

--- a/net/quectel-cm/patches/910-fix-make-recipes.patch
+++ b/net/quectel-cm/patches/910-fix-make-recipes.patch
@@ -1,0 +1,25 @@
+--- a/Makefile
++++ b/Makefile
+@@ -22,17 +22,17 @@ endif
+ 
+ CFLAGS+=-Wall -O1
+ 
+-release: clean qmi-proxy mbim-proxy
++release: clean quectel-qmi-proxy quectel-mbim-proxy
+ 	$(CC) ${CFLAGS} -s ${QL_CM_SRC} ${QL_CM_DHCP} -o quectel-CM -lpthread -ldl -lrt
+ 
+ debug: clean
+ 	$(CC) ${CFLAGS} -g -DCM_DEBUG ${QL_CM_SRC} ${QL_CM_DHCP} -o quectel-CM -lpthread -ldl -lrt
+ 
+-qmi-proxy:
+-	$(CC) ${CFLAGS} -s quectel-qmi-proxy.c  -o quectel-qmi-proxy -lpthread -ldl -lrt
++quectel-qmi-proxy:
++	$(CC) ${CFLAGS} -s quectel-qmi-proxy.c -o quectel-qmi-proxy -lpthread -ldl -lrt
+ 
+-mbim-proxy:
+-	$(CC) ${CFLAGS} -s quectel-mbim-proxy.c  -o quectel-mbim-proxy -lpthread -ldl -lrt
++quectel-mbim-proxy:
++	$(CC) ${CFLAGS} -s quectel-mbim-proxy.c -o quectel-mbim-proxy -lpthread -ldl -lrt
+ 
+ clean:
+ 	rm -rf *.o libmnl/*.o quectel-CM quectel-qmi-proxy quectel-mbim-proxy

--- a/net/quectel-cm/patches/920-fix-message-typos.patch
+++ b/net/quectel-cm/patches/920-fix-message-typos.patch
@@ -1,0 +1,29 @@
+--- a/QMIThread.c
++++ b/QMIThread.c
+@@ -1301,7 +1301,7 @@ static int requestRegistrationState2(UCH
+     int err;
+     USHORT MobileCountryCode = 0;
+     USHORT MobileNetworkCode = 0;
+-    const char *pDataCapStr = "UNKNOW";
++    const char *pDataCapStr = "UNKNOWN";
+     LONG remainingLen;
+     PSERVICE_STATUS_INFO pServiceStatusInfo;
+     int is_lte = 0;
+@@ -1637,7 +1637,7 @@ static int requestRegistrationState(UCHA
+     PQMINAS_DATA_CAP pDataCap;
+     USHORT MobileCountryCode = 0;
+     USHORT MobileNetworkCode = 0;
+-    const char *pDataCapStr = "UNKNOW";
++    const char *pDataCapStr = "UNKNOWN";
+ 
+     if (s_9x07) {
+         return requestRegistrationState2(pPSAttachedState);
+@@ -1690,7 +1690,7 @@ static int requestRegistrationState(UCHA
+              case 0x0B: pDataCapStr = "LTE"; break;
+              case 0x0C: pDataCapStr = "HSDPA"; break;
+              case 0x0D: pDataCapStr = "HSDPA"; break;
+-             default: pDataCapStr = "UNKNOW"; break;
++             default: pDataCapStr = "UNKNOWN"; break;
+         }
+     }
+ 


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me

**Description:**
Package as this may be handy for 4G and 5G modem users.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** HEAD
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** banana-pi,bpi-r4-pro

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [X] It can be applied using `git am`
- [X] It has been refreshed to avoid offsets, fuzzes, etc., using
- [X] It is structured in a way that it is potentially upstreamable

cc: @kmilo17pet