### PR TITLE
inotify-tools: update to 4.25.9.0

### DIFF
--- a/utils/inotify-tools/Makefile
+++ b/utils/inotify-tools/Makefile
@@ -1,9 +1,9 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=inotify-tools
-PKG_VERSION:=4.23.9.0
-PKG_HASH:=1dfa33f80b6797ce2f6c01f454fd486d30be4dca1b0c5c2ea9ba3c30a5c39855
-PKG_RELEASE:=2
+PKG_VERSION:=4.25.9.0
+PKG_HASH:=d33a4fd24c72c2d08893f129d724adf725b93dae96c359e4f4e9f32573cc853b
+PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=https://codeload.github.com/rvoicilas/inotify-tools/tar.gz/$(PKG_VERSION)?
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz

--- a/utils/inotify-tools/patches/100-fix-version.patch
+++ b/utils/inotify-tools/patches/100-fix-version.patch
@@ -1,0 +1,11 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -2,7 +2,7 @@
+ # Process this file with autoconf to produce a configure script.
+ 
+ AC_PREREQ(2.59)
+-AC_INIT([inotify-tools], [4.23.9.0])
++AC_INIT([inotify-tools], [4.25.9.0])
+ AC_CONFIG_AUX_DIR([config])
+ AC_CONFIG_SRCDIR([src/inotifywait.cpp])
+ AC_CONFIG_HEADERS([config.h])


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @dangowrt

**Description:**
Update inotify-tools to 4.25.9.0.

The 4.25.9.0 release brings various fixes and updates accumulated
since 4.23 including build system fixes, smaller bug fixes and
maintenance updates.

Upstream:
* https://github.com/inotify-tools/inotify-tools/releases/tag/4.25.9.0
* https://github.com/inotify-tools/inotify-tools/blob/4.25.9.0/ChangeLog

---

## 🧪 Run Testing Details

- **OpenWrt Version:** master
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** (compile-only, no runtime testing)

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
