### PR TITLE
boost: updates package to version 1.91.0

### DIFF
--- a/libs/boost/Makefile
+++ b/libs/boost/Makefile
@@ -11,13 +11,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=boost
-PKG_VERSION:=1.90.0
-PKG_SOURCE_VERSION:=1_90_0
-PKG_RELEASE:=3
+PKG_VERSION:=1.91.0
+PKG_SOURCE_VERSION:=1_91_0
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)_$(PKG_SOURCE_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://archives.boost.io/release/$(PKG_VERSION)/source @SF/$(PKG_NAME)/$(PKG_NAME)/$(PKG_VERSION)
-PKG_HASH:=49551aff3b22cbc5c5a9ed3dbc92f0e23ea50a0f7325b0d198b705e8ee3fc305
+PKG_HASH:=de5e6b0e4913395c6bdfa90537febd9028ea4c0735d2cdb0cd9b45d5f51264f5
 
 PKG_MAINTAINER:=Carlos M. Ferreira <carlosmf.pt@gmail.com>
 PKG_LICENSE:=BSL-1.0
@@ -42,7 +42,7 @@ define Package/boost/Default
 endef
 
 define Package/boost/description
-This package provides the Boost v1.90.0 libraries.
+This package provides the Boost v1.91.0 libraries.
 Boost is a set of free, peer-reviewed, portable C++ source libraries.
 
 This package provides the following run-time libraries:
@@ -79,7 +79,7 @@ This package provides the following run-time libraries:
  - wave
 
 There are many more header-only libraries supported by Boost.
-See more at https://www.boost.org/libraries/1.90.0/grid/
+See more at https://www.boost.org/libraries/1.91.0/grid/
 endef
 
 PKG_BUILD_DEPENDS:=boost/host
@@ -297,7 +297,7 @@ define Package/boost-test
 	$(call Package/boost/Default)
 	TITLE+= (test)
 	HIDDEN:=1
-	DEPENDS+=+boost-timer
+	DEPENDS+=+boost-timer +boost-regex
 endef
 
 define Build/Configure
@@ -345,7 +345,7 @@ $(eval $(call DefineBoostLibrary,contract,atomic chrono container date_time thre
 $(eval $(call DefineBoostLibrary,coroutine,chrono context thread,,!boost-coroutine-exclude))
 $(eval $(call DefineBoostLibrary,date_time))
 #$(eval $(call DefineBoostLibrary,exception,,))
-$(eval $(call DefineBoostLibrary,fiber,coroutine filesystem,,!boost-fiber-exclude))
+$(eval $(call DefineBoostLibrary,fiber,coroutine filesystem regex,,!boost-fiber-exclude))
 $(eval $(call DefineBoostLibrary,filesystem,atomic))
 $(eval $(call DefineBoostLibrary,graph))
 $(eval $(call DefineBoostLibrary,iostreams,random regex,,,zlib liblzma libbz2 libzstd))


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @ClaymorePT 

**Description:**
This commit updates boost to version 1.91.0

New libraries in this release:
* Decimal [2]: An implementation of IEEE754 Decimal Floating Point Numbers, from Matt Borland and Christopher Kormanyos.

More info about Boost 1.91.0 can be found at the usual place [1].

[1]: https://www.boost.org/users/history/version_1_91_0.html
[2]: https://www.boost.org/libs/decimal

---

## 🧪 Run Testing Details

- **OpenWrt Version: 25.12.3**
- **OpenWrt Target/Subtarget: bcm27xx-bcm2710**
- **OpenWrt Device: Raspberry PI 3**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
