### PR TITLE
frr: update to 10.6.1

### DIFF
--- a/net/frr/Makefile
+++ b/net/frr/Makefile
@@ -7,12 +7,12 @@
 
 include $(TOPDIR)/rules.mk
 PKG_NAME:=frr
-PKG_VERSION:=10.4.1
+PKG_VERSION:=10.6.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/FRRouting/frr/tar.gz/$(PKG_NAME)-$(PKG_VERSION)?
-PKG_HASH:=8e4003eaba168626c5ea7a6735f2c85c87b04214e6f8c8f2715b21f8ae40970b
+PKG_HASH:=35f2cb4328617261db687e1d4e400c7c491b41b3aa4a109d7da9ebff0cf7e402
 
 
 PKG_MAINTAINER:=Lucian Cristian <lucian.cristian@gmail.com>

--- a/net/frr/patches/997-reverse_python_test.patch
+++ b/net/frr/patches/997-reverse_python_test.patch
@@ -1,6 +1,6 @@
 --- a/configure.ac
 +++ b/configure.ac
-@@ -954,7 +954,6 @@ AC_DEFINE_UNQUOTED([DFLT_NAME], ["$DFLT_
+@@ -979,7 +979,6 @@ AC_DEFINE_UNQUOTED([DFLT_NAME], ["$DFLT_
  #
  
  AS_IF([test "$host" = "$build"], [


### PR DESCRIPTION
update frr to latest stable 10.6.1
tested x86_64

## 📦 Package Details

**Maintainer:** @lucize 
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [x] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
