### PR TITLE
libreswan: reduce crypto deps

### DIFF
--- a/net/libreswan/Makefile
+++ b/net/libreswan/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libreswan
 PKG_VERSION:=4.12
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://download.libreswan.org/
@@ -44,30 +44,12 @@ define Package/libreswan
 	  +ip-full +kmod-xfrm-interface \
 	  +libevent2 +libevent2-pthreads \
 	  +libldns +librt +libunbound +nss-utils +nspr +libcap-ng \
-	  +kmod-crypto-acompress \
-	  +kmod-crypto-aead \
-	  +kmod-crypto-authenc \
-	  +kmod-crypto-arc4 \
-	  +kmod-crypto-cbc \
-	  +kmod-crypto-ccm \
 	  +kmod-crypto-chacha20poly1305 \
 	  +kmod-crypto-cmac \
-	  +kmod-crypto-ctr \
-	  +kmod-crypto-cts \
-	  +kmod-crypto-des \
 	  +kmod-crypto-ecb \
 	  +kmod-crypto-ecdh \
 	  +kmod-crypto-gcm \
-	  +kmod-crypto-ghash \
-	  +kmod-crypto-hash \
-	  +kmod-crypto-hmac \
-	  +kmod-crypto-md4 \
-	  +kmod-crypto-md5 \
-	  +kmod-crypto-null \
-	  +kmod-crypto-pcbc \
-	  +kmod-crypto-sha1 \
 	  +kmod-crypto-sha256 \
-	  +kmod-crypto-sha512 \
 	  +kmod-crypto-xcbc \
 	  +kmod-crypto-rng
 endef


### PR DESCRIPTION
Some of these are obsolete. Others like CTS make no sense for IPSec.

## 📦 Package Details

**Maintainer:** @lucize 