### PR TITLE
jsoncpp: build with C++17 to enable string_view API

### DIFF
--- a/libs/jsoncpp/Makefile
+++ b/libs/jsoncpp/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=jsoncpp
 PKG_VERSION:=1.9.7
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/open-source-parsers/jsoncpp/tar.gz/$(PKG_VERSION)?
@@ -42,7 +42,8 @@ endef
 
 MESON_ARGS += \
 	-Db_lto=true \
-	-Dtests=false
+	-Dtests=false \
+	-Dcpp_std=c++17
 
 TARGET_LDFLAGS += -Wl,--gc-sections
 


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me

**Description:**

jsoncpp 1.9.7 added std::string_view overloads for Value::get() and Value::operator[], but these are only compiled when C++17 is active. Building with the default C++11 standard leaves those symbols out of the library, causing link failures for consumers that include the headers with C++17 enabled (e.g. upmpdcli 1.9.17, domoticz 2025.2).

Add -Dcpp_std=c++17 to the meson args so the string_view API is available in the installed library.

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
