### PR TITLE
treewide: fix dangling SONAME symlinks when using ABI_VERSION

### DIFF
--- a/libs/libmariadb/Makefile
+++ b/libs/libmariadb/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libmariadb
 PKG_VERSION:=3.4.8
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=mariadb-connector-c-$(PKG_VERSION)-src.tar.gz
 PKG_SOURCE_URL:=\
@@ -146,7 +146,7 @@ define Package/$(PKG_NAME)/install
 		$(PKG_INSTALL_DIR)$(MARIADB_PLUGIN_DIR)/mysql_clear_password.so \
 		$(PKG_INSTALL_DIR)$(MARIADB_PLUGIN_DIR)/sha256_password.so \
 		$(1)$(MARIADB_PLUGIN_DIR)
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libmariadb.so.$(ABI_VERSION) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libmariadb.so.$(ABI_VERSION)* $(1)/usr/lib
 endef
 
 define BuildPlugin

--- a/libs/libyaml-cpp/Makefile
+++ b/libs/libyaml-cpp/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libyaml-cpp
 PKG_VERSION:=0.8.0
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/jbeder/yaml-cpp
@@ -52,7 +52,7 @@ endef
 
 define Package/libyaml-cpp/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libyaml-cpp.so.$(ABI_VERSION) $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libyaml-cpp.so.$(ABI_VERSION)* $(1)/usr/lib/
 endef
 
 $(eval $(call BuildPackage,libyaml-cpp))

--- a/libs/oniguruma/Makefile
+++ b/libs/oniguruma/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=oniguruma
 PKG_VERSION:=6.9.10
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=onig-v$(subst _,-,$(PKG_VERSION)).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/kkos/oniguruma/tar.gz/v$(PKG_VERSION)?
@@ -43,7 +43,7 @@ CONFIGURE_ARGS += --enable-posix-api
 
 define Package/oniguruma/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/libonig.so.$(ABI_VERSION) $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libonig.so.$(ABI_VERSION)* $(1)/usr/lib/
 endef
 
 define Build/InstallDev

--- a/libs/tinycdb/Makefile
+++ b/libs/tinycdb/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tinycdb
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 PKG_SOURCE_URL:=https://www.corpit.ru/mjt/tinycdb/
 PKG_VERSION:=0.78
 PKG_HASH:=50678f432d8ada8d69f728ec11c3140e151813a7847cf30a62d86f3a720ed63c
@@ -45,7 +45,7 @@ endef
 
 define Package/tinycdb/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libcdb.so.$(ABI_VERSION) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libcdb.so.$(ABI_VERSION)* $(1)/usr/lib
 endef
 
 define Build/Compile


### PR DESCRIPTION
A previous commit (from https://github.com/openwrt/packages/pull/28220)  attempted to introduce proper SONAME symlinks for packages utilizing ABI_VERSION. However, it incorrectly copied only the symlink without the underlying physical library file, resulting in broken packages with dangling symlinks.

Before:
```
tar -Oxzf bin/packages/arm_cortex-a9_vfpv3-d16/packages/oniguruma_6.9.9-r1_arm_cortex-a9_vfpv3-d16.ipk ./data.tar.gz | tar -tzvf -
drwxr-xr-x  0 0      0           0 Feb  5  2024 ./
drwxr-xr-x  0 0      0           0 Feb  5  2024 ./usr/
drwxr-xr-x  0 0      0           0 Feb  5  2024 ./usr/lib/
lrwxrwxrwx  0 0      0           0 Feb  5  2024 ./usr/lib/libonig.so.5 -> libonig.so.5.4.0
```

After:
```
tar -Oxzf bin/packages/arm_cortex-a9_vfpv3-d16/packages/oniguruma_6.9.9-r1_arm_cortex-a9_vfpv3-d16.ipk ./data.tar.gz | tar -tzvf -
drwxr-xr-x  0 0      0           0 Feb  5  2024 ./
drwxr-xr-x  0 0      0           0 Feb  5  2024 ./usr/
drwxr-xr-x  0 0      0           0 Feb  5  2024 ./usr/lib/
lrwxrwxrwx  0 0      0           0 Feb  5  2024 ./usr/lib/libonig.so.5 -> libonig.so.5.4.0
-rwxr-xr-x  0 0      0      526493 Feb  5  2024 ./usr/lib/libonig.so.5.4.0
```

This properly standardizes shared library packaging, prevents shipping duplicate full-sized files (as seen previously in packages like libre2), and aligns the packages feed with core OpenWrt practices. As you could see in the previous commit (see it in the ``Fixes`` tag):

Before:
```
tar -Oxzf bin/packages/arm_cortex-a9_vfpv3-d16/packages/re2_2023.02.01\~b025c6a3-r1_arm_cortex-a9_vfpv3-d16.ipk ./data.tar.gz | tar -tzvf -
drwxr-xr-x  0 0      0           0 Aug 18  2024 ./
drwxr-xr-x  0 0      0           0 Aug 18  2024 ./usr/
drwxr-xr-x  0 0      0           0 Aug 18  2024 ./usr/lib/
-rw-r--r--  0 0      0      331875 Aug 18  2024 ./usr/lib/libre2.so
-rw-r--r--  0 0      0      331875 Aug 18  2024 ./usr/lib/libre2.so.10
-rw-r--r--  0 0      0      331875 Aug 18  2024 ./usr/lib/libre2.so.10.0.0
```

After:
```
tar -Oxzf bin/packages/arm_cortex-a9_vfpv3-d16/packages/re2_2023.02.01\~b025c6a3-r1_arm_cortex-a9_vfpv3-d16.ipk ./data.tar.gz | tar -tzvf -
drwxr-xr-x  0 0      0           0 Aug 18  2024 ./
drwxr-xr-x  0 0      0           0 Aug 18  2024 ./usr/
drwxr-xr-x  0 0      0           0 Aug 18  2024 ./usr/lib/
lrwxrwxrwx  0 0      0           0 Aug 18  2024 ./usr/lib/libre2.so -> libre2.so.10
lrwxrwxrwx  0 0      0           0 Aug 18  2024 ./usr/lib/libre2.so.10 -> libre2.so.10.0.0
-rwxr-xr-x  0 0      0      331875 Aug 18  2024 ./usr/lib/libre2.so.10.0.0
```

Fixes: 537c2a631dd117564720a80f6976280901b010f5 ("treewide: avoid deref symlinks when installing .so")
Fixes: https://github.com/openwrt/packages/issues/29387

Follow-up of the discussion in https://github.com/openwrt/packages/pull/29397