### PR TITLE
https-dns-proxy: ignore disabled dnsmasq port 0

### DIFF
--- a/net/https-dns-proxy/Makefile
+++ b/net/https-dns-proxy/Makefile
@@ -3,7 +3,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=https-dns-proxy
 PKG_VERSION:=2026.03.18
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/aarond10/https_dns_proxy/

--- a/net/https-dns-proxy/files/etc/init.d/https-dns-proxy
+++ b/net/https-dns-proxy/files/etc/init.d/https-dns-proxy
@@ -463,7 +463,8 @@ dnsmasq_instance_append_force_dns_port() {
 	local cfg="$1" instance_port
 	[ "$(uci_get 'dhcp' "$cfg")" = "dnsmasq" ] || return 1
 	config_get instance_port "$cfg" 'port' '53'
-		str_contains_word "$force_dns_port" "$instance_port" || force_dns_port="${force_dns_port:+${force_dns_port} }${instance_port}"
+	[ "$instance_port" = "0" ] && return 0
+	str_contains_word "$force_dns_port" "$instance_port" || force_dns_port="${force_dns_port:+${force_dns_port} }${instance_port}"
 }
 
 dnsmasq_doh_server() {

--- a/net/https-dns-proxy/tests/run_tests.sh
+++ b/net/https-dns-proxy/tests/run_tests.sh
@@ -505,6 +505,11 @@ force_dns_port="53 853"
 dnsmasq_instance_append_force_dns_port "cfg01"
 assert_eq "append_force_dns_port: already present port 53 not duplicated" "53 853" "$force_dns_port"
 
+uci_set "dhcp" "cfg03" ".type" "dnsmasq"
+uci_set "dhcp" "cfg03" "port" "0"
+dnsmasq_instance_append_force_dns_port "cfg03"
+assert_eq "append_force_dns_port: disabled dnsmasq port 0 ignored" "53 853" "$force_dns_port"
+
 uci_set "dhcp" "cfg02" ".type" "dnsmasq"
 uci_set "dhcp" "cfg02" "port" "5353"
 dnsmasq_instance_append_force_dns_port "cfg02"


### PR DESCRIPTION
dnsmasq may be configured with port 0 to disable its DNS listener.

Ignore that value when collecting ports for force_dns_port so https-dns-proxy does not generate firewall metadata for port 0.

Add a regression test to ensure disabled dnsmasq DNS ports are skipped.

## 📦 Package Details

**Maintainer:** Stan Grishin <stangri@melmac.ca> ( @stangri )

**Description:**
When `dnsmasq` is configured with `option port '0'` to disable its DNS
listener, `https-dns-proxy` still appends that value to
`force_dns_port`.

As a result, it generates firewall metadata for an invalid port:
```json
{
  "type": "rule",
  "src": "lan",
  "dest": "*",
  "proto": "tcp udp",
  "dest_port": "0",
  "target": "REJECT"
}
```

This change ignores `dnsmasq` port `0` when collecting ports for
`force_dns_port`, so only real listening ports are used.

It also adds a regression test to ensure disabled `dnsmasq` DNS ports
are skipped.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 24.10.4
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** VM
---

## ✅ Formalities

- [ ] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [x] It is structured in a way that it is potentially upstreamable
