### PR TITLE
GnuPG stack: update libksba, gnupg2, gpgme to 1.6.8 / 2.5.19 / 2.0.1

### DIFF
--- a/libs/gpgme/Makefile
+++ b/libs/gpgme/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gpgme
-PKG_VERSION:=1.24.2
+PKG_VERSION:=2.0.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://gnupg.org/ftp/gcrypt/$(PKG_NAME)
-PKG_HASH:=e11b1a0e361777e9e55f48a03d89096e2abf08c63d84b7017cfe1dce06639581
+PKG_HASH:=821ab0695c842eab51752a81980c92b0410c7eadd04103f791d5d2a526784966
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=LGPL-2.1-or-later
@@ -27,14 +27,6 @@ define Package/libgpgme
   DEPENDS:=+libassuan +libgpg-error
 endef
 
-define Package/libgpgmepp
-  SECTION:=libs
-  CATEGORY:=Libraries
-  TITLE:=GnuPG Made Easy (GPGME) library (C++)
-  URL:=https://gnupg.org/software/gpgme/index.html
-  DEPENDS:=+libgpgme +libstdcpp
-endef
-
 define Package/libgpgme/description
 GnuPG Made Easy (GPGME) is a library designed to make access to GnuPG
 easier for applications. It provides a High-Level Crypto API for
@@ -51,20 +43,17 @@ CONFIGURE_ARGS += \
 	--disable-gpg-test \
 	--disable-gpgsm-test \
 	--disable-g13-test \
-	--enable-languages="cpp"
+	--enable-languages=""
 
 ifneq ($(CONFIG_USE_MUSL),)
   TARGET_CFLAGS += -D_LARGEFILE64_SOURCE
 endif
 
 define Build/InstallDev
-	$(INSTALL_DIR) $(1)/usr/include/gpgme++
+	$(INSTALL_DIR) $(1)/usr/include
 	$(INSTALL_DATA) \
 		$(PKG_INSTALL_DIR)/usr/include/gpgme.h \
 		$(1)/usr/include/
-	$(INSTALL_DATA) \
-		$(PKG_INSTALL_DIR)/usr/include/gpgme++/*.h \
-		$(1)/usr/include/gpgme++/
 
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) \
@@ -84,11 +73,6 @@ define Build/InstallDev
 		$(PKG_INSTALL_DIR)/usr/lib/pkgconfig/gpgme-glib.pc \
 		$(1)/usr/lib/pkgconfig
 
-	$(INSTALL_DIR) $(1)/usr/lib/cmake/Gpgmepp
-	$(INSTALL_DATA) \
-		$(PKG_INSTALL_DIR)/usr/lib/cmake/Gpgmepp/*.cmake \
-		$(1)/usr/lib/cmake/Gpgmepp
-
 	$(INSTALL_DIR) $(2)/bin $(1)/usr/bin
 	$(INSTALL_BIN) \
 		$(PKG_INSTALL_DIR)/usr/bin/gpgme-config \
@@ -104,10 +88,4 @@ define Package/libgpgme/install
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgpgme.so.* $(1)/usr/lib/
 endef
 
-define Package/libgpgmepp/install
-	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgpgmepp.so.* $(1)/usr/lib/
-endef
-
 $(eval $(call BuildPackage,libgpgme))
-$(eval $(call BuildPackage,libgpgmepp))

--- a/libs/libksba/Makefile
+++ b/libs/libksba/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libksba
-PKG_VERSION:=1.6.7
+PKG_VERSION:=1.6.8
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://gnupg.org/ftp/gcrypt/$(PKG_NAME)
-PKG_HASH:=cf72510b8ebb4eb6693eef765749d83677a03c79291a311040a5bfd79baab763
+PKG_HASH:=0f4510f1c7a679c3545990a31479f391ad45d84e039176309d42f80cf41743f5
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=LGPL-3.0-or-later GPL-2.0-or-later

--- a/utils/gnupg2/Makefile
+++ b/utils/gnupg2/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gnupg
-PKG_VERSION:=2.4.8
+PKG_VERSION:=2.5.19
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://gnupg.org/ftp/gcrypt/gnupg
-PKG_HASH:=b58c80d79b04d3243ff49c1c3fc6b5f83138eb3784689563bcdd060595318616
+PKG_HASH:=722aa8a426dd9b44e0d194b73bfee3a3e617d65674cd4d1d062e6df29f1788c6
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=GPL-3.0-or-later


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @dangowrt

**Description:**
Update the entire GnuPG stack in dependency order:

1. **libksba 1.6.7 -> 1.6.8** (foundation, used by gpgsm)
2. **gnupg2 2.4.8 -> 2.5.19** (current upstream stable per
   https://gnupg.org/download/ ; the 2.4.x series is now
   labelled "oldstable" / LTS)
3. **gpgme 1.24.2 -> 2.0.1** (the C++/Qt/Python language
   bindings have been split off upstream into separate
   releases; the libgpgmepp subpackage is dropped here too)

### libksba 1.6.8
* Fix double increment in DN parser while counting hexdigits.
* Fix a memory leak in the BER decoder's error handling.
* Fix an assertion failure in the OCSP code.
* Support SHA256 based CertIDs in OCSP.
* Use nonstring attribute for gcc-15.
* Remove remaining WindowsCE support.

### gnupg2 2.5.19
* New OpenPGP key formats: Curve25519 and Curve448 (RFC9580)
* SHA3 family signature support
* Kyber post-quantum hybrid keys
* KEM (Key Encapsulation Mechanism) operations
* dirmngr: improved LDAP and HTTP keyserver support
* scdaemon: better support for new smartcard tokens
* Many bug fixes and security improvements

### gpgme 2.0.1
* New gpgme_op_random_bytes / gpgme_op_random_value functions to
  get cryptographically strong random data from gpg.
* New decrypt flag to skip actual decryption so information about
  recipients can be retrieved.
* New flag for key generation to mark a (sub)key as group owned.
* gpgme_signers_add: when key was retrieved with fingerprint!'!'
  suffix, the requested subkey is used for signing.
* timestamp/expires fields changed from signed long to unsigned
  long for better 32bit time_t support.
* Removed long-deprecated gpgme_attr_t enums and trustlist feature.
* Removed never-implemented GPGME_EXPORT_MODE_NOUID flag.
* C++ / Qt / Python bindings have been split into separate
  releases upstream; libgpgmepp subpackage dropped accordingly.

Upstream NEWS:
* https://dev.gnupg.org/source/libksba/browse/master/NEWS
* https://dev.gnupg.org/source/gnupg/browse/master/NEWS
* https://dev.gnupg.org/source/gpgme/browse/master/NEWS

Supersedes #29363 (gpgme alone) and #29368 (libksba alone).

---

## 🧪 Run Testing Details

- **OpenWrt Version:** master
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** (compile-only, no runtime testing)

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
