### PR TITLE
cryptsetup, lvm2: update to 2.8.6 / 2.03.40

### DIFF
--- a/utils/cryptsetup/Makefile
+++ b/utils/cryptsetup/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cryptsetup
-PKG_VERSION:=2.8.0
+PKG_VERSION:=2.8.6
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/linux/utils/cryptsetup/v$(subst $(space),.,$(wordlist 1, 2, $(subst .,$(space),$(PKG_VERSION))))
-PKG_HASH:=cc9e2d37c25a871cea37520b28d532207b0c1670fb10fc54d68071f63f5243a2
+PKG_HASH:=8004265fd993885d08f7b633dbe056851de1a210307613a4ebddc743fccefe5a
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=GPL-2.0-or-later LGPL-2.1-or-later

--- a/utils/lvm2/Makefile
+++ b/utils/lvm2/Makefile
@@ -9,15 +9,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=LVM2
-PKG_VERSION:=2.03.33
-PKG_VERSION_DM:=1.02.207
-PKG_RELEASE:=2
+PKG_VERSION:=2.03.40
+PKG_VERSION_DM:=1.02.209
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME).$(PKG_VERSION).tgz
 PKG_SOURCE_URL:=https://sourceware.org/pub/lvm2 \
                 https://www.mirrorservice.org/sites/sourceware.org/pub/lvm2
 
-PKG_HASH:=be4babd8a986d73279f1e75fbb1d33cb41559b75c2063611781bfeb8c2def139
+PKG_HASH:=60c9bb5c0a109f20267bb40ba50c00c84a110fc14c129f21afb5566929bf5645
 PKG_BUILD_DIR:=$(BUILD_DIR)/lvm2-$(BUILD_VARIANT)/$(PKG_NAME).$(PKG_VERSION)
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>

--- a/utils/lvm2/patches/002-const-stdio.patch
+++ b/utils/lvm2/patches/002-const-stdio.patch
@@ -1,6 +1,6 @@
 --- a/lib/commands/toolcontext.c
 +++ b/lib/commands/toolcontext.c
-@@ -1669,6 +1669,7 @@ struct cmd_context *create_toolcontext(u
+@@ -1668,6 +1668,7 @@ struct cmd_context *create_toolcontext(u
  	/* FIXME Make this configurable? */
  	reset_lvm_errno(1);
  
@@ -8,7 +8,7 @@
  	/* Set in/out stream buffering before glibc */
  	if (set_buffering
  	    && !cmd->running_on_valgrind /* Skipping within valgrind execution. */
-@@ -1713,6 +1714,7 @@ struct cmd_context *create_toolcontext(u
+@@ -1712,6 +1713,7 @@ struct cmd_context *create_toolcontext(u
  	} else if (!set_buffering)
  		/* Without buffering, must not use stdin/stdout */
  		init_silent(1);
@@ -16,7 +16,7 @@
  
  	/*
  	 * Environment variable LVM_SYSTEM_DIR overrides this below.
-@@ -2047,6 +2049,7 @@ void destroy_toolcontext(struct cmd_cont
+@@ -2050,6 +2052,7 @@ void destroy_toolcontext(struct cmd_cont
  	if (cmd->cft_def_hash)
  		dm_hash_destroy(cmd->cft_def_hash);
  
@@ -24,7 +24,7 @@
  	if (!cmd->running_on_valgrind && cmd->linebuffer) {
  		int flags;
  		/* Reset stream buffering to defaults */
-@@ -2070,6 +2073,7 @@ void destroy_toolcontext(struct cmd_cont
+@@ -2073,6 +2076,7 @@ void destroy_toolcontext(struct cmd_cont
  
  		free(cmd->linebuffer);
  	}
@@ -34,7 +34,7 @@
  
 --- a/tools/lvmcmdline.c
 +++ b/tools/lvmcmdline.c
-@@ -3404,6 +3404,7 @@ int lvm_split(char *str, int *argc, char
+@@ -3394,6 +3394,7 @@ int lvm_split(char *str, int *argc, char
  /* Make sure we have always valid filedescriptors 0,1,2 */
  static int _check_standard_fds(void)
  {
@@ -42,7 +42,7 @@
  	int err = is_valid_fd(STDERR_FILENO);
  
  	if (!is_valid_fd(STDIN_FILENO) &&
-@@ -3430,6 +3431,12 @@ static int _check_standard_fds(void)
+@@ -3420,6 +3421,12 @@ static int _check_standard_fds(void)
  		       strerror(errno));
  		return 0;
  	}

--- a/utils/lvm2/patches/003-no-mallinfo.patch
+++ b/utils/lvm2/patches/003-no-mallinfo.patch
@@ -1,6 +1,6 @@
 --- a/lib/mm/memlock.c
 +++ b/lib/mm/memlock.c
-@@ -199,12 +199,15 @@ static void _allocate_memory(void)
+@@ -201,12 +201,15 @@ static void _allocate_memory(void)
  	 *  memory on free(), this is good enough for our purposes.
  	 */
  	while (missing > 0) {
@@ -16,7 +16,7 @@
  		inf = MALLINFO();
  
  		if (hblks < inf.hblks) {
-@@ -214,9 +217,12 @@ static void _allocate_memory(void)
+@@ -216,9 +219,12 @@ static void _allocate_memory(void)
  			free(areas[area]);
  			_size_malloc_tmp /= 2;
  		} else {
@@ -27,9 +27,9 @@
  		}
 +#endif
  
- 		if (area == max_areas && missing > 0) {
+ 		if (area == MAX_AREAS && missing > 0) {
  			/* Too bad. Warn the user and proceed, as things are
-@@ -540,8 +546,13 @@ static void _lock_mem(struct cmd_context
+@@ -552,8 +558,13 @@ static void _lock_mem(struct cmd_context
  	 * will not block memory locked thread
  	 * Note: assuming _memlock_count_daemon is updated before _memlock_count
  	 */


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @dangowrt

**Description:**
Update disk-encryption / volume-manager stack:
* cryptsetup: 2.8.4 -> 2.8.6
* lvm2: 2.03.33 -> 2.03.40 (libdm 1.02.207 -> 1.02.209)

cryptsetup 2.8.6 is a stable bug-fix release. All users of 2.8.x
should upgrade. Highlights since 2.8.4:
* Fix FileVault metadata parsing crash with crafted images.
* Fix reading FileVault image metadata from incorrect offset.
* OpenSSL backend: increase the number of allowed threads to 64.
* Fix LUKS2 reencryption lock name.
* UUID match check on resume; specific error for failed detached
  header allocation; LibreSSL build fix; Meson configuration
  parity fixes; many AI-assisted code fixes.

lvm2 2.03.40 covers seven point releases since 2.03.33:
* atomic leases via Compare-and-Write (CAW) in lvmlockd.
* persistent reservation support on a VG.
* new lvm-index(7), lvm-categories(7), lvm-args(7) man pages.
* Switched internal device_mapper consumers to libdm.
* Many bug fixes throughout (lock leaks, dmeventd remonitoring,
  raid health reporting, vgreduce, vgsplit, ...).

The bundled libdm version is bumped from 1.02.207 to 1.02.209;
no user-visible changes documented in WHATS_NEW_DM.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** master
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** (compile-only, no runtime testing)

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
