### PR TITLE
gcem, fluidsynth: new gcem build-dep + fluidsynth 2.5.4

### DIFF
--- a/libs/gcem/Makefile
+++ b/libs/gcem/Makefile
@@ -1,0 +1,55 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=gcem
+PKG_RELEASE:=1
+
+# gcem upstream tags only sporadically; pin to the commit that fluidsynth
+# 2.5.x's FindGCEM.cmake / submodule references. Update in lockstep with
+# the consumer's expected revision.
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/kthohr/gcem.git
+PKG_SOURCE_DATE:=2024-04-28
+PKG_SOURCE_VERSION:=012ae73c6d0a2cb09ffe86475f5c6fba3926e200
+PKG_MIRROR_HASH:=70df878c9d85281c6816c231cbb320a9eccb4fb73ef32612cf8948b17716fc49
+
+PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
+PKG_LICENSE:=Apache-2.0
+PKG_LICENSE_FILES:=LICENSE
+
+CMAKE_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+# upstream CMakeLists.txt declares cmake_minimum_required(VERSION 3.1),
+# which trips modern CMake's deprecated-policy guard.
+CMAKE_OPTIONS += \
+	-DCMAKE_POLICY_VERSION_MINIMUM=3.5
+
+define Package/gcem
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=GCE-Math header-only constexpr math library
+  URL:=https://github.com/kthohr/gcem
+  BUILDONLY:=1
+endef
+
+define Package/gcem/description
+GCE-Math (Generalized Constant Expression Math) is a templated C++
+library enabling compile-time computation of mathematical functions.
+Header-only; consumed at build time only.
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/gcem.hpp $(1)/usr/include/
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/gcem_incl $(1)/usr/include/
+	$(INSTALL_DIR) $(1)/usr/lib/cmake/gcem
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/cmake/gcem/* $(1)/usr/lib/cmake/gcem/
+endef
+
+define Package/gcem/install
+	:
+endef
+
+$(eval $(call BuildPackage,gcem))

--- a/sound/fluidsynth/Makefile
+++ b/sound/fluidsynth/Makefile
@@ -1,17 +1,22 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fluidsynth
-PKG_VERSION:=2.4.7
+PKG_VERSION:=2.5.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/FluidSynth/fluidsynth/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=7fb0e328c66a24161049e2b9e27c3b6e51a6904b31b1a647f73cc1f322523e88
+PKG_HASH:=72f5720328fe44e2e5c67813885f0a6b4b004d048bd2eeeb0c0064074ebff530
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=LGPL-2.1
 PKG_LICENSE_FILES:=LICENSE
 PKG_CPE_ID:=cpe:/a:fluidsynth:fluidsynth
+
+# fluidsynth >= 2.5 build-depends on the gcem header-only constexpr math
+# library; the OpenWrt 'gcem' package installs its headers and CMake
+# config files into staging so find_package(GCEM) resolves there.
+PKG_BUILD_DEPENDS:=gcem
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk


### PR DESCRIPTION
**Maintainer:** @dangowrt

This PR introduces a new `gcem` package and updates `fluidsynth` to
2.5.4 to consume it.

## `gcem`: new package

GCE-Math (Generalized Constant Expression Math) is a header-only
templated C++ library for compile-time computation of mathematical
functions. Pinned to commit `012ae73c` (2024-04-28), the revision
referenced by fluidsynth 2.5.x's bundled `FindGCEM.cmake` / git
submodule. `BUILDONLY:=1`, headers + CMake config installed into
staging_dir for downstream consumers.

Upstream: https://github.com/kthohr/gcem

## `fluidsynth`: update to 2.5.4 (from 2.4.7)

Highlights:
* 2.5.x major version with API additions for sequencer client
  unregistration, MIDI file reading flexibility, soundfont selectors
  and sample tuning improvements.
* Bug fixes for SF3 voice handling, reverb engine stability,
  GM/GS/XT mode reset behaviour and audio drivers (PortAudio, SDL2,
  Pulseaudio, JACK, OPL).
* Build system fixes including CMake updates and new toolchain
  compatibility.

fluidsynth >= 2.5 newly requires GCEM at build time. Rather than
embed the gcem source into the fluidsynth Makefile (which would
fall back to upstream's CMake-time GitHub download in offline CI,
or duplicate the download/extract dance in fluidsynth's own
`Build/Prepare`), this PR adds gcem as its own package and wires
fluidsynth's `PKG_BUILD_DEPENDS:=gcem`. `find_package(GCEM REQUIRED)`
then resolves cleanly against the staging-dir copy:

```
-- Found GCEM: /…/staging_dir/target-…_musl/usr/include
```

gcem is header-only (CMake `INTERFACE` target), so there is nothing
to dynamically link; the dependency exists only at build time.

Upstream:
* https://github.com/FluidSynth/fluidsynth/releases/tag/v2.5.4
* https://github.com/FluidSynth/fluidsynth/wiki/ReleaseNotes
