### PR TITLE
prometheus-node-exporter-lua: fix uci_dhcp_host crash with list mac

### DIFF
--- a/utils/prometheus-node-exporter-lua/Makefile
+++ b/utils/prometheus-node-exporter-lua/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=prometheus-node-exporter-lua
 PKG_VERSION:=2025.11.22
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Etienne CHAMPETIER <champetier.etienne@gmail.com>
 PKG_LICENSE:=Apache-2.0

--- a/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/uci_dhcp_host.lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/uci_dhcp_host.lua
@@ -6,8 +6,11 @@ local function scrape()
 
   curs:foreach("dhcp", "host", function(s)
     if s[".type"] == "host" then
-      labels = {name=s["name"], mac=string.upper(s["mac"]), dns=s["dns"], ip=s["ip"]}
-      metric_uci_host(labels, 1)
+      local macs = type(s["mac"]) == "table" and s["mac"] or {s["mac"]}
+      for _, mac in ipairs(macs) do
+        labels = {name=s["name"], mac=string.upper(mac), dns=s["dns"], ip=s["ip"]}
+        metric_uci_host(labels, 1)
+      end
     end
   end)
 end


### PR DESCRIPTION
Maintainer: Jean-Laurent Girod
Compile tested: No
Run tested: GL-X300B, OpenWrt 25.12.2, mixed list/option DHCP host entries

## Description

When a DHCP host entry uses `list mac` instead of `option mac`, UCI
returns a Lua table instead of a string. Calling `string.upper()` on a
table causes a crash:

```
ERROR: bad argument #1 to 'upper' (string expected, got table)
```

This fix handles both cases by normalising the `mac` value to a table
and iterating over all entries, emitting one metric per MAC address.
Single `option mac` entries continue to work as before.

Fixes: #25055