### PR TITLE
csu-autoauth: add new package

### DIFF
--- a/net/csu-autoauth/Makefile
+++ b/net/csu-autoauth/Makefile
@@ -1,0 +1,54 @@
+#
+# Copyright (C) 2026
+#
+# This is free software, licensed under the MIT License.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=csu-autoauth
+PKG_VERSION:=26.5.15
+PKG_RELEASE:=1
+
+PKG_SOURCE:=CSU-Net-Portal-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/barkure/CSU-Net-Portal/tar.gz/refs/tags/v$(PKG_VERSION)
+PKG_HASH:=41dab361af91152c1649184ae88fcab415a38fd1400a2617424f02abafd68aa3
+PKG_BUILD_DIR:=$(BUILD_DIR)/CSU-Net-Portal-$(PKG_VERSION)
+
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+PKG_ARCH:=all
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/csu-autoauth
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=CSU portal auto authentication service
+  DEPENDS:=+curl
+  URL:=https://github.com/barkure/CSU-Net-Portal
+endef
+
+define Package/csu-autoauth/description
+  Auto authenticate to the Central South University network portal
+  and keep the session alive.
+endef
+
+define Build/Compile
+endef
+
+define Package/csu-autoauth/conffiles
+/etc/config/csu-autoauth
+endef
+
+define Package/csu-autoauth/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) ./files/csu-autoauth.sh $(1)/usr/bin/csu-autoauth.sh
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/csu-autoauth.init $(1)/etc/init.d/csu-autoauth
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_CONF) ./files/csu-autoauth.config $(1)/etc/config/csu-autoauth
+endef
+
+$(eval $(call BuildPackage,csu-autoauth))

--- a/net/csu-autoauth/files/csu-autoauth.config
+++ b/net/csu-autoauth/files/csu-autoauth.config
@@ -1,0 +1,5 @@
+config main 'main'
+    option username ''
+    option password ''
+    option type '1'
+    option interval '10'

--- a/net/csu-autoauth/files/csu-autoauth.init
+++ b/net/csu-autoauth/files/csu-autoauth.init
@@ -1,0 +1,15 @@
+#!/bin/sh /etc/rc.common
+
+START=99
+USE_PROCD=1
+
+start_service() {
+    procd_open_instance
+    procd_set_param command /usr/bin/csu-autoauth.sh
+    procd_set_param respawn 3600 5 5
+    procd_close_instance
+}
+
+stop_service() {
+    :
+}

--- a/net/csu-autoauth/files/csu-autoauth.sh
+++ b/net/csu-autoauth/files/csu-autoauth.sh
@@ -1,0 +1,104 @@
+#!/bin/sh
+
+. /lib/functions.sh
+
+CONFIG_SECTION="${CONFIG_SECTION:-main}"
+
+USERNAME=""
+PASSWORD=""
+TYPE=""
+INTERVAL=""
+
+LOG_DIR="${LOG_DIR:-/tmp/log}"
+LOG_FILE="${LOG_FILE:-$LOG_DIR/csu-autoauth.log}"
+
+get_time() {
+    date '+%Y-%m-%d %H:%M:%S'
+}
+
+init_log_file() {
+    mkdir -p "$LOG_DIR"
+    : > "$LOG_FILE"
+}
+
+log() {
+    message="[$(get_time)] $1"
+    echo "$message"
+    printf '%s\n' "$message" >> "$LOG_FILE"
+}
+
+load_config() {
+    config_load csu-autoauth || return 1
+    config_get USERNAME "$CONFIG_SECTION" username
+    config_get PASSWORD "$CONFIG_SECTION" password
+    config_get TYPE "$CONFIG_SECTION" type "1"
+    config_get INTERVAL "$CONFIG_SECTION" interval "10"
+
+    case "$TYPE" in
+        "1") NET_SUFFIX="cmccn" ;;
+        "2") NET_SUFFIX="unicomn" ;;
+        "3") NET_SUFFIX="telecomn" ;;
+        "4") NET_SUFFIX="" ;;
+        *)   NET_SUFFIX="" ;;
+    esac
+}
+
+validate_config() {
+    if [ -z "$USERNAME" ] || [ -z "$PASSWORD" ]; then
+        log "Missing username or password in /etc/config/csu-autoauth"
+        return 1
+    fi
+
+    case "$INTERVAL" in
+        ''|*[!0-9]*)
+            log "Invalid interval '$INTERVAL', expected a positive integer"
+            return 1
+            ;;
+    esac
+}
+
+is_online() {
+    curl -s --max-time 5 http://captive.apple.com | grep -q "Success"
+}
+
+login() {
+    if [ -n "$NET_SUFFIX" ]; then
+        USER_ACCOUNT="${USERNAME}@${NET_SUFFIX}"
+    else
+        USER_ACCOUNT="$USERNAME"
+    fi
+
+    URL="https://10.1.1.1:802/eportal/portal/login"
+    log "Authenticating as: $USER_ACCOUNT"
+    response=$(curl -k -s -G "$URL" \
+        -d "user_account=$USER_ACCOUNT" \
+        -d "user_password=$PASSWORD")
+    log "Login response: $response"
+}
+
+init_log_file
+load_config || {
+    log "Failed to load UCI config: /etc/config/csu-autoauth"
+    exit 1
+}
+validate_config || exit 1
+log "Start monitoring network status (every ${INTERVAL}s)..."
+LAST_STATUS=""
+while true; do
+    if is_online; then
+        CURRENT_STATUS="up"
+        if [ "$LAST_STATUS" != "$CURRENT_STATUS" ]; then
+            log "Network up"
+            LAST_STATUS="$CURRENT_STATUS"
+        fi
+    else
+        CURRENT_STATUS="down"
+        if [ "$LAST_STATUS" != "$CURRENT_STATUS" ]; then
+            log "Network down"
+            LAST_STATUS="$CURRENT_STATUS"
+        fi
+        log "Triggering authentication..."
+        login
+    fi
+    sleep "$INTERVAL"
+done


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @barkure

**Description:**
Add `csu-autoauth`, a shell-based auto authentication service for the Central South University network portal.

It installs:
- the authentication script
- a procd init script
- a UCI configuration file

The package uses the tagged upstream `v1.0.4` source archive, depends on `curl`,
and is marked as `PKG_ARCH:=all`, so it is architecture-independent within
OpenWrt-supported environments.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** OpenWrt 25.12.3 r32912-6639b15f62 / LuCI (HEAD detached at 650a6ca) branch 26.124.63982~650a6ca
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** Xiaomi Mi Router AX3000T

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed
contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/csu-autoauth/refresh V=s

- [x] It is structured in a way that it is potentially upstreamable