### PR TITLE
cni, cni-plugins: update to 1.3.0 / 1.9.1

### DIFF
--- a/utils/cni-plugins/Makefile
+++ b/utils/cni-plugins/Makefile
@@ -1,13 +1,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cni-plugins
-PKG_VERSION:=1.1.1
-PKG_RELEASE:=2
+PKG_VERSION:=1.9.1
+PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_VERSION:=v$(PKG_VERSION)
 PKG_SOURCE_URL:=https://github.com/containernetworking/plugins
-PKG_MIRROR_HASH:=4372700fa1fb159235586432800f228d92246d13571f5a29aa9bc58291eac6d9
+PKG_MIRROR_HASH:=26cbc77b2cd9e929cadd058787c5fed39fa5bce48f78b40bf6970f0a06d07a57
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>, Paul Spooren <mail@aparcar.org>
 PKG_LICENSE:=Apache-2.0

--- a/utils/cni/Makefile
+++ b/utils/cni/Makefile
@@ -1,14 +1,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cni
-PKG_VERSION:=1.1.2
+PKG_VERSION:=1.3.0
 PKG_RELEASE:=1
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/containernetworking/$(PKG_NAME)/archive/v$(PKG_VERSION)
-PKG_HASH:=7d4bcaf83acdd54b3dc216f7aa5b5e1b32cb797d9c6af601a2c26b97470ed743
+PKG_HASH:=aca115624f471218656e9b0cb04b768e1ac6af05b84e79264bad5ee9230798cf
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>, Paul Spooren <mail@aparcar.org>, Oskari Rauta <oskari.rauta@gmail.com>
 


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @dangowrt

**Description:**
Update the Container Network Interface stack:
* cni: 1.1.2 -> 1.3.0
* cni-plugins: 1.1.1 -> 1.9.1

CNI library now supports the DEL --force option, GC --valid-attachments,
new minimum Go version 1.21 and drops support for old plugin API
versions (<0.4.0).

cni-plugins covers a long span of releases (1.2.x – 1.9.x) including:
* portmap nftables backend, bandwidth optimisation
* bridge "vlanTrunk", DAD/PVID; macvlan/ipvlan "linkInContainer"
* dhcp option 121 classless static routes
* host-local single-IP ranges, firewall ingressPolicy with iptables/nft
* tuning tx queue length
* CVE/security Go module bumps; minimum Go version 1.23

Upstream changelogs:
* https://github.com/containernetworking/cni/releases/tag/v1.3.0
* https://github.com/containernetworking/plugins/blob/v1.9.1/CHANGELOG.md

---

## 🧪 Run Testing Details

- **OpenWrt Version:** master
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** (compile-only, no runtime testing)

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
