### PR TITLE
exim: update to 4.99.3 (security release — EXIM-Security-2026-05-01.1)

### DIFF
--- a/mail/exim/Makefile
+++ b/mail/exim/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=exim
-PKG_VERSION:=4.99
+PKG_VERSION:=4.99.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://downloads.exim.org/exim4/
-PKG_HASH:=5df38b042ffa9a9c8d31b20bc8481558070e361b06f657608622a62a327adcba
+PKG_HASH:=663e76d2a0d9b8fc5b373d0008e44ae044f10feb22bc9dbae8c7f21345ebfb3b
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 
 PKG_LICENSE:=GPL-2.0-or-later


### PR DESCRIPTION
**Maintainer:** @dangowrt

4.99.3 (security release):
 * Addresses EXIM-Security-2026-05-01.1: a remotely reachable
   Use-After-Free vulnerability in Exim's BDAT (binary data
   transmission) body parsing path when using the GnuTLS
   backend. This can lead to heap corruption and potential code
   execution. Affects 4.97 through 4.99.x when built with GnuTLS
   support AND with STARTTLS and CHUNKING advertised.
   Reported by xbow security.

Previous security releases folded into this bump:

4.99.2 (security release):
 * Addresses Exim-Security-2026-04.1, covering 4 CVEs:
   - CVE-2026-40684: Possible crash with malicious DNS data (musl libc)
   - CVE-2026-40685: Possible OOB read/write on corrupt JSON in header
   - CVE-2026-40686: Possible OOB read with large UTF8 trailing characters
   - CVE-2026-40687: Possible OOB read/write with SPA authenticator

4.99.1 (security release):
 * Re-incarnation of CVE-2025-26794, ports fixes from 4.98.1/4.98.2.

Link: https://exim.org/static/doc/security/EXIM-Security-2026-05-01.1/
Link: https://git.exim.org/exim.git/blob/refs/tags/exim-4.99.3:/doc/doc-txt/ChangeLog

