### PR TITLE
radicale3: cherry-pick bump version and do some spring cleaning

### DIFF
--- a/lang/python/vobject/Makefile
+++ b/lang/python/vobject/Makefile
@@ -4,12 +4,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=vobject
-PKG_VERSION:=0.9.6.1
-PKG_RELEASE:=2
+PKG_VERSION:=0.9.9
+PKG_RELEASE:=1
 PKG_LICENSE:=Apache-2.0
 
 PYPI_NAME:=$(PKG_NAME)
-PKG_HASH:=96512aec74b90abb71f6b53898dd7fe47300cc940104c4f79148f0671f790101
+PKG_HASH:=ac44e5d7e2079d84c1d52c50a615b9bec4b1ba958608c4c7fe40cbf33247b38e
+PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
@@ -27,6 +28,11 @@ endef
 
 define Package/python3-vobject/description
   vCard and vCalendar support for Python
+endef
+
+define Build/Prepare
+	$(call Build/Prepare/Default)
+	$(SED) 's/version = attr:.*/version = $(PKG_VERSION)/' $(PKG_BUILD_DIR)/setup.cfg
 endef
 
 $(eval $(call Py3Package,python3-vobject))

--- a/lang/python/vobject/test.sh
+++ b/lang/python/vobject/test.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+[ "$1" = python3-vobject ] || exit 0
+
+python3 - << 'EOF'
+import vobject
+
+# Parse a simple vCard
+vcard_text = """BEGIN:VCARD
+VERSION:3.0
+FN:John Doe
+N:Doe;John;;;
+EMAIL:john@example.com
+END:VCARD
+"""
+vcard = vobject.readOne(vcard_text)
+assert vcard.fn.value == "John Doe"
+assert vcard.email.value == "john@example.com"
+
+# Parse a simple iCalendar
+ical_text = """BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+SUMMARY:Test Event
+DTSTART:20260101T120000Z
+DTEND:20260101T130000Z
+END:VEVENT
+END:VCALENDAR
+"""
+cal = vobject.readOne(ical_text)
+events = list(cal.vevent_list)
+assert len(events) == 1
+assert events[0].summary.value == "Test Event"
+
+print("python3-vobject OK")
+EOF

--- a/net/radicale3/Makefile
+++ b/net/radicale3/Makefile
@@ -4,7 +4,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=radicale3
-PKG_VERSION:=3.7.1
+PKG_VERSION:=3.7.2
 PKG_RELEASE:=1
 
 PKG_LICENSE:=GPL-3.0-or-later
@@ -13,7 +13,7 @@ PKG_CPE_ID:=cpe:/a:radicale:radicale
 
 PYPI_NAME:=Radicale
 PYPI_SOURCE_NAME:=radicale
-PKG_HASH:=cabb87ad9f0b6aaa724f0621810c0e0c0421ef04ef2617e988d9da63859cd8ad
+PKG_HASH:=2c61de17ee4105a998dd250a79732b83313f74aa396bd40b71e7438b695e0edc
 
 PKG_MAINTAINER:=Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>
 
@@ -29,8 +29,7 @@ define Package/radicale3
   TITLE:=Radicale 3.x CalDAV/CardDAV server
   USERID:=radicale3=226:radicale3=226
   DEPENDS:=+python3 +python3-dateutil +python3-vobject +python3-setuptools \
-    +python3-defusedxml +python3-libpass +python3-requests +python3-pika \
-    +python3-packaging
+    +python3-defusedxml +python3-libpass +python3-requests +python3-pika
   PROVIDES:=radicale radicale2
 endef
 

--- a/net/radicale3/Makefile
+++ b/net/radicale3/Makefile
@@ -1,9 +1,6 @@
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
 
-# cspell:words TOPDIR PYPI Radicale conffiles dateutil defusedxml libpass
-# cspell:words setuptools vobject
-
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=radicale3

--- a/net/radicale3/files/radicale3.init
+++ b/net/radicale3/files/radicale3.init
@@ -1,7 +1,5 @@
 #!/bin/sh /etc/rc.common
 # shellcheck shell=ash
-# cspell:words CFGDIR SYSCFG USRCFG cfgfile chgrp defval getline hostlist
-# cspell:words htpasswd radicale tmpconf tmpusers multifilesystem
 
 # shellcheck disable=SC2034
 START=99
@@ -19,7 +17,7 @@ conf_line() {
 	local value="$3"
 
 	if [ -n "$value" ]; then
-		echo "$option = $value" >> "$cfgfile"
+		echo "$option = $value" >>"$cfgfile"
 	fi
 }
 
@@ -59,7 +57,7 @@ conf_section() {
 	local hostlist=""
 	local value
 
-	echo "[$cfg]" >> "$cfgfile"
+	echo "[$cfg]" >>"$cfgfile"
 
 	case $cfg in
 	server)
@@ -130,13 +128,13 @@ conf_section() {
 	headers)
 		config_get cors "$cfg" cors
 		if [ -n "$cors" ]; then
-			echo "Access-Control-Allow-Origin = $cors" >> "$cfgfile"
+			echo "Access-Control-Allow-Origin = $cors" >>"$cfgfile"
 		fi
 		;;
-  # TODO: Add sharing configuration
+		# TODO: Add sharing configuration
 	esac
 
-	echo "" >> "$cfgfile"
+	echo "" >>"$cfgfile"
 }
 
 add_missing_sections() {
@@ -144,21 +142,21 @@ add_missing_sections() {
 
 	for section in server encoding auth rights storage web logging headers sharing; do
 		if ! grep -q "\[$section\]" "$cfgfile"; then
-			echo "[$section]" >> "$cfgfile"
+			echo "[$section]" >>"$cfgfile"
 			case $section in
 			server)
-				echo "hosts = 127.0.0.1:5232, [::1]:5232" >> "$cfgfile"
+				echo "hosts = 127.0.0.1:5232, [::1]:5232" >>"$cfgfile"
 				;;
 			auth)
-				echo "type = htpasswd" >> "$cfgfile"
-				echo "htpasswd_filename = $USRCFG" >> "$cfgfile"
-				echo "htpasswd_encryption = plain" >> "$cfgfile"
+				echo "type = htpasswd" >>"$cfgfile"
+				echo "htpasswd_filename = $USRCFG" >>"$cfgfile"
+				echo "htpasswd_encryption = plain" >>"$cfgfile"
 				;;
 			storage)
-				echo "filesystem_folder = $DATADIR" >> "$cfgfile"
+				echo "filesystem_folder = $DATADIR" >>"$cfgfile"
 				;;
 			esac
-			echo "" >> "$cfgfile"
+			echo "" >>"$cfgfile"
 		fi
 	done
 }
@@ -171,7 +169,7 @@ add_user() {
 	config_get name "$cfg" name
 	config_get password "$cfg" password
 
-	[ -n "$name" ] && echo "$name:$password" >> "$tmpfile"
+	[ -n "$name" ] && echo "$name:$password" >>"$tmpfile"
 }
 
 build_users() {
@@ -199,8 +197,8 @@ build_config() {
 	chmod 0750 "$CFGDIR"
 	chgrp radicale3 "$CFGDIR"
 
-	cat "$tmpconf" > "$SYSCFG"
-	cat "$tmpusers" > "$USRCFG"
+	cat "$tmpconf" >"$SYSCFG"
+	cat "$tmpusers" >"$USRCFG"
 	chmod 0640 "$SYSCFG" "$USRCFG"
 	chgrp radicale3 "$SYSCFG" "$USRCFG"
 


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @danielfdickinson 

**Description:**
Cherry pick #29328 radicale3: bump version and do some spring cleaning

* Bump version to 3.7.2 (and adjust dependencies as necessary)
* Cleanup some extraneous spell checker hints
* Standardize formatting of initscript
* Include cherry-pick of vobject package (python-vobject) as CI will fail without this dependency having a test override.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** OpenWrt 25.12-SNAPSHOT r32924-e850a972b5
- **OpenWrt Target/Subtarget:** bcm27xx/bcm2712
- **OpenWrt Device:** Raspberry Pi 5 Model B Rev 1.0

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
