### PR TITLE
gpgme: update to 2.0.1

### DIFF
--- a/libs/gpgme/Makefile
+++ b/libs/gpgme/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gpgme
-PKG_VERSION:=1.24.2
+PKG_VERSION:=2.0.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://gnupg.org/ftp/gcrypt/$(PKG_NAME)
-PKG_HASH:=e11b1a0e361777e9e55f48a03d89096e2abf08c63d84b7017cfe1dce06639581
+PKG_HASH:=821ab0695c842eab51752a81980c92b0410c7eadd04103f791d5d2a526784966
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=LGPL-2.1-or-later
@@ -27,14 +27,6 @@ define Package/libgpgme
   DEPENDS:=+libassuan +libgpg-error
 endef
 
-define Package/libgpgmepp
-  SECTION:=libs
-  CATEGORY:=Libraries
-  TITLE:=GnuPG Made Easy (GPGME) library (C++)
-  URL:=https://gnupg.org/software/gpgme/index.html
-  DEPENDS:=+libgpgme +libstdcpp
-endef
-
 define Package/libgpgme/description
 GnuPG Made Easy (GPGME) is a library designed to make access to GnuPG
 easier for applications. It provides a High-Level Crypto API for
@@ -51,20 +43,17 @@ CONFIGURE_ARGS += \
 	--disable-gpg-test \
 	--disable-gpgsm-test \
 	--disable-g13-test \
-	--enable-languages="cpp"
+	--enable-languages=""
 
 ifneq ($(CONFIG_USE_MUSL),)
   TARGET_CFLAGS += -D_LARGEFILE64_SOURCE
 endif
 
 define Build/InstallDev
-	$(INSTALL_DIR) $(1)/usr/include/gpgme++
+	$(INSTALL_DIR) $(1)/usr/include
 	$(INSTALL_DATA) \
 		$(PKG_INSTALL_DIR)/usr/include/gpgme.h \
 		$(1)/usr/include/
-	$(INSTALL_DATA) \
-		$(PKG_INSTALL_DIR)/usr/include/gpgme++/*.h \
-		$(1)/usr/include/gpgme++/
 
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) \
@@ -84,11 +73,6 @@ define Build/InstallDev
 		$(PKG_INSTALL_DIR)/usr/lib/pkgconfig/gpgme-glib.pc \
 		$(1)/usr/lib/pkgconfig
 
-	$(INSTALL_DIR) $(1)/usr/lib/cmake/Gpgmepp
-	$(INSTALL_DATA) \
-		$(PKG_INSTALL_DIR)/usr/lib/cmake/Gpgmepp/*.cmake \
-		$(1)/usr/lib/cmake/Gpgmepp
-
 	$(INSTALL_DIR) $(2)/bin $(1)/usr/bin
 	$(INSTALL_BIN) \
 		$(PKG_INSTALL_DIR)/usr/bin/gpgme-config \
@@ -104,10 +88,4 @@ define Package/libgpgme/install
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgpgme.so.* $(1)/usr/lib/
 endef
 
-define Package/libgpgmepp/install
-	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgpgmepp.so.* $(1)/usr/lib/
-endef
-
 $(eval $(call BuildPackage,libgpgme))
-$(eval $(call BuildPackage,libgpgmepp))


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @dangowrt

**Description:**
Update gpgme to 2.0.1 (major version update from 1.24.2).

Major change: the C++, Qt, and Python bindings have been split off
upstream into separate releases. The libgpgmepp subpackage is
therefore dropped here too; consumers needing C++ bindings will
have to wait until gpgme++ is packaged separately.

Changes from 1.24.x to 2.0.x:
* New gpgme_op_random_bytes / gpgme_op_random_value functions to
  get cryptographically strong random data from gpg.
* New decrypt flag to skip actual decryption so information about
  recipients can be retrieved.
* New flag for key generation to mark a (sub)key as group owned.
* gpgme_signers_add: when key was retrieved with fingerprint!'!'
  suffix, the requested subkey is used for signing.
* timestamp/expires fields changed from signed long to unsigned
  long for better 32bit time_t support.
* Removed long-deprecated gpgme_attr_t enums and functions.
* Removed never-implemented GPGME_EXPORT_MODE_NOUID flag.
* Removed entire trustlist feature.

2.0.1:
* Adjust for changes to the posix test(1) command.
* Extend internal gpgsm_assuan_simple_command to consume diag
  output (fixes possible lockup).

Drop --enable-languages=cpp from configure args (no longer
supported), drop the C++ headers, cmake bits and libgpgmepp
shared library from Build/InstallDev, and remove the libgpgmepp
Package definition.

Upstream NEWS:
* https://dev.gnupg.org/source/gpgme/browse/master/NEWS

---

## 🧪 Run Testing Details

- **OpenWrt Version:** master
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** (compile-only, no runtime testing)

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
