### PR TITLE
gawk: update to 5.4.0

### DIFF
--- a/utils/gawk/Makefile
+++ b/utils/gawk/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gawk
-PKG_VERSION:=5.3.2
+PKG_VERSION:=5.4.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNU/gawk
-PKG_HASH:=f8c3486509de705192138b00ef2c00bbbdd0e84c30d5c07d23fc73a9dc4cc9cc
+PKG_HASH:=3dd430f0cd3b4428c6c3f6afc021b9cd3c1f8c93f7a688dc268ca428a90b4ac1
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=GPL-3.0-or-later


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @dangowrt

**Description:**
Update gawk to 5.4.0.

Major release. Changes from 5.3.x to 5.4.0:
* Use Mike Haertel's MinRX regular expression matcher by default.
  The old regex and dfa engines are still available.
* New @nsinclude directive: like @include but doesn't reset the
  namespace to "awk".
* lshift()/rshift() return 0 when shifting more bits than uintmax_t.
* Persistent memory: store meta-info in backing file, warn on
  version mismatch, allow dynamic extensions with persistent memory.
* ordchr extension now supports multibyte / wide characters.
* length(array) is no longer an extension (POSIX 2024).
* --traditional rationalised to match BWK awk behaviour.
* Assertions are now enabled in the C code.
* Hexadecimal floating-point values may now be used in source,
  strtonum() and -n/--non-decimal-data option.
* UDP networking support is now deprecated, will be removed in 6.0.
* Reading regular disk input files is somewhat faster.

Upstream NEWS:
* https://git.savannah.gnu.org/cgit/gawk.git/plain/NEWS?h=gawk-5.4.0

---

## 🧪 Run Testing Details

- **OpenWrt Version:** master
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** (compile-only, no runtime testing)

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
