### PR TITLE
Ddns blazingfast io

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -290,6 +290,21 @@ define Package/ddns-scripts-beget/description
   'option password' to be a valid API key for beget.com
 endef
 
+define Package/ddns-scripts-blazingfast
+  $(call Package/ddns-scripts/Default)
+  TITLE:=Extension for blazingfast.io Anycast DNS API
+  DEPENDS:=ddns-scripts +curl
+  PROVIDES:=ddns-scripts_blazingfast.io
+endef
+
+define Package/ddns-scripts-blazingfast/description
+  Dynamic DNS Client scripts extension for blazingfast.io Anycast DNS API (require curl)
+  It requires:
+  'option username'  to be a valid blazingfast.io client area username
+  'option password'  to be the matching blazingfast.io client area password
+  'option domain'    to contain the full DNS record name to update (e.g. uk.nightmare.gr)
+  'option param_opt' to contain service_id=X zone_id=Y record_id=Z
+endef
 
 define Package/ddns-scripts-pdns
   $(call Package/ddns-scripts/Default)
@@ -468,6 +483,7 @@ define Package/ddns-scripts-services/install
 	rm $(1)/usr/share/ddns/default/dnspod.cn-v3.json
 	rm $(1)/usr/share/ddns/default/no-ip.com.json
 	rm $(1)/usr/share/ddns/default/bind-nsupdate.json
+	rm $(1)/usr/share/ddns/default/blazingfast.io.json
 	rm $(1)/usr/share/ddns/default/route53-v1.json
 	rm $(1)/usr/share/ddns/default/cnkuai.cn.json
 	rm $(1)/usr/share/ddns/default/gandi.net.json
@@ -829,6 +845,23 @@ fi
 exit 0
 endef
 
+define Package/ddns-scripts-blazingfast/install
+	$(INSTALL_DIR) $(1)/usr/lib/ddns
+	$(INSTALL_BIN) ./files/usr/lib/ddns/update_blazingfast_io.sh \
+		$(1)/usr/lib/ddns
+
+	$(INSTALL_DIR) $(1)/usr/share/ddns/default
+	$(INSTALL_DATA) ./files/usr/share/ddns/default/blazingfast.io.json \
+		$(1)/usr/share/ddns/default/
+endef
+
+define Package/ddns-scripts-blazingfast/prerm
+#!/bin/sh
+if [ -z "$${IPKG_INSTROOT}" ]; then
+	/etc/init.d/ddns stop
+fi
+exit 0
+endef
 
 define Package/ddns-scripts-pdns/install
 	$(INSTALL_DIR) $(1)/usr/lib/ddns
@@ -999,6 +1032,7 @@ $(eval $(call BuildPackage,ddns-scripts-route53))
 $(eval $(call BuildPackage,ddns-scripts-cnkuai))
 $(eval $(call BuildPackage,ddns-scripts-gandi))
 $(eval $(call BuildPackage,ddns-scripts-beget))
+$(eval $(call BuildPackage,ddns-scripts-blazingfast))
 $(eval $(call BuildPackage,ddns-scripts-pdns))
 $(eval $(call BuildPackage,ddns-scripts-scaleway))
 $(eval $(call BuildPackage,ddns-scripts-transip))

--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -295,6 +295,7 @@ define Package/ddns-scripts-blazingfast
   TITLE:=Extension for blazingfast.io Anycast DNS API
   DEPENDS:=ddns-scripts +curl
   PROVIDES:=ddns-scripts_blazingfast.io
+  MAINTAINER:=Fotios Kitsantas <fkitsantas@icloud.com>
 endef
 
 define Package/ddns-scripts-blazingfast/description

--- a/net/ddns-scripts/files/usr/lib/ddns/update_blazingfast_io.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/update_blazingfast_io.sh
@@ -189,7 +189,7 @@ blazingfast_transfer
 
 # verify success from API response
 __DATA=$(jsonfilter -i "$DATFILE" -e "@.info[0]" 2>/dev/null)
-echo "$__DATA" | grep -q "updated successfully" && {
+echo "$__DATA" | grep -q "dnsrecordupdated" && {
 	write_log 7 "Record updated: $domain -> $__IP"
 	return 0
 }

--- a/net/ddns-scripts/files/usr/lib/ddns/update_blazingfast_io.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/update_blazingfast_io.sh
@@ -1,0 +1,199 @@
+#!/bin/sh
+#
+# Distributed under the terms of the GNU General Public License (GPL) version 2.0
+#
+# Script for sending updates to blazingfast.io Anycast DNS
+# API documentation: https://my.blazingfast.io/api
+#
+# May, 2026 - Fotios Kitsantas <fkitsantas@icloud.com>
+#
+# This script is parsed by dynamic_dns_functions.sh inside send_update() function
+#
+# using following options from /etc/config/ddns
+# option username  - Your Blazingfast client area username
+# option password  - Your Blazingfast client area password
+# option domain    - Full DNS record name to update, e.g. uk.nightmare.gr
+# option param_opt - Space-separated key=value pairs:
+#                    service_id=SERVICE_ID zone_id=ZONE_ID record_id=RECORD_ID
+#
+# How to find your service_id, zone_id, record_id:
+#
+#   1. Get your token:
+#      TOKEN=$(curl -s -X POST 'https://my.blazingfast.io/api/login' \
+#        -d "username=USERNAME" \
+#        -d "password=PASSWORD" | grep -o '"token":"[^"]*"' | cut -d'"' -f4)
+#
+#   2. List services to get service_id:
+#      curl -s 'https://my.blazingfast.io/api/service' \
+#        -H "Authorization: Bearer $TOKEN" | python3 -m json.tool
+#
+#   3. List DNS zones to get zone_id (replace SERVICE_ID):
+#      curl -s 'https://my.blazingfast.io/api/service/SERVICE_ID/dns' \
+#        -H "Authorization: Bearer $TOKEN" | python3 -m json.tool
+#
+#   4. List records to get record_id (replace SERVICE_ID and ZONE_ID):
+#      curl -s 'https://my.blazingfast.io/api/service/SERVICE_ID/dns/ZONE_ID' \
+#        -H "Authorization: Bearer $TOKEN" | python3 -m json.tool
+#
+#   Then set param_opt to "service_id=SERVICE_ID zone_id=ZONE_ID record_id=RECORD_ID"
+#
+# variable __IP already defined with the ip-address to use for update
+#
+
+# check parameters
+[ -z "$CURL" ] && [ -z "$CURL_SSL" ] && write_log 14 "Blazingfast communication requires cURL with SSL support. Please install"
+[ -z "$username" ] && write_log 14 "Service section not configured correctly! Missing 'username'"
+[ -z "$password" ] && write_log 14 "Service section not configured correctly! Missing 'password'"
+[ -z "$domain"   ] && write_log 14 "Service section not configured correctly! Missing 'domain'"
+[ $use_https -eq 0 ] && use_https=1	# force HTTPS
+
+# parse param_opt — expects: service_id=X zone_id=Y record_id=Z
+local __SERVICE_ID __ZONE_ID __RECORD_ID
+if [ -n "$param_opt" ]; then
+	for pair in $param_opt; do
+		case $pair in
+			service_id=*) __SERVICE_ID=${pair#*=}; write_log 7 "service_id: $__SERVICE_ID" ;;
+			zone_id=*)    __ZONE_ID=${pair#*=};    write_log 7 "zone_id: $__ZONE_ID" ;;
+			record_id=*)  __RECORD_ID=${pair#*=};  write_log 7 "record_id: $__RECORD_ID" ;;
+			*) ;;
+		esac
+	done
+fi
+
+[ -z "$__SERVICE_ID" ] && write_log 14 "param_opt missing service_id=VALUE"
+[ -z "$__ZONE_ID"    ] && write_log 14 "param_opt missing zone_id=VALUE"
+[ -z "$__RECORD_ID"  ] && write_log 14 "param_opt missing record_id=VALUE"
+
+# set record type
+local __TYPE
+[ $use_ipv6 -eq 0 ] && __TYPE="A" || __TYPE="AAAA"
+
+local __URLBASE="https://my.blazingfast.io/api"
+local __PRGBASE __RUNPROG __TOKEN __DATA
+
+# transfer function — mirrors Cloudflare's pattern for retry/error handling
+blazingfast_transfer() {
+	local __CNT=0
+	local __ERR
+	while : ; do
+		write_log 7 "#> $__RUNPROG"
+		eval "$__RUNPROG"
+		__ERR=$?
+		[ $__ERR -eq 0 ] && break
+
+		write_log 3 "cURL Error: '$__ERR'"
+		write_log 7 "$(cat $ERRFILE)"
+
+		[ $VERBOSE_MODE -gt 1 ] && {
+			write_log 4 "Transfer failed - Verbose Mode: $VERBOSE_MODE - NO retry on error"
+			break
+		}
+
+		__CNT=$(( $__CNT + 1 ))
+		[ $retry_max_count -gt 0 -a $__CNT -gt $retry_max_count ] && \
+			write_log 14 "Transfer failed after $retry_max_count retries"
+
+		write_log 4 "Transfer failed - retry $__CNT/$retry_max_count in $RETRY_SECONDS seconds"
+		sleep $RETRY_SECONDS &
+		PID_SLEEP=$!
+		wait $PID_SLEEP
+		PID_SLEEP=0
+	done
+}
+
+# build base curl command — handles SSL, proxy, interface, certificates
+# exactly as other providers do
+__PRGBASE="$CURL -RsS -o $DATFILE --stderr $ERRFILE"
+
+if [ -n "$bind_network" ]; then
+	local __DEVICE
+	network_get_device __DEVICE $bind_network || \
+		write_log 13 "Cannot detect local device using 'network_get_device $bind_network' - Error: '$?'"
+	write_log 7 "Force communication via device '$__DEVICE'"
+	__PRGBASE="$__PRGBASE --interface $__DEVICE"
+fi
+
+if [ $force_ipversion -eq 1 ]; then
+	[ $use_ipv6 -eq 0 ] && __PRGBASE="$__PRGBASE -4" || __PRGBASE="$__PRGBASE -6"
+fi
+
+if [ "$cacert" = "IGNORE" ]; then
+	__PRGBASE="$__PRGBASE --insecure"
+elif [ -f "$cacert" ]; then
+	__PRGBASE="$__PRGBASE --cacert $cacert"
+elif [ -d "$cacert" ]; then
+	__PRGBASE="$__PRGBASE --capath $cacert"
+elif [ -n "$cacert" ]; then
+	write_log 14 "No valid certificate(s) found at '$cacert' for HTTPS communication"
+fi
+
+if [ -z "$proxy" ]; then
+	__PRGBASE="$__PRGBASE --noproxy '*'"
+elif [ -z "$CURL_PROXY" ]; then
+	write_log 13 "cURL: libcurl compiled without Proxy support"
+fi
+
+# -------------------------------------------------------------------
+# Step 1 — Authenticate and obtain JWT token
+# -------------------------------------------------------------------
+write_log 7 "Authenticating with Blazingfast.io"
+
+__RUNPROG="$__PRGBASE --request POST '$__URLBASE/login'"
+__RUNPROG="$__RUNPROG --data 'username=$username'"
+__RUNPROG="$__RUNPROG --data 'password=$password'"
+blazingfast_transfer
+
+__TOKEN=$(jsonfilter -i "$DATFILE" -e "@.token" 2>/dev/null)
+[ -z "$__TOKEN" ] && {
+	write_log 4 "Blazingfast authentication failed — check username/password"
+	write_log 7 "$(cat $DATFILE)"
+	return 1
+}
+write_log 7 "Authentication successful"
+
+# add auth header to base command for all subsequent calls
+__PRGBASE="$__PRGBASE --header 'Authorization: Bearer $__TOKEN'"
+__PRGBASE="$__PRGBASE --header 'Content-Type: application/json'"
+
+# -------------------------------------------------------------------
+# Step 2 — GET_REGISTERED_IP mode
+# Returns the IP currently stored in the DNS record
+# (used by ddns-scripts to compare before deciding to update)
+# -------------------------------------------------------------------
+if [ -n "$GET_REGISTERED_IP" ]; then
+	__RUNPROG="$__PRGBASE --request GET '$__URLBASE/service/$__SERVICE_ID/dns/$__ZONE_ID/records/$__RECORD_ID'"
+	blazingfast_transfer
+
+	__DATA=$(jsonfilter -i "$DATFILE" -e "@.record.content" 2>/dev/null)
+	if [ -n "$__DATA" ]; then
+		write_log 7 "Registered IP '$__DATA' detected via Blazingfast API"
+		REGISTERED_IP="$__DATA"
+		return 0
+	else
+		write_log 4 "Could not extract IP from Blazingfast API response"
+		write_log 7 "$(cat $DATFILE)"
+		return 127
+	fi
+fi
+
+# -------------------------------------------------------------------
+# Step 3 — Update the DNS record
+# -------------------------------------------------------------------
+cat > $DATFILE << EOF
+{"name":"$domain","ttl":300,"priority":0,"type":"$__TYPE","content":"$__IP"}
+EOF
+
+__RUNPROG="$__PRGBASE --request PUT --data @$DATFILE"
+__RUNPROG="$__RUNPROG '$__URLBASE/service/$__SERVICE_ID/dns/$__ZONE_ID/records/$__RECORD_ID'"
+blazingfast_transfer
+
+# verify success from API response
+__DATA=$(jsonfilter -i "$DATFILE" -e "@.info[0]" 2>/dev/null)
+echo "$__DATA" | grep -q "updated successfully" && {
+	write_log 7 "Record updated: $domain -> $__IP"
+	return 0
+}
+
+write_log 4 "Blazingfast API reported an error:"
+write_log 7 "$(cat $DATFILE)"
+return 1

--- a/net/ddns-scripts/files/usr/share/ddns/default/blazingfast.io.json
+++ b/net/ddns-scripts/files/usr/share/ddns/default/blazingfast.io.json
@@ -1,0 +1,9 @@
+{
+    "name": "blazingfast.io",
+    "ipv4": {
+        "url": "update_blazingfast_io.sh"
+    },
+    "ipv6": {
+        "url": "update_blazingfast_io.sh"
+    }
+}


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @feckert

**Description:**
Adds DDNS update support for blazingfast.io Anycast DNS via their REST API.
Authentication uses JWT tokens obtained from the login endpoint. The A/AAAA
record is updated via PUT request. Service, zone and record IDs are passed
via `param_opt` as space-separated `key=value` pairs
(`service_id=X zone_id=Y record_id=Z`). Supports both IPv4 and IPv6.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** ddns-scripts 2.8.2-12
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** GL.iNet MT5000 (Brume 3)

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
