### PR TITLE
Add no-ip.com to DDNS list

### DIFF
--- a/net/ddns-scripts/files/usr/share/ddns/list
+++ b/net/ddns-scripts/files/usr/share/ddns/list
@@ -52,6 +52,7 @@ mythic-beasts.com-v2
 namecheap.com
 netcup.com
 njal.la
+no-ip.com
 no-ip.pl
 now-dns.com
 nsupdate.info


### PR DESCRIPTION
The configuration file `no-ip.com.json` already exists in the `default` directory, but it was missing from the `list` file,This causes the service to be unavailable in the LuCI interface.
This PR adds `no-ip.com` to the list to enable the existing configuration.
Tested on iStoreOS with ddns-scripts 2.8.2. Update works successfully.