### PR TITLE
ci: cancel in-progress Test and Build runs on PR update

### DIFF
--- a/.github/workflows/multi-arch-test-build.yml
+++ b/.github/workflows/multi-arch-test-build.yml
@@ -7,6 +7,10 @@ permissions:
   contents: read
   pull-requests: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   formalities:
     name: Test Formalities


### PR DESCRIPTION
When a contributor pushes a new commit to an open PR, the previous Test and Build run is no longer informative and only consumes a runner slot that the new run could use. Add a concurrency group keyed on the workflow name and ref so a fresh push cancels the prior in-progress run for the same PR.

Since this workflow only triggers on pull_request, the ref is always refs/pull/<num>/merge (unique per PR), so cancel-in-progress can be set unconditionally.
