### PR TITLE
postgresql: update to 18.3

### DIFF
--- a/libs/postgresql/Makefile
+++ b/libs/postgresql/Makefile
@@ -5,8 +5,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=postgresql
-PKG_VERSION:=17.5
-PKG_RELEASE:=3
+PKG_VERSION:=18.3
+PKG_RELEASE:=1
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=PostgreSQL
 PKG_CPE_ID:=cpe:/a:postgresql:postgresql
@@ -16,7 +16,7 @@ PKG_SOURCE_URL:=\
 	https://ftp.postgresql.org/pub/source/v$(PKG_VERSION) \
 	http://ftp.postgresql.org/pub/source/v$(PKG_VERSION)
 
-PKG_HASH:=fcb7ab38e23b264d1902cb25e6adafb4525a6ebcbd015434aeef9eda80f528d8
+PKG_HASH:=d95663fbbf3a80f81a9d98d895266bdcb74ba274bcc04ef6d76630a72dee016f
 
 PKG_BUILD_FLAGS:=no-mips16
 PKG_FIXUP:=autoreconf
@@ -236,7 +236,6 @@ define Build/InstallDev
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/pg_config.h $(1)/usr/include/
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/pg_config_manual.h $(1)/usr/include/
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/postgres_ext.h $(1)/usr/include/
-	$(CP) $(PKG_INSTALL_DIR)/usr/include/pg_config_ext.h $(1)/usr/include/
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/postgresql $(1)/usr/include/
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libpq.{a,so*} $(1)/usr/lib/

--- a/libs/postgresql/patches/900-pg_ctl-setuid.patch
+++ b/libs/postgresql/patches/900-pg_ctl-setuid.patch
@@ -1,6 +1,6 @@
 --- a/src/bin/pg_ctl/pg_ctl.c
 +++ b/src/bin/pg_ctl/pg_ctl.c
-@@ -91,6 +91,7 @@ static char *event_source = NULL;
+@@ -92,6 +92,7 @@ static char *event_source = NULL;
  static char *register_servicename = "PostgreSQL";	/* FIXME: + version ID? */
  static char *register_username = NULL;
  static char *register_password = NULL;
@@ -8,7 +8,7 @@
  static char *argv0 = NULL;
  static bool allow_core_files = false;
  static time_t start_time;
-@@ -1988,6 +1989,9 @@ do_help(void)
+@@ -2000,6 +2001,9 @@ do_help(void)
  #endif
  	printf(_("  -s, --silent           only print errors, no informational messages\n"));
  	printf(_("  -t, --timeout=SECS     seconds to wait when using -w option\n"));
@@ -18,7 +18,7 @@
  	printf(_("  -V, --version          output version information, then exit\n"));
  	printf(_("  -w, --wait             wait until operation completes (default)\n"));
  	printf(_("  -W, --no-wait          do not wait until operation completes\n"));
-@@ -2200,6 +2204,7 @@ main(int argc, char **argv)
+@@ -2212,6 +2216,7 @@ main(int argc, char **argv)
  		{"options", required_argument, NULL, 'o'},
  		{"silent", no_argument, NULL, 's'},
  		{"timeout", required_argument, NULL, 't'},
@@ -26,7 +26,7 @@
  		{"core-files", no_argument, NULL, 'c'},
  		{"wait", no_argument, NULL, 'w'},
  		{"no-wait", no_argument, NULL, 'W'},
-@@ -2240,20 +2245,6 @@ main(int argc, char **argv)
+@@ -2252,20 +2257,6 @@ main(int argc, char **argv)
  		}
  	}
  
@@ -47,7 +47,7 @@
  
  	env_wait = getenv("PGCTLTIMEOUT");
  	if (env_wait != NULL)
-@@ -2328,11 +2319,15 @@ main(int argc, char **argv)
+@@ -2340,11 +2331,15 @@ main(int argc, char **argv)
  				wait_seconds_arg = true;
  				break;
  			case 'U':
@@ -63,7 +63,7 @@
  				break;
  			case 'w':
  				do_wait = true;
-@@ -2413,6 +2408,41 @@ main(int argc, char **argv)
+@@ -2425,6 +2420,41 @@ main(int argc, char **argv)
  		exit(1);
  	}
  


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @dangowrt

**Description:**
Update postgresql to 18.3.

Major version update from 17.5 to 18.3.

PostgreSQL 18 (released September 2025, GA stable) brings:
* Asynchronous I/O (AIO) for shared buffers, sequential scans,
  bitmap heap scans and pg_prewarm.
* Skip scans for B-tree indexes.
* Performance improvements for partition pruning.
* Logical replication: improved replication of generated columns,
  protocol version 5.
* Native UUIDv7 support.
* Larger I/O for sequential and parallel scans.
* Concurrent reindex of partitioned tables.
* pg_dump: --filter for selective dumps.
* Numerous SQL/JSON improvements.
* New built-in role pg_signal_autovacuum_worker.

18.3 is the third maintenance release with bug fixes since 18.0.

Drop the now obsolete pg_config_ext.h copy in Build/InstallDev:
this header has been removed upstream in PostgreSQL 18.

Upstream:
* https://www.postgresql.org/docs/release/18.0/
* https://www.postgresql.org/docs/release/18.3/

---

## 🧪 Run Testing Details

- **OpenWrt Version:** master
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** (compile-only, no runtime testing)

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
