### PR TITLE
wavpack: update to 5.9.0

### DIFF
--- a/sound/wavpack/Makefile
+++ b/sound/wavpack/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wavpack
-PKG_VERSION:=5.8.1
+PKG_VERSION:=5.9.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.wavpack.com/
-PKG_HASH:=7322775498602c8850afcfc1ae38f99df4cbcd51386e873d6b0f8047e55c0c26
+PKG_HASH:=b5291bc4e6d69ebbd3da3800c5bf4a70f19bb92679b23e09b3b612c1e648d1ff
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=BSD-3c


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @dangowrt

**Description:**
Update wavpack to 5.9.0.

Release 5.9.0 (January 16, 2026):
* added: new feature to wvtag to copy tags from one WavPack file
  to another
* improved: minor tweaks to the new DNS (dynamic noise shaping)
  algorithm
* improved: better handling of specific non-standard WAV and AIFF
  files
* improved: added CI (GitHub Actions) and fixed a few minor build
  issues
* fixed: --pause option failed in many situations (Windows-only)
* fixed: issues related to encoding from an unknown length
  (e.g., pipes)
* fixed: several fuzzer-revealed issues related to multithreading
* fixed: potential buffer overruns in WavpackOpenRawDecoder()

Upstream:
* https://github.com/dbry/WavPack/blob/5.9.0/NEWS

---

## 🧪 Run Testing Details

- **OpenWrt Version:** master
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** (compile-only, no runtime testing)

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
