### PR TITLE
libwacom: update to 2.18.0

### DIFF
--- a/libs/libwacom/Makefile
+++ b/libs/libwacom/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libwacom
-PKG_VERSION:=2.16.1
+PKG_VERSION:=2.18.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/linuxwacom/$(PKG_NAME)/releases/download/$(PKG_NAME)-$(PKG_VERSION)/
-PKG_HASH:=0f9bc90babad92b2c4c6571b53af3aee065f437cce01c06c860599e1a10680aa
+PKG_HASH:=7dbb9ab37df9df47ae2fdbb644916c986728291749bcd5ad8bcaa26f1e15f002
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @dangowrt

**Description:**
Update libwacom to 2.18.0.

Changes since 2.16.1:

2.18.0:
* New Devices: XP-Pen Deco MW (bluetooth), Deco02; Huion Kamvas Pro 19;
  Lenovo ThinkVision M14t Gen 2.
* New API: libwacom_stylus_is_generic() returns true for generic
  styli that are added by libwacom.

2.17.0:
* New Devices: Dell Inspiron 14 7445 2-in-1; Wacom One 14;
  Huion Kamvas 13 (Gen 3), Kamvas 16 (Gen 3); Waltop Batteryless
  Tablet; XP-Pen Deco Pro LW (Gen 2).
* Wacom styli IDs updated and aliased in preparation for upcoming
  kernel changes.

Upstream NEWS:
* https://github.com/linuxwacom/libwacom/blob/libwacom-2.18.0/NEWS

---

## 🧪 Run Testing Details

- **OpenWrt Version:** master
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** (compile-only, no runtime testing)

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
