### PR TITLE
watchcat: bounce interfaces in restart_iface mode instead of just ifup

### DIFF
--- a/utils/watchcat/files/watchcat.sh
+++ b/utils/watchcat/files/watchcat.sh
@@ -87,6 +87,8 @@ watchcat_restart_network_iface() {
 	local network
 	network="$(find_config "$1")"
 	logger -p daemon.info -t "watchcat[$$]" "Restarting network interface: \"$1\" (network: \"$network\")."
+	ifdown "$network"
+	sleep 1
 	ifup "$network"
 }
 
@@ -235,7 +237,7 @@ watchcat_ping() {
 			if [ "$ping_result" -eq 0 ]; then
 				time_lastcheck_withinternet="$time_now"
 			else
-				logger -p daemon.info -t "watchcat[$$]" "Could not reach $host for $((time_now - time_lastcheck_withinternet)). Rebooting after reaching $failure_period"
+				logger -p daemon.info -t "watchcat[$$]" "Could not reach $host for $((time_now - time_lastcheck_withinternet)) seconds. Will reboot after $failure_period seconds of failed reachability"
 			fi
 		done
 


### PR DESCRIPTION
The `restart_iface` path currently logs that it is restarting the
interface, but it only calls `ifup` on the logical network.

This changes it to bring the network down first, wait briefly, and then
bring it back up so the restart more closely matches the expected
behavior.

It also clarifies the `ping_reboot` log message so it does not imply
that the reboot is happening before the failure threshold is actually
reached.

## Package Details

**Maintainer:** Roger D <rogerdammit@gmail.com>

**Description:**
`watchcat` can reboot the device or restart networking when connectivity
checks fail for a configured period. This change makes
`restart_iface` behave more like an actual restart and makes the
`ping_reboot` logging clearer during failure periods.

---

## Run Testing Details

- **OpenWrt Version:** 24.10.4 r28959-29397011cc
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** VM
---

## Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
