### PR TITLE
gdu: add new package

### DIFF
--- a/utils/gdu/Makefile
+++ b/utils/gdu/Makefile
@@ -1,0 +1,55 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=gdu
+PKG_VERSION:=5.36.1
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/dundee/gdu/tar.gz/refs/tags/v$(PKG_VERSION)?
+PKG_HASH:=dd31ea9afd848edf734143aabd5fdf66236ce2c866dc09f9dededb61d39fe63c
+
+PKG_MAINTAINER:=John Audia <therealgraysky@proton.me>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_DEPENDS:=golang/host
+PKG_BUILD_PARALLEL:=1
+PKG_BUILD_FLAGS:=no-mips16
+
+GO_PKG:=github.com/dundee/gdu/v5
+GO_PKG_BUILD_PKG:=github.com/dundee/gdu/v5/cmd/gdu
+
+GO_PKG_LDFLAGS_X:=$(GO_PKG)/build.Version=$(PKG_VERSION)
+
+GO_PKG_TARGET_VARS:= \
+	CGO_ENABLED=0
+
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/golang/golang-package.mk
+
+define Package/gdu
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=Fast disk usage analyzer
+  URL:=https://github.com/dundee/gdu
+  DEPENDS:=$(GO_ARCH_DEPENDS)
+endef
+
+define Package/gdu/description
+  Fast disk usage analyzer with console interface written in Go.
+  GDU is intended primarily for SSD disks where it can fully
+  utilize parallel processing.
+endef
+
+define Package/gdu/install
+	$(call GoPackage/Package/Install/Bin,$(1))
+	$(INSTALL_DIR) $(1)/etc/
+	$(INSTALL_DATA) ./files/gdu.yaml $(1)/etc/gdu.yaml
+endef
+
+define Package/gdu/conffiles
+/etc/gdu.yaml
+endef
+
+$(eval $(call GoBinPackage,gdu))
+$(eval $(call BuildPackage,gdu))

--- a/utils/gdu/Makefile
+++ b/utils/gdu/Makefile
@@ -1,0 +1,55 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=gdu
+PKG_VERSION:=5.37.0
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/dundee/gdu/tar.gz/refs/tags/v$(PKG_VERSION)?
+PKG_HASH:=48e20d39a1bf706b3e11bbfeae550a0890610d3e6030a73952903f5fcf062347
+
+PKG_MAINTAINER:=John Audia <therealgraysky@proton.me>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_DEPENDS:=golang/host
+PKG_BUILD_PARALLEL:=1
+PKG_BUILD_FLAGS:=no-mips16
+
+GO_PKG:=github.com/dundee/gdu/v5
+GO_PKG_BUILD_PKG:=github.com/dundee/gdu/v5/cmd/gdu
+
+GO_PKG_LDFLAGS_X:=$(GO_PKG)/build.Version=$(PKG_VERSION)
+
+GO_PKG_TARGET_VARS:= \
+	CGO_ENABLED=0
+
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/golang/golang-package.mk
+
+define Package/gdu
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=Fast disk usage analyzer
+  URL:=https://github.com/dundee/gdu
+  DEPENDS:=$(GO_ARCH_DEPENDS)
+endef
+
+define Package/gdu/description
+  Fast disk usage analyzer with console interface written in Go.
+  GDU is intended primarily for SSD disks where it can fully
+  utilize parallel processing.
+endef
+
+define Package/gdu/install
+	$(call GoPackage/Package/Install/Bin,$(1))
+	$(INSTALL_DIR) $(1)/etc/
+	$(INSTALL_DATA) ./files/gdu.yaml $(1)/etc/gdu.yaml
+endef
+
+define Package/gdu/conffiles
+/etc/gdu.yaml
+endef
+
+$(eval $(call GoBinPackage,gdu))
+$(eval $(call BuildPackage,gdu))

--- a/utils/gdu/files/gdu.yaml
+++ b/utils/gdu/files/gdu.yaml
@@ -1,0 +1,5 @@
+# GDU configuration for OpenWrt
+# Disables Unicode symbols in the size bar for compatibility
+# with OpenWrt terminal environments.
+no-unicode: true
+

--- a/utils/gdu/patches/010-feat-load-etc-gdu.yaml-as-system-wide-config.patch
+++ b/utils/gdu/patches/010-feat-load-etc-gdu.yaml-as-system-wide-config.patch
@@ -1,0 +1,181 @@
+From 4a2254be6ab14163e2077d195f6bb8d6a36afd19 Mon Sep 17 00:00:00 2001
+From: graysky <therealgraysky@proton.me>
+Date: Thu, 14 May 2026 09:05:09 -0400
+Subject: [PATCH] feat: load /etc/gdu.yaml as system-wide config (#567)
+
+* feat: load /etc/gdu.yaml as system-wide config
+
+Load /etc/gdu.yaml before the user config so admins can set
+org-wide defaults. User config (~/.gdu.yaml or --config-file)
+still takes full precedence.
+
+Useful for example on OpenWrt where no-unicode: true should be set
+for all users.
+
+* fix(test): correct app.Flags import path in main_test.go
+
+Use github.com/dundee/gdu/v5/cmd/gdu/app instead of the
+non-existent github.com/dundee/gdu/v5/pkg/app to match
+the import already used in main.go.
+
+* fix: add consts
+
+---------
+
+Co-authored-by: graysky <therealgraysky AT proton DOT me>
+Co-authored-by: Daniel Milde <daniel@milde.cz>
+---
+ cmd/gdu/main.go      | 39 ++++++++++++++++++++------
+ cmd/gdu/main_test.go | 66 +++++++++++++++++++++++++++++++++++++++++++-
+ 2 files changed, 96 insertions(+), 9 deletions(-)
+
+--- a/cmd/gdu/main.go
++++ b/cmd/gdu/main.go
+@@ -19,6 +19,11 @@ import (
+ 	"github.com/dundee/gdu/v5/pkg/device"
+ )
+ 
++const (
++	osWindows = "windows"
++	osPlan9   = "plan9"
++)
++
+ var (
+ 	af        *app.Flags
+ 	configErr error
+@@ -109,15 +114,33 @@ func init() {
+ 	setDefaults()
+ }
+ 
+-func initConfig() {
+-	setConfigFilePath()
+-	data, err := os.ReadFile(af.CfgFile)
++var systemConfigPath = "/etc/gdu.yaml"
++
++func loadConfig(path string) error {
++	data, err := os.ReadFile(path)
+ 	if err != nil {
+-		configErr = err
+-		return // config file does not exist, return
++		return err
++	}
++	return yaml.Unmarshal(data, &af)
++}
++
++func initConfig() {
++	// Load system-wide config first (ignored on Windows/Plan9 and when absent).
++	if runtime.GOOS != osWindows && runtime.GOOS != osPlan9 {
++		if err := loadConfig(systemConfigPath); err != nil && !os.IsNotExist(err) {
++			configErr = err
++			return
++		}
+ 	}
+ 
+-	configErr = yaml.Unmarshal(data, &af)
++	// Load user config; its values overwrite whatever the system config set.
++	setConfigFilePath()
++	if err := loadConfig(af.CfgFile); err != nil {
++		if !os.IsNotExist(err) {
++			configErr = err
++		}
++		return
++	}
+ }
+ 
+ func setDefaults() {
+@@ -195,7 +218,7 @@ func runE(command *cobra.Command, args [
+ 		}
+ 	}
+ 
+-	if runtime.GOOS == "windows" && af.LogFile == "/dev/null" {
++	if runtime.GOOS == osWindows && af.LogFile == "/dev/null" {
+ 		af.LogFile = "nul"
+ 	}
+ 
+@@ -223,7 +246,7 @@ func runE(command *cobra.Command, args [
+ 	istty := isatty.IsTerminal(os.Stdout.Fd())
+ 
+ 	// we are not able to analyze disk usage on Windows and Plan9
+-	if runtime.GOOS == "windows" || runtime.GOOS == "plan9" {
++	if runtime.GOOS == osWindows || runtime.GOOS == osPlan9 {
+ 		af.ShowApparentSize = true
+ 	}
+ 
+--- a/cmd/gdu/main_test.go
++++ b/cmd/gdu/main_test.go
+@@ -1,6 +1,12 @@
+ package main
+ 
+-import "testing"
++import (
++	"os"
++	"path/filepath"
++	"testing"
++
++	"github.com/dundee/gdu/v5/cmd/gdu/app"
++)
+ 
+ func TestNoViewFileFlagRegistered(t *testing.T) {
+ 	flag := rootCmd.Flags().Lookup("no-view-file")
+@@ -45,3 +51,61 @@ func TestInteractiveFlagCanBeSet(t *test
+ 		t.Fatal("expected Interactive to be true after setting flag")
+ 	}
+ }
++
++func TestInitConfigMalformedSystemConfig(t *testing.T) {
++	// Write invalid YAML to a temp file and point systemConfigPath at it.
++	tmp := filepath.Join(t.TempDir(), "gdu.yaml")
++	if err := os.WriteFile(tmp, []byte(":\tinvalid: yaml: {"), 0o600); err != nil {
++		t.Fatalf("could not write temp config: %v", err)
++	}
++
++	origPath := systemConfigPath
++	origErr := configErr
++	origAf := af
++	t.Cleanup(func() {
++		systemConfigPath = origPath
++		configErr = origErr
++		af = origAf
++	})
++
++	systemConfigPath = tmp
++	af = &app.Flags{}
++	configErr = nil
++
++	initConfig()
++
++	if configErr == nil {
++		t.Fatal("expected configErr to be set for malformed system config, got nil")
++	}
++}
++
++func TestInitConfigMalformedUserConfig(t *testing.T) {
++	// Write invalid YAML to a temp file and pass it via --config-file.
++	tmp := filepath.Join(t.TempDir(), "user.yaml")
++	if err := os.WriteFile(tmp, []byte(":\tinvalid: yaml: {"), 0o600); err != nil {
++		t.Fatalf("could not write temp config: %v", err)
++	}
++
++	origArgs := os.Args
++	origPath := systemConfigPath
++	origErr := configErr
++	origAf := af
++	t.Cleanup(func() {
++		os.Args = origArgs
++		systemConfigPath = origPath
++		configErr = origErr
++		af = origAf
++	})
++
++	// Point system config at a nonexistent path so it is skipped cleanly.
++	systemConfigPath = filepath.Join(t.TempDir(), "nonexistent.yaml")
++	os.Args = []string{"gdu", "--config-file=" + tmp}
++	af = &app.Flags{}
++	configErr = nil
++
++	initConfig()
++
++	if configErr == nil {
++		t.Fatal("expected configErr to be set for malformed user config, got nil")
++	}
++}


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

Gdu is the modern equivalent of ncdu, and is much faster returning results particularly on solid-state disks thanks to its utilization of parallel processing, period. It is perfectly fine for HDDs as well, but the performance gains are not on the same order of magnitude[1].

Beyond the speed benefits, it's worth noting that. The OpenWrt package for ncdu builds the version that is written in C[2] rather than the version written in zig which is faster. Merging gdu would allow the best option of supplying a fast alternative without the need for a host package for zig.

1. https://github.com/dundee/gdu#cold-cache
2. https://github.com/openwrt/packages/blob/master/utils/ncdu/Makefile#L11

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** x86/64-glibc
- **OpenWrt Device:** Intel N150

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
