### PR TITLE
openfortivpn: add realm parameter support

### DIFF
--- a/net/openfortivpn/files/openfortivpn.sh
+++ b/net/openfortivpn/files/openfortivpn.sh
@@ -24,6 +24,7 @@ proto_openfortivpn_init_config() {
 	proto_config_add_string "remote_status_check"
 	proto_config_add_boolean "saml_login"
 	proto_config_add_int "saml_login_port"
+	proto_config_add_string  "realm"
 	no_device=1
 	available=1
 }
@@ -34,9 +35,9 @@ proto_openfortivpn_setup() {
 	local msg ifname ip server_ips pwfile callfile
 
 	local peeraddr port tunlink local_ip username password persist_int \
-	      trusted_cert remote_status_check saml_login saml_login_port
+	      trusted_cert remote_status_check saml_login saml_login_port realm
 	json_get_vars host peeraddr port tunlink local_ip username password persist_int \
-		      trusted_cert remote_status_check saml_login saml_login_port
+		      trusted_cert remote_status_check saml_login saml_login_port realm
 
 	ifname="vpn-$config"
 
@@ -147,6 +148,8 @@ proto_openfortivpn_setup() {
 			append_args "--saml-login"
 		fi
 	}
+
+	[ -n "$realm" ] && append_args "--realm=$realm"
 
 	callfile="/var/etc/openfortivpn/peers/$config"
 	echo "115200


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @lucize 
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->
Some FortiGate VPN gateways require a specific authentication realm
when multiple domains or user groups are configured on the same server.

This commit updates the netifd protocol script to parse the 'realm'
option from the UCI configuration and correctly append it to the
openfortivpn command line arguments.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12.3
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** ASUS TUF-AX4200

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
