### PR TITLE
openvpn: add kmod-ovpn-backports dependency

### DIFF
--- a/net/openvpn/Makefile
+++ b/net/openvpn/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=openvpn
 
 PKG_VERSION:=2.7.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=\
 	https://build.openvpn.net/downloads/releases/ \
@@ -42,6 +42,7 @@ define Package/openvpn/Default
 	   +OPENVPN_$(1)_ENABLE_LZ4:liblz4 \
 	   +OPENVPN_$(1)_ENABLE_IPROUTE2:ip \
 	   +OPENVPN_$(1)_ENABLE_DCO:libnl-genl \
+	   +OPENVPN_$(1)_ENABLE_DCO:kmod-ovpn-backports \
 	   $(3)
   VARIANT:=$(1)
   PROVIDES:=openvpn openvpn-crypto


### PR DESCRIPTION
With openwrt/openwrt@f7d6e73 and openwrt/packages@974c2be, kmod-ovpn-backports can now be built and run correctly.
add this dependency enables DCO.

Link: openwrt/packages@01fafd69e

Test on: Mediatek Filogic GL-MT3000 (with kmod-crypto-hw-safexcel)

The previous PR (https://github.com/openwrt/packages/pull/29193) can't be reopened, so creat a new PR.

## 📦 Package Details

**Maintainer:** @commodo

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** Mediatek Filogic
- **OpenWrt Device:** GL-MT3000

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
