### PR TITLE
python-platformio: add target package and missing dependencies

### DIFF
--- a/lang/python/python-ajsonrpc/Makefile
+++ b/lang/python/python-ajsonrpc/Makefile
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: GPL-2.0-only
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-ajsonrpc
+PKG_VERSION:=1.2.0
+PKG_RELEASE:=1
+
+PYPI_NAME:=ajsonrpc
+PKG_HASH:=791bac18f0bf0dee109194644f151cf8b7ff529c4b8d6239ac48104a3251a19f
+
+PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE.txt
+
+HOST_BUILD_DEPENDS:=python-setuptools/host
+PKG_BUILD_DEPENDS:=python-setuptools/host
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/host-build.mk
+include ../python3-package.mk
+include ../python3-host-build.mk
+
+define Package/python3-ajsonrpc
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=Async JSON-RPC 2.0 protocol + asyncio server
+  URL:=https://github.com/pavlov99/ajsonrpc
+  DEPENDS:= \
+    +python3-asyncio \
+    +python3-light \
+    +python3-logging
+endef
+
+define Package/python3-ajsonrpc/description
+  Lightweight JSON-RPC 2.0 protocol implementation and asynchronous server
+  powered by asyncio. This library is a successor of json-rpc and written
+  by the same team.
+endef
+
+$(eval $(call Py3Package,python3-ajsonrpc))
+$(eval $(call BuildPackage,python3-ajsonrpc))
+$(eval $(call BuildPackage,python3-ajsonrpc-src))
+$(eval $(call HostBuild))

--- a/lang/python/python-anyio/Makefile
+++ b/lang/python/python-anyio/Makefile
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: GPL-2.0-only
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-anyio
+PKG_VERSION:=4.13.0
+PKG_RELEASE:=1
+
+PYPI_NAME:=anyio
+PKG_HASH:=334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc
+
+PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+HOST_BUILD_DEPENDS:= \
+	python3/host \
+	python-idna/host
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/host-build.mk
+include ../python3-package.mk
+include ../python3-host-build.mk
+
+define Package/python3-anyio
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=Anyio
+  URL:=https://github.com/agronholm/anyio
+  DEPENDS:= \
+    +python3-asyncio \
+    +python3-idna \
+    +python3-light \
+    +python3-logging \
+    +python3-openssl
+endef
+
+define Package/python3-anyio/description
+  High-level concurrency and networking framework on top of asyncio or
+  Trio.
+endef
+
+$(eval $(call Py3Package,python3-anyio))
+$(eval $(call BuildPackage,python3-anyio))
+$(eval $(call BuildPackage,python3-anyio-src))
+$(eval $(call HostBuild))

--- a/lang/python/python-h11/Makefile
+++ b/lang/python/python-h11/Makefile
@@ -1,6 +1,4 @@
-# This is free software, licensed under the GNU General Public License v2.
-# See /LICENSE for more information.
-#
+# SPDX-License-Identifier: GPL-2.0-only
 
 include $(TOPDIR)/rules.mk
 
@@ -16,6 +14,7 @@ PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE.txt
 
+HOST_BUILD_DEPENDS:=python-setuptools/host
 PKG_BUILD_DEPENDS:=python-setuptools/host
 
 include ../pypi.mk
@@ -39,3 +38,4 @@ endef
 $(eval $(call Py3Package,python3-h11))
 $(eval $(call BuildPackage,python3-h11))
 $(eval $(call BuildPackage,python3-h11-src))
+$(eval $(call HostBuild))

--- a/lang/python/python-marshmallow/Makefile
+++ b/lang/python/python-marshmallow/Makefile
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: GPL-2.0-only
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-marshmallow
+PKG_VERSION:=4.3.0
+PKG_RELEASE:=1
+
+PYPI_NAME:=marshmallow
+PKG_HASH:=fb43c53b3fe240b8f6af37223d6ef1636f927ad9bea8ab323afad95dff090880
+
+PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+HOST_BUILD_DEPENDS:= \
+	python3/host \
+	python-packaging/host
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/host-build.mk
+include ../python3-package.mk
+include ../python3-host-build.mk
+
+define Package/python3-marshmallow
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=Marshmallow
+  URL:=https://github.com/marshmallow-code/marshmallow
+  DEPENDS:= \
+    +python3-decimal \
+    +python3-light \
+    +python3-packaging \
+    +python3-urllib \
+    +python3-uuid
+endef
+
+define Package/python3-marshmallow/description
+  A lightweight library for converting complex datatypes to and from native
+  Python datatypes.
+endef
+
+$(eval $(call Py3Package,python3-marshmallow))
+$(eval $(call BuildPackage,python3-marshmallow))
+$(eval $(call BuildPackage,python3-marshmallow-src))
+$(eval $(call HostBuild))

--- a/lang/python/python-platformio/Makefile
+++ b/lang/python/python-platformio/Makefile
@@ -1,31 +1,35 @@
-# This is free software, licensed under the GNU General Public License v2.
-# See /LICENSE for more information.
-#
+# SPDX-License-Identifier: GPL-2.0-only
 
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-platformio
 PKG_VERSION:=6.1.19
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=platformio
 PKG_HASH:=7b53eaa36fcba554411b669eab845626da7c4b90fa6aaee9fe9f1875d82f5f54
 
-PKG_MAINTAINER:=Austin Lane <vidplace7@gmail.com>
+PKG_MAINTAINER:=Austin Lane <vidplace7@gmail.com>, Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 
-PKG_HOST_ONLY:=1
 HOST_BUILD_DEPENDS:= \
-	python3/host \
+	python-ajsonrpc/host \
+	python-bottle/host \
 	python-build/host \
-	python-installer/host \
-	python-pyserial/host \
 	python-click/host \
-	python-semantic-version/host \
+	python-installer/host \
+	python-marshmallow/host \
+	python-pyelftools/host \
+	python-pyserial/host \
 	python-requests/host \
+	python-semantic-version/host \
+	python-setuptools/host \
+	python-starlette/host \
 	python-tabulate/host \
-	python-pyelftools/host
+	python-uvicorn/host \
+	python-wsproto/host
+PKG_BUILD_DEPENDS:=python-setuptools/host
 
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
@@ -37,25 +41,40 @@ define Package/python3-platformio
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
-  TITLE:=PlatformIO Host Tools
+  TITLE:=PlatformIO
   URL:=https://github.com/platformio/platformio-core
-  BUILDONLY:=1
   DEPENDS:= \
-	+python3-light \
-	+python3-pyserial \
-	+python3-click \
-	+python3-semantic-version \
-	+python3-requests \
-	+python3-tabulate \
-	+python3-pyelftools
+    +python3-ajsonrpc \
+    +python3-asyncio \
+    +python3-bottle \
+    +python3-click \
+    +python3-colorama \
+    +python3-ctypes \
+    +python3-light \
+    +python3-logging \
+    +python3-marshmallow \
+    +python3-multiprocessing \
+    +python3-openssl \
+    +python3-pyelftools \
+    +python3-pyserial \
+    +python3-requests \
+    +python3-semantic-version \
+    +python3-starlette \
+    +python3-tabulate \
+    +python3-urllib \
+    +python3-uuid \
+    +python3-uvicorn \
+    +python3-wsproto \
+    +python3-xml
 endef
 
 define Package/python3-platformio/description
-PlatformIO is an open-source build system for embedded development,
-supporting multiple platforms, frameworks, and boards
-with features like dependency management and IDE integration.
+  PlatformIO is a cross-platform, cross-architecture, multiple framework,
+  professional tool for embedded systems engineers and for software
+  developers who write applications for embedded products.
 endef
 
 $(eval $(call Py3Package,python3-platformio))
 $(eval $(call BuildPackage,python3-platformio))
+$(eval $(call BuildPackage,python3-platformio-src))
 $(eval $(call HostBuild))

--- a/lang/python/python-semantic-version/Makefile
+++ b/lang/python/python-semantic-version/Makefile
@@ -1,15 +1,13 @@
 #
 # Copyright (C) 2023 Jeffery To
 #
-# This is free software, licensed under the GNU General Public License v2.
-# See /LICENSE for more information.
-#
+# SPDX-License-Identifier: GPL-2.0-only
 
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-semantic-version
 PKG_VERSION:=2.10.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=semantic-version
 PYPI_SOURCE_NAME:=semantic_version
@@ -19,13 +17,13 @@ PKG_LICENSE:=BSD-2-Clause
 PKG_LICENSE_FILES:=LICENSE
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 
-PKG_HOST_ONLY:=1
 HOST_BUILD_DEPENDS:= \
 	python3/host \
 	python-setuptools/host \
 	python-build/host \
 	python-installer/host \
 	python-wheel/host
+PKG_BUILD_DEPENDS:=python-setuptools/host
 
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
@@ -40,12 +38,11 @@ define Package/python3-semantic-version
   TITLE:=Library implementing the 'SemVer' scheme
   URL:=https://github.com/rbarrois/python-semanticversion
   DEPENDS:=+python3-light
-  BUILDONLY:=1
 endef
 
 define Package/python3-semantic-version/description
-This small python library provides a few tools to handle SemVer in
-Python. It follows strictly the 2.0.0 version of the SemVer scheme.
+  This small python library provides a few tools to handle SemVer in
+  Python. It follows strictly the 2.0.0 version of the SemVer scheme.
 endef
 
 $(eval $(call Py3Package,python3-semantic-version))

--- a/lang/python/python-starlette/Makefile
+++ b/lang/python/python-starlette/Makefile
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: GPL-2.0-only
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-starlette
+PKG_VERSION:=1.0.0
+PKG_RELEASE:=1
+
+PYPI_NAME:=starlette
+PKG_HASH:=6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149
+
+PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=LICENSE.md
+
+HOST_BUILD_DEPENDS:= \
+	python-anyio/host \
+	python-setuptools/host
+PKG_BUILD_DEPENDS:=python-setuptools/host
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/host-build.mk
+include ../python3-package.mk
+include ../python3-host-build.mk
+
+define Package/python3-starlette
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=Starlette
+  URL:=https://github.com/agronholm/starlette
+  DEPENDS:= \
+    +python3-asyncio \
+    +python3-anyio \
+    +python3-light \
+    +python3-urllib \
+    +python3-uuid
+endef
+
+define Package/python3-starlette/description
+  Starlette is a lightweight ASGI framework/toolkit, which is ideal for
+  building async web services in Python.
+endef
+
+$(eval $(call Py3Package,python3-starlette))
+$(eval $(call BuildPackage,python3-starlette))
+$(eval $(call BuildPackage,python3-starlette-src))
+$(eval $(call HostBuild))

--- a/lang/python/python-uvicorn/Makefile
+++ b/lang/python/python-uvicorn/Makefile
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: GPL-2.0-only
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-uvicorn
+PKG_VERSION:=0.46.0
+PKG_RELEASE:=1
+
+PYPI_NAME:=uvicorn
+PKG_HASH:=fb9da0926999cc6cb22dc7cd71a94a632f078e6ae47ff683c5c420750fb7413d
+
+PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=LICENSE.md
+
+HOST_BUILD_DEPENDS:= \
+	python3/host \
+	python-click/host \
+	python-h11/host
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/host-build.mk
+include ../python3-package.mk
+include ../python3-host-build.mk
+
+define Package/python3-uvicorn
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=Uvicorn
+  URL:=https://github.com/Kludex/uvicorn
+  DEPENDS:= \
+    +python3-asyncio \
+    +python3-click \
+    +python3-h11 \
+    +python3-light \
+    +python3-logging \
+    +python3-multiprocessing \
+    +python3-openssl \
+    +python3-urllib
+endef
+
+define Package/python3-uvicorn/description
+  Uvicorn is an ASGI web server implementation for Python.
+endef
+
+$(eval $(call Py3Package,python3-uvicorn))
+$(eval $(call BuildPackage,python3-uvicorn))
+$(eval $(call BuildPackage,python3-uvicorn-src))
+$(eval $(call HostBuild))

--- a/lang/python/python-wsproto/Makefile
+++ b/lang/python/python-wsproto/Makefile
@@ -1,6 +1,4 @@
-# This is free software, licensed under the GNU General Public License v2.
-# See /LICENSE for more information.
-#
+# SPDX-License-Identifier: GPL-2.0-only
 
 include $(TOPDIR)/rules.mk
 
@@ -16,6 +14,7 @@ PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
 
+HOST_BUILD_DEPENDS:=python-setuptools/host
 PKG_BUILD_DEPENDS:=python-setuptools/host
 
 include ../pypi.mk
@@ -41,3 +40,4 @@ endef
 $(eval $(call Py3Package,python3-wsproto))
 $(eval $(call BuildPackage,python3-wsproto))
 $(eval $(call BuildPackage,python3-wsproto-src))
+$(eval $(call HostBuild))

--- a/lang/python/python3-bottle/Makefile
+++ b/lang/python/python3-bottle/Makefile
@@ -1,9 +1,7 @@
 #
 # Copyright (C) 2015 OpenWrt.org
 #
-# This is free software, licensed under the GNU General Public License v2.
-# See /LICENSE for more information.
-#
+# SPDX-License-Identifier: GPL-2.0-only
 
 include $(TOPDIR)/rules.mk
 
@@ -14,6 +12,7 @@ PKG_RELEASE:=1
 PYPI_NAME:=bottle
 PKG_HASH:=787e78327e12b227938de02248333d788cfe45987edca735f8f88e03472c3f47
 
+HOST_BUILD_DEPENDS:=python-setuptools/host
 PKG_BUILD_DEPENDS:=python-setuptools/host
 
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
@@ -43,3 +42,4 @@ endef
 $(eval $(call Py3Package,python3-bottle))
 $(eval $(call BuildPackage,python3-bottle))
 $(eval $(call BuildPackage,python3-bottle-src))
+$(eval $(call HostBuild))


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @vidplace7, adding @commodo as requested

**Description:**

Add missing dependencies to PlatformIO and remove host-only build.

These packages are dependencies of Meshtastic. I'm splitting it into multiple PRs so as not overwhelm the CI.

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

Compile-tested only.

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

cc: @BKPepe, @commodo please have a look at the packaging: I don't use Python, so something is probably messed up.