### PR TITLE
neofetch-rs: add new package

### DIFF
--- a/utils/neofetch-rs/Makefile
+++ b/utils/neofetch-rs/Makefile
@@ -1,0 +1,37 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=neofetch-rs
+PKG_VERSION:=2026.03.07~10b819f
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/ahaoboy/neofetch.git
+PKG_SOURCE_DATE:=2026-03-07
+PKG_SOURCE_VERSION:=10b819f06ac9cbf72a700ff7f34b5df0864be12f
+PKG_MIRROR_HASH:=159a5a43be2a59fa8b5bbf0634e6e6c7f43a13df50491cde47b41487cfe1a80c
+
+PKG_MAINTAINER:=Albrecht Lohofener <albrecht@albrechtloh.de>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_DEPENDS:=rust/host
+PKG_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/rust/rust-package.mk
+
+define Package/neofetch-rs
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=Shows system information in a visually appealing way
+  DEPENDS:=$(RUST_ARCH_DEPENDS)
+  URL:=https://github.com/ahaoboy/neofetch
+endef
+
+define Package/neofetch-rs/description
+ neofetch-rs is a Rust reimplementation of the original neofetch tool. neofetch itself 
+ is similar to the popular screenfetch tool. It provides general system information output.
+endef
+
+$(eval $(call RustBinPackage,neofetch-rs))
+$(eval $(call BuildPackage,neofetch-rs))

--- a/utils/neofetch-rs/test-version.sh
+++ b/utils/neofetch-rs/test-version.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+# neofetch-rs does not expose a stable version string matching PKG_VERSION.
+# Functional checks are implemented in test.sh.
+exit 0


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @albrechtl
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->
neofetch-rs is a Rust reimplementation of the original neofetch tool. neofetch itself is similar to the popular screenfetch tool. It provides general system information output.

Example
```
root@OpenWrt:~# neofetch 
 _______                       root@OpenWrt
|       |.-----.-----.-----.   -------
|   -   ||  _  |  -__|     |   OS: OpenWrt SNAPSHOT mips
|_______||   __|_____|__|__|   Kernel: 6.18.26
         |__|                  Uptime: 1 day, 7 hours, 52 mins
 ________        __            Disk(/): 1.6 MiB / 7.9 MiB (20%)
|  |  |  |.----.|  |_          Memory: 39.8 MiB / 116.7 MiB
|  |  |  ||   _||   _|         Temperature: cpu-thermal: 33.0°C
|________||__|  |____|                      temp1: 33.0°C
                               Local IP: 192.168.1.1

```



---

## 🧪 Run Testing Details

- **OpenWrt Version:**
OpenWrt SNAPSHOT, r34251+1-e4b3d5c799
- **OpenWrt Target/Subtarget:**
realtek/rtl838x
- **OpenWrt Device:**
zyxel_gs1900-8-a1
---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
