### PR TITLE
libxmp: update to 4.7.0

### DIFF
--- a/sound/libxmp/Makefile
+++ b/sound/libxmp/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libxmp
-PKG_VERSION:=4.6.3
+PKG_VERSION:=4.7.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/$(PKG_NAME)/$(PKG_NAME)/releases/download/$(PKG_NAME)-$(PKG_VERSION)
-PKG_HASH:=b189a2ff3f3eef0008512e0fb27c2cdc27480bc1066b82590a84d02548fab96d
+PKG_HASH:=b6251de1859352c6988752563d60983cb8aa9fd7dfe9f81b8bc6688da47f3464
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @dangowrt

**Description:**
Update libxmp to 4.7.0.

A substantial release with many new features and module format
fixes since 4.6.3.

Highlights:
* Increase maximum sampling rate (XMP_MAX_SRATE) to 768000.
* xmp_seek_time now always seeks; new xmp_seek_time_frame for
  frame-accurate seeking.
* New tempo factor APIs: xmp_set_tempo_factor_relative,
  xmp_get_tempo_factor, xmp_get_tempo_factor_relative.
* New API define XMP_FORMAT_32BIT to enable 32-bit integer output.
* New API defines XMP_INST_NO_DEFAULT_PAN, XMP_MARK_SKIP,
  XMP_MARK_END.
* Add support for Pack-Ice depacking and Software Visions DMF
  (Apocalypse Abyss MOD variant).
* Internal module time/duration calculations now use doubles.
* Numerous bug fixes across MOD, XM, S3M, IT, RTM, MED, Funktracker,
  Imago Orpheus IMF, Liquid Tracker LIQ, DigiBooster Pro, IMS and
  other formats.

Upstream changelog:
* https://github.com/libxmp/libxmp/blob/libxmp-4.7.0/docs/Changelog

---

## 🧪 Run Testing Details

- **OpenWrt Version:** master
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** (compile-only, no runtime testing)

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
