### PR TITLE
libksba: update to 1.6.8

### DIFF
--- a/libs/libksba/Makefile
+++ b/libs/libksba/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libksba
-PKG_VERSION:=1.6.7
+PKG_VERSION:=1.6.8
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://gnupg.org/ftp/gcrypt/$(PKG_NAME)
-PKG_HASH:=cf72510b8ebb4eb6693eef765749d83677a03c79291a311040a5bfd79baab763
+PKG_HASH:=0f4510f1c7a679c3545990a31479f391ad45d84e039176309d42f80cf41743f5
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=LGPL-3.0-or-later GPL-2.0-or-later


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @dangowrt

**Description:**
Update libksba to 1.6.8.

Changes since 1.6.7:
* Fix double increment in DN parser while counting hexdigits.
* Fix a memory leak in the BER decoder's error handling.
* Fix an assertion failure in the OCSP code.
* Support SHA256 based CertIDs in OCSP.
* Use nonstring attribute for gcc-15.
* Remove remaining WindowsCE support.

Upstream NEWS:
* https://dev.gnupg.org/source/libksba/browse/master/NEWS

---

## 🧪 Run Testing Details

- **OpenWrt Version:** master
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** (compile-only, no runtime testing)

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
