### PR TITLE
zabbix: bump version and fix a build dependency

### DIFF
--- a/admin/zabbix/Makefile
+++ b/admin/zabbix/Makefile
@@ -62,12 +62,13 @@ endef
 define Package/zabbix-get/config
 	config ZABBIX_BUILD_SUPPORT_BIN
 		bool
-		depends on (PACKAGE_zabbix-agentd || PACKAGE_zabbix-proxy || PACKAGE_zabbix-server) && ZABBIX_ENABLE_ZABBIX
+		depends on PACKAGE_zabbix-agentd && ZABBIX_ENABLE_ZABBIX
 		default y
 		help
-			This option exists to prevent trying to build get and/or sender when none
-			of agentd, server, or proxy are being built. In that case get and sender are
-			not built by the Zabbix build system.
+			This option exists to prevent trying to build get and/or sender when the
+			of agent is not being built. In that case get and sender are not built by
+			the Zabbix build system. This is not a dependency DEPENDS because the
+			binaries do not require the agent to function.
 endef
 
 define Package/zabbix/Default

--- a/admin/zabbix/Makefile
+++ b/admin/zabbix/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zabbix
-PKG_VERSION:=7.0.25
+PKG_VERSION:=7.0.26
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://cdn.zabbix.com/zabbix/sources/stable/$(basename $(PKG_VERSION))/ \
 	https://cdn.zabbix.com/zabbix/sources/oldstable/$(basename $(PKG_VERSION))/
-PKG_HASH:=3a42e85da9cbd8aadd11bfcbe021f0f9c6caa510f564e37f3ac1046984acb729
+PKG_HASH:=3c27a97b52c75e2eccfa43dec5e3fd7d52876f5fdd94172495b025ec9f2a13a8
 
 PKG_MAINTAINER:=Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>
 PKG_LICENSE:=AGPL-3.0-only


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @danielfdickinson 

**Description:**

* Bump version to 7.0.26 (latest LTS)
* Fix build dependency check for zabbix-get and zabbix-sender; they require zabbix-agentd (full version) to be built in order for the configure script to build them. They, however, do not runtime depend on zabbix-agentd.

zabbix-frontend-server depends on a fix for oniguruma (#29397).

---

## 🧪 Run Testing Details

- **OpenWrt Version:** OpenWrt SNAPSHOT r34318-6018bd5b11
- **OpenWrt Target/Subtarget:** bcm27xx/bcm2712
- **OpenWrt Device:** Raspberry Pi 5 Model B Rev 1.0

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
