### PR TITLE
https-dns-proxy: update to 2026.03.18-3

### DIFF
--- a/net/https-dns-proxy/Makefile
+++ b/net/https-dns-proxy/Makefile
@@ -3,7 +3,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=https-dns-proxy
 PKG_VERSION:=2026.03.18
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/aarond10/https_dns_proxy/

--- a/net/https-dns-proxy/files/etc/init.d/https-dns-proxy
+++ b/net/https-dns-proxy/files/etc/init.d/https-dns-proxy
@@ -145,13 +145,11 @@ notrack_nft() {
 				return
 			fi
 			new_content="$(cat <<-EOF
-				table inet https_dns_proxy_notrack {
-					chain raw_output {
-						type filter hook output priority raw; policy accept;
-						meta l4proto { tcp, udp } th dport { ${port_set} } ip daddr 127.0.0.0/8 notrack
-						meta l4proto { tcp, udp } th sport { ${port_set} } ip saddr 127.0.0.0/8 notrack
-					}
-				}
+				add table inet https_dns_proxy_notrack
+				flush table inet https_dns_proxy_notrack
+				add chain inet https_dns_proxy_notrack raw_output { type filter hook output priority raw; policy accept; }
+				add rule inet https_dns_proxy_notrack raw_output meta l4proto { tcp, udp } th dport { ${port_set} } ip daddr 127.0.0.0/8 notrack
+				add rule inet https_dns_proxy_notrack raw_output meta l4proto { tcp, udp } th sport { ${port_set} } ip saddr 127.0.0.0/8 notrack
 			EOF
 			)"
 			existing_content="$(cat "$NOTRACK_NFT_FILE" 2>/dev/null)"
@@ -162,9 +160,9 @@ notrack_nft() {
 			[ -s "$NOTRACK_NFT_FILE" ] && nft -c -f "$NOTRACK_NFT_FILE"
 		;;
 		remove)
-			[ -f "$NOTRACK_NFT_FILE" ] && rm -f "$NOTRACK_NFT_FILE"
-			nft delete table inet https_dns_proxy_notrack 2>/dev/null
-			[ ! -s "$NOTRACK_NFT_FILE" ]
+			rm -f "$NOTRACK_NFT_FILE"
+			nft delete table inet https_dns_proxy_notrack >/dev/null 2>&1
+			! nft list table inet https_dns_proxy_notrack >/dev/null 2>&1 && [ ! -s "$NOTRACK_NFT_FILE" ]
 		;;
 	esac
 }
@@ -426,7 +424,7 @@ stop_service() {
 		uci_commit 'dhcp'
 		dnsmasq_restart || _error=1
 	fi
-	notrack_nft remove
+	notrack_nft remove || _error=1
 # shellcheck disable=SC2015
 	[ -z "$_error" ] && output_okn || output_failn
 }
@@ -463,7 +461,8 @@ dnsmasq_instance_append_force_dns_port() {
 	local cfg="$1" instance_port
 	[ "$(uci_get 'dhcp' "$cfg")" = "dnsmasq" ] || return 1
 	config_get instance_port "$cfg" 'port' '53'
-		str_contains_word "$force_dns_port" "$instance_port" || force_dns_port="${force_dns_port:+${force_dns_port} }${instance_port}"
+	[ "$instance_port" = "0" ] && return 0
+	str_contains_word "$force_dns_port" "$instance_port" || force_dns_port="${force_dns_port:+${force_dns_port} }${instance_port}"
 }
 
 dnsmasq_doh_server() {

--- a/net/https-dns-proxy/tests/run_tests.sh
+++ b/net/https-dns-proxy/tests/run_tests.sh
@@ -505,6 +505,11 @@ force_dns_port="53 853"
 dnsmasq_instance_append_force_dns_port "cfg01"
 assert_eq "append_force_dns_port: already present port 53 not duplicated" "53 853" "$force_dns_port"
 
+uci_set "dhcp" "cfg03" ".type" "dnsmasq"
+uci_set "dhcp" "cfg03" "port" "0"
+dnsmasq_instance_append_force_dns_port "cfg03"
+assert_eq "append_force_dns_port: disabled dnsmasq port 0 ignored" "53 853" "$force_dns_port"
+
 uci_set "dhcp" "cfg02" ".type" "dnsmasq"
 uci_set "dhcp" "cfg02" "port" "5353"
 dnsmasq_instance_append_force_dns_port "cfg02"
@@ -690,9 +695,14 @@ assert_rc "notrack_nft remove deletes the snippet file" 0 $?
 grep -q "delete table inet https_dns_proxy_notrack" "$__nft_calls_file"
 assert_rc "notrack_nft remove invokes 'nft delete table'" 0 $?
 
-# ── remove is a no-op when file already absent ──
+# ── remove is a no-op when file already absent and table already gone ──
+# Mock `nft` to return non-zero so `nft list table` reports "no such table"
+# (the real-world post-delete state); the new remove logic returns 0 only
+# when both the file and the live table are absent.
+__nft_rc=1
 notrack_nft remove
-assert_rc "notrack_nft remove succeeds when file already absent" 0 $?
+assert_rc "notrack_nft remove succeeds when file and table both absent" 0 $?
+__nft_rc=0
 
 ###############################################################################
 #                         SHELL SCRIPT SYNTAX                                 #


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Dell EMC Edge620, OpenWrt 25.12.1
Run tested: x86_64, Dell EMC Edge620, OpenWrt 25.12.1

Description:
update to 2026.03.18, release 3
thanks to @egc112 and @dhrm1k for the fixes below

Makefile:
  - update PKG_RELEASE to 3

files/etc/init.d/https-dns-proxy:
  - refactor nftable rules to explicitly add and flush the table and
    chains instead of block replacement
  - make nftable `delete table` call silent in `notrack_nft remove`
  - update `notrack_nft remove` to check for absence of nftable table
    instead of just checking the file
  - ensure `notrack_nft remove` sets _error=1 on failure
  - ignore dnsmasq instances with port 0 in
    `dnsmasq_instance_append_force_dns_port`

tests/run_tests.sh:
  - add test case to ensure dnsmasq port 0 is ignored
  - update `notrack_nft remove` test to confirm success when both file
    and table are absent