### PR TITLE
openvpn: use mbedtls by default

### DIFF
--- a/net/openvpn/Makefile
+++ b/net/openvpn/Makefile
@@ -44,11 +44,12 @@ define Package/openvpn/Default
 	   +OPENVPN_$(1)_ENABLE_DCO:libnl-genl \
 	   $(3)
   VARIANT:=$(1)
+  DEFAULT_VARIANT:=$(4)
   PROVIDES:=openvpn openvpn-crypto
 endef
 
 Package/openvpn-openssl=$(call Package/openvpn/Default,openssl,OpenSSL,+PACKAGE_openvpn-openssl:libopenssl)
-Package/openvpn-mbedtls=$(call Package/openvpn/Default,mbedtls,mbedTLS,+PACKAGE_openvpn-mbedtls:libmbedtls)
+Package/openvpn-mbedtls=$(call Package/openvpn/Default,mbedtls,mbedTLS,+PACKAGE_openvpn-mbedtls:libmbedtls,1)
 Package/openvpn-wolfssl=$(call Package/openvpn/Default,wolfssl,WolfSSL,+PACKAGE_openvpn-wolfssl:libwolfssl @BROKEN)
 
 define Package/openvpn/config/Default


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @commodo

**Description:**
When luci-proto-openvpn is selected in `make menuconfig`, openvpn-openssl is picked up automatically. As mbedTLS is the default TLS package, set DEFAULT_VARIANT on openvpn-mbedtls so that it is used by default.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.