### PR TITLE
openal-soft: update to 1.25.1

### DIFF
--- a/sound/openal-soft/Makefile
+++ b/sound/openal-soft/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openal-soft
-PKG_VERSION:=1.24.3
+PKG_VERSION:=1.25.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/kcat/openal-soft/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=7e1fecdeb45e7f78722b776c5cf30bd33934b961d7fd2a11e0494e064cc631ce
+PKG_HASH:=5f8efe8dfba5e9307a50251ba615ace857c7fa9dddfe34130b83e213d7f7cf24
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=LGPL-2.0-only BSD-3-Clause


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @dangowrt

**Description:**
Update openal-soft to 1.25.1.

1.25.1:
* Fixed the OpenSL and JACK backends.
* Fixed WASAPI and CoreAudio capture.
* Fixed building the OSS backend with OSS v4.
* Fixed a debug assertion with HRTF enabled.
* Fixed an STL hardening assertion in the polyphase resampler.
* Added a new stereo-encoding option for Tetraphonic Surround Matrix
  Encoding.

1.25.0:
* Updated library codebase to C++20.
* Fixed alcIsExtensionPresent to do a case-insensitive compare.
* Fixed potential noise when switching reverbs.
* Fixed reverb panning with certain output modes.
* Fixed retrieving the alGetProcAddressDirect extension function.
* Fixed negative source offsets with a callback buffer.
* Added build options for STL hardening (default ON for performant
  checks).
* Added support for fourth-order ambisonics.
* Added support for CAF files to the Wave Writer backend.
* Added optional support for C++20 modules.
* Updated alsoft-config to Qt6.
* Changed default period size to 512 sample frames.

Upstream:
* https://github.com/kcat/openal-soft/blob/1.25.1/ChangeLog

---

## 🧪 Run Testing Details

- **OpenWrt Version:** master
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** (compile-only, no runtime testing)

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
