### PR TITLE
gnupg2: update to 2.5.19

### DIFF
--- a/utils/gnupg2/Makefile
+++ b/utils/gnupg2/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gnupg
-PKG_VERSION:=2.4.8
+PKG_VERSION:=2.5.19
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://gnupg.org/ftp/gcrypt/gnupg
-PKG_HASH:=b58c80d79b04d3243ff49c1c3fc6b5f83138eb3784689563bcdd060595318616
+PKG_HASH:=722aa8a426dd9b44e0d194b73bfee3a3e617d65674cd4d1d062e6df29f1788c6
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=GPL-3.0-or-later


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @dangowrt

**Description:**
Update gnupg2 to 2.5.19.

Switch from the LTS 2.4.x series to the current 2.5.x development
branch leading up to GnuPG 2.6.

Highlights of changes since 2.4.8:
* New OpenPGP key formats: Curve25519 and Curve448 (RFC9580)
* SHA3 family signature support
* Kyber post-quantum hybrid keys
* KEM (Key Encapsulation Mechanism) operations
* dirmngr: improved LDAP and HTTP keyserver support
* scdaemon: better support for new smartcard tokens
* Many bug fixes and security improvements

Upstream NEWS:
* https://dev.gnupg.org/source/gnupg/browse/master/NEWS
* https://gnupg.org/download/release_notes.html

---

## 🧪 Run Testing Details

- **OpenWrt Version:** master
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** (compile-only, no runtime testing)

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
