### PR TITLE
libcurl-gnutls: update to 8.20.0

### DIFF
--- a/net/libcurl-gnutls/Makefile
+++ b/net/libcurl-gnutls/Makefile
@@ -10,12 +10,12 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=libcurl-gnutls
 
 PKG_SOURCE_NAME:=curl
-PKG_VERSION:=8.14.1
+PKG_VERSION:=8.20.0
 PKG_RELEASE:=1
 PKG_SOURCE:=$(PKG_SOURCE_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/curl/curl/releases/download/curl-$(subst .,_,$(PKG_VERSION))/ \
 	https://curl.se/download/
-PKG_HASH:=f4619a1e2474c4bbfedc88a7c2191209c8334b48fa1f4e53fd584cc12e9120dd
+PKG_HASH:=63fe2dc148ba0ceae89922ef838f7e5c946272c2e78b7c59fab4b79d3ce2b896
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @dangowrt

**Description:**
Update libcurl-gnutls to 8.20.0.

Tracks upstream curl 8.20.0 (April 2026 release).

Highlights of changes since 8.14.1:
* async-thrdd: use thread queue for resolving
* build: make NTLM disabled by default
* lib: add thread pool and queue
* lib: drop support for < c-ares 1.16.0
* lib: make SMB support opt-in
* multi.h: add CURLMNWC_CLEAR_ALL
* rtmp: drop support
* cmake: drop support for CMake 3.17 and older
* Various TLS, HTTP/3, altsvc and resolver bug fixes.

Upstream release notes:
* https://curl.se/changes.html#8_20_0
* https://github.com/curl/curl/blob/curl-8_20_0/RELEASE-NOTES

---

## 🧪 Run Testing Details

- **OpenWrt Version:** master
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** (compile-only, no runtime testing)

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
