### PR TITLE
onigumura: fix library installation

### DIFF
--- a/libs/oniguruma/Makefile
+++ b/libs/oniguruma/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=oniguruma
 PKG_VERSION:=6.9.10
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=onig-v$(subst _,-,$(PKG_VERSION)).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/kkos/oniguruma/tar.gz/v$(PKG_VERSION)?
@@ -43,7 +43,7 @@ CONFIGURE_ARGS += --enable-posix-api
 
 define Package/oniguruma/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libonig.so.$(ABI_VERSION) $(1)/usr/lib/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/libonig.so.$(ABI_VERSION) $(1)/usr/lib/
 endef
 
 define Build/InstallDev


### PR DESCRIPTION
Commit 537c2a631 ("treewide: avoid deref symlinks when installing .so") intended to avoid duplicating .so* files, but this package actually relies on install dereferencing the file that matches the SONAME version, to avoid installing unnecessary symlinks.

Fixes: openwrt/packages#29387
Fixes: 537c2a631 ("treewide: avoid deref symlinks when installing .so")

Ping @BKPepe 