### PR TITLE
xdg-dbus-proxy: update to 0.1.7

### DIFF
--- a/utils/xdg-dbus-proxy/Makefile
+++ b/utils/xdg-dbus-proxy/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=xdg-dbus-proxy
-PKG_VERSION:=0.1.6
+PKG_VERSION:=0.1.7
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/flatpak/$(PKG_NAME)/releases/download/$(PKG_VERSION)
-PKG_HASH:=131bf59fce7c7ee7ecbc5d9106d6750f4f597bfe609966573240f7e4952973a1
+PKG_HASH:=3ad3d27ba574e178acb5e4d438ba36ace25e3564f899c36f31c56f82c7adbbe7
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=LGPLv2-or-later


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @dangowrt

**Description:**
Update xdg-dbus-proxy to 0.1.7.

Changes in 0.1.7 (2025-04-07):
* Drop the autotools build system
* Unbreak the CI
* Prevent a crash on disconnect
* Fix building with glibc >= 2.43
* Fix the eavesdrop filtering to prevent message interception

Upstream NEWS:
* https://github.com/flatpak/xdg-dbus-proxy/blob/0.1.7/NEWS

---

## 🧪 Run Testing Details

- **OpenWrt Version:** master
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** (compile-only, no runtime testing)

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
