### PR TITLE
bubblewrap: update to 0.11.2

### DIFF
--- a/utils/bubblewrap/Makefile
+++ b/utils/bubblewrap/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bubblewrap
-PKG_VERSION:=0.11.0
+PKG_VERSION:=0.11.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/containers/$(PKG_NAME)/releases/download/v$(PKG_VERSION)
-PKG_HASH:=988fd6b232dafa04b8b8198723efeaccdb3c6aa9c1c7936219d5791a8b7a8646
+PKG_HASH:=69abc30005d2186baf7737feacd8da35633b93cf5af38838ecff17c5f8e924f6
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=LGPLv2-or-later


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @dangowrt

**Description:**
Update bubblewrap to 0.11.2.

0.11.2 (CVE-2026-41163):
* In setuid mode, don't run the low-privileged parts of the setup as
  dumpable, as that allows it to be ptraced which can lead to problems.
* New build option `-Dsupport_setuid`, which if set to false (the
  default) disables the support for setuid.

0.11.1:
* Reset disposition of `SIGCHLD`, restoring normal subprocess management
  if bwrap was run from a process that was ignoring that signal.
* Don't ignore `--userns 0`, `--userns2 0` or `--pidns 0` if used.
* Fix grammar in an error message and a broken link in the docs.

Upstream NEWS: https://github.com/containers/bubblewrap/blob/v0.11.2/NEWS.md

---

## 🧪 Run Testing Details

- **OpenWrt Version:** master
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** (compile-only, no runtime testing)

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
