### PR TITLE
libevdev: update to 1.13.6

### DIFF
--- a/libs/libevdev/Makefile
+++ b/libs/libevdev/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libevdev
-PKG_VERSION:=1.13.4
+PKG_VERSION:=1.13.6
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.freedesktop.org/software/libevdev/
-PKG_HASH:=f00ab8d42ad8b905296fab67e13b871f1a424839331516642100f82ad88127cd
+PKG_HASH:=73f215eccbd8233f414737ac06bca2687e67c44b97d2d7576091aa9718551110
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @dangowrt

**Description:**
Update libevdev to 1.13.6.

Minor update from 1.13.4 with new EV_KEY/EV_ABS code definitions
synced with the latest kernel input headers, plus various bug fixes
and tooling improvements.

Upstream:
* https://gitlab.freedesktop.org/libevdev/libevdev/-/tags/libevdev-1.13.6

---

## 🧪 Run Testing Details

- **OpenWrt Version:** master
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** (compile-only, no runtime testing)

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
