### PR TITLE
exfatprogs: update to 1.3.2

### DIFF
--- a/utils/exfatprogs/Makefile
+++ b/utils/exfatprogs/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=exfatprogs
-PKG_VERSION:=1.2.9
+PKG_VERSION:=1.3.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/exfatprogs/exfatprogs/releases/download/$(PKG_VERSION)
-PKG_HASH:=d9a42197c6ff9e6a8e923789413008e317415cf7a4ab85c486c5ffcaf49ca175
+PKG_HASH:=67ddb50543636292df8fde58117eefd54210d6cd7bf1eea5e91d2c4dccbc425e
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=GPL-2.0-only


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @dangowrt

**Description:**
Update exfatprogs to 1.3.2.

1.3.2 (2026-03-09):
* fsck.exfat: option to show a progress bar
* mkfs.exfat: discard blocks prior to write outs by default
* mkfs.exfat: read-after-write verification of the volume boot record
* exfatprogs: adjust utility exit codes
* dump.exfat: handle paths including '.', '..', and repeated '/'
* fsck.exfat: convert 0x80 entries into deleted file entries

1.3.1 (2025-12-15):
* fsck.exfat: support repairing the allocation bitmap size
* exfatprogs: temporarily disable building defrag.exfat (data loss)
* libexfat: fix a NULL pointer dereference in read_file_dentry_set()

1.3.0 (2025-10-15):
* defrag.exfat: new tool to defragment an exFAT filesystem
* mkfs.exfat: minimize zero-out initialization in quick format mode
* fsck.exfat: set the entry after an unused entry as unused
* Various bug fixes

Upstream NEWS: https://github.com/exfatprogs/exfatprogs/blob/1.3.2/NEWS

---

## 🧪 Run Testing Details

- **OpenWrt Version:** master
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** (compile-only, no runtime testing)

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
