### PR TITLE
jose: disable man page generation via asciidoc

### DIFF
--- a/libs/jose/patches/010-disable-asciidoc-man.patch
+++ b/libs/jose/patches/010-disable-asciidoc-man.patch
@@ -1,0 +1,11 @@
+--- a/meson.build
++++ b/meson.build
+@@ -39,7 +39,7 @@ zlib = dependency('zlib')
+ threads = dependency('threads')
+ jansson = dependency('jansson', version: '>=2.10')
+ libcrypto = dependency('libcrypto', version: '>=1.0.2')
+-a2x = find_program('a2x', required: false)
++a2x = disabler()
+ 
+ mans = []
+ 


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @Tiboris

**Description:**
Build fix for jose: disable man page generation via asciidoc.

The asciidoc/a2x toolchain bundled with newer Python (3.14) is
incompatible with jose's docbook XSL configuration, causing the
build to fail with xsltproc returning non-zero status while
processing `jose.1.xml`.

Since the man pages are not strictly required for OpenWrt (and
typically stripped from the final image anyway), unconditionally
disable a2x detection in `meson.build` via a `disabler()` so that
the `mans` list stays empty regardless of host tooling.

This blocks the gnunet-rest build chain on hosts with python
3.14 + recent docbook-xsl, hence the patch.

Upstream:
* https://github.com/latchset/jose

---

## 🧪 Run Testing Details

- **OpenWrt Version:** master
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** (compile-only, no runtime testing)

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
