### PR TITLE
ell: update to 0.83 (and rebuild mptcpd)

### DIFF
--- a/libs/ell/Makefile
+++ b/libs/ell/Makefile
@@ -1,13 +1,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ell
-PKG_VERSION:=0.82
+PKG_VERSION:=0.83
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://git.kernel.org/pub/scm/libs/ell/ell.git
 PKG_SOURCE_VERSION:=$(PKG_VERSION)
-PKG_MIRROR_HASH:=2c918e0a9451729830f7ccb502b651c58f764ec37a172447613d4d66c12e22b1
+PKG_MIRROR_HASH:=a590b3ef07f05aa62e8cf4081a07fbb1f835eb6d77e945d7b39afdb1746f4c7a
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=GPL-2.0-only

--- a/net/mptcpd/Makefile
+++ b/net/mptcpd/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mptcpd
 PKG_VERSION:=0.14
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/multipath-tcp/mptcpd/releases/download/v$(PKG_VERSION)


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @dangowrt

**Description:**
Update Embedded Linux Library to 0.83 and rebuild its only
consumer (mptcpd) against the new version.

ell 0.83 changes since 0.82:
* Fix issue with PKCS#8 unit tests.
* Add additional test vectors for AES-CCM.

mptcpd is bumped only via PKG_RELEASE so it gets rebuilt against
the updated libell.

Upstream changelog:
* https://git.kernel.org/pub/scm/libs/ell/ell.git/log/?h=0.83

---

## 🧪 Run Testing Details

- **OpenWrt Version:** master
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** (compile-only, no runtime testing)

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
