### PR TITLE
watchcat: standardize scripts and assume maintainership

### DIFF
--- a/utils/watchcat/Makefile
+++ b/utils/watchcat/Makefile
@@ -9,9 +9,9 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=watchcat
 PKG_VERSION:=1
-PKG_RELEASE:=22
+PKG_RELEASE:=23
 
-PKG_MAINTAINER:=Roger D <rogerdammit@gmail.com>
+PKG_MAINTAINER:=Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>
 PKG_LICENSE:=GPL-2.0
 
 include $(INCLUDE_DIR)/package.mk

--- a/utils/watchcat/files/migrate-watchcat
+++ b/utils/watchcat/files/migrate-watchcat
@@ -1,9 +1,13 @@
 #!/bin/sh
 
-. /lib/functions.sh
+# shellcheck shell=busybox
+
+# shellcheck source=/dev/null
+. "${IPKG_INSTROOT}"/lib/functions.sh
 
 upgrade_watchcat() {
 	local cfg="$1"
+	local period mode pinghosts forcedelay
 
 	config_get period "$cfg" period
 	config_get mode "$cfg" mode

--- a/utils/watchcat/files/watchcat.init
+++ b/utils/watchcat/files/watchcat.init
@@ -20,7 +20,8 @@ append_string() {
 }
 
 time_to_seconds() {
-	time=$1
+	local time="$1"
+	local seconds
 
 	{ [ "$time" -ge 1 ] 2>/dev/null && seconds="$time"; } ||
 		{ [ "${time%s}" -ge 1 ] 2>/dev/null && seconds="${time%s}"; } ||
@@ -28,13 +29,13 @@ time_to_seconds() {
 		{ [ "${time%h}" -ge 1 ] 2>/dev/null && seconds=$((${time%h} * 3600)); } ||
 		{ [ "${time%d}" -ge 1 ] 2>/dev/null && seconds=$((${time%d} * 86400)); }
 
-	# shellcheck disable=SC2086
-	echo $seconds
-	unset seconds
-	unset time
+	printf "%s" "$seconds"
 }
 
 config_watchcat() {
+	local period mode pinghosts pingperiod forcedely pingsize interface
+	local mmifacename unlockbands addressfamily script
+
 	# Read config
 	config_get period "$1" period "120"
 	config_get mode "$1" mode "ping_reboot"
@@ -62,7 +63,7 @@ config_watchcat() {
 	[ "$period" -ge 1 ] ||
 		append_string "error" "period has invalid format. Use time value(ex: '30'; '4m'; '6h'; '2d')" "; "
 
-	# ping_reboot mode and restart_iface mode specific checks
+	# ping_reboot mode,restart_iface mode, and run_script specific checks
 	if [ "$mode" = "ping_reboot" ] || [ "$mode" = "restart_iface" ] || [ "$mode" = "run_script" ]; then
 		if [ -z "$error" ]; then
 			pingperiod_default="$((period / 5))"
@@ -77,7 +78,6 @@ config_watchcat() {
 				append_string "warn" "pingperiod cannot be a negative value." "; "
 			fi
 
-			# shellcheck disable=SC2154
 			if [ "$mmifacename" != "null" ] && [ "$period" -lt 30 ]; then
 				append_string "error" "Check interval is less than 30s. For robust operation with ModemManager modem interfaces it is recommended to set the period to at least 30s."
 			fi
@@ -109,14 +109,12 @@ config_watchcat() {
 		;;
 	ping_reboot)
 		procd_open_instance "watchcat_${1}"
-		# shellcheck disable=SC2154
 		procd_set_param command /usr/bin/watchcat.sh "ping_reboot" "$period" "$forcedelay" "$pinghosts" "$pingperiod" "$pingsize" "$addressfamily" "$interface"
 		procd_set_param respawn "${respawn_threshold:-3600}" "${respawn_timeout:-5}" "${respawn_retry:-5}"
 		procd_close_instance
 		;;
 	restart_iface)
 		procd_open_instance "watchcat_${1}"
-		# shellcheck disable=SC2154
 		procd_set_param command /usr/bin/watchcat.sh "restart_iface" "$period" "$pinghosts" "$pingperiod" "$pingsize" "$interface" "$mmifacename" "$unlockbands" "$addressfamily"
 		procd_set_param respawn "${respawn_threshold:-3600}" "${respawn_timeout:-5}" "${respawn_retry:-5}"
 		procd_close_instance

--- a/utils/watchcat/files/watchcat.init
+++ b/utils/watchcat/files/watchcat.init
@@ -1,5 +1,8 @@
 #!/bin/sh /etc/rc.common
 
+# shellcheck shell=busybox
+
+# shellcheck disable=SC2034
 USE_PROCD=1
 
 START=97
@@ -19,12 +22,13 @@ append_string() {
 time_to_seconds() {
 	time=$1
 
-	{ [ "$time" -ge 1 ] 2> /dev/null && seconds="$time"; } ||
-		{ [ "${time%s}" -ge 1 ] 2> /dev/null && seconds="${time%s}"; } ||
-		{ [ "${time%m}" -ge 1 ] 2> /dev/null && seconds=$((${time%m} * 60)); } ||
-		{ [ "${time%h}" -ge 1 ] 2> /dev/null && seconds=$((${time%h} * 3600)); } ||
-		{ [ "${time%d}" -ge 1 ] 2> /dev/null && seconds=$((${time%d} * 86400)); }
+	{ [ "$time" -ge 1 ] 2>/dev/null && seconds="$time"; } ||
+		{ [ "${time%s}" -ge 1 ] 2>/dev/null && seconds="${time%s}"; } ||
+		{ [ "${time%m}" -ge 1 ] 2>/dev/null && seconds=$((${time%m} * 60)); } ||
+		{ [ "${time%h}" -ge 1 ] 2>/dev/null && seconds=$((${time%h} * 3600)); } ||
+		{ [ "${time%d}" -ge 1 ] 2>/dev/null && seconds=$((${time%d} * 86400)); }
 
+	# shellcheck disable=SC2086
 	echo $seconds
 	unset seconds
 	unset time
@@ -73,6 +77,7 @@ config_watchcat() {
 				append_string "warn" "pingperiod cannot be a negative value." "; "
 			fi
 
+			# shellcheck disable=SC2154
 			if [ "$mmifacename" != "null" ] && [ "$period" -lt 30 ]; then
 				append_string "error" "Check interval is less than 30s. For robust operation with ModemManager modem interfaces it is recommended to set the period to at least 30s."
 			fi
@@ -104,12 +109,14 @@ config_watchcat() {
 		;;
 	ping_reboot)
 		procd_open_instance "watchcat_${1}"
+		# shellcheck disable=SC2154
 		procd_set_param command /usr/bin/watchcat.sh "ping_reboot" "$period" "$forcedelay" "$pinghosts" "$pingperiod" "$pingsize" "$addressfamily" "$interface"
 		procd_set_param respawn "${respawn_threshold:-3600}" "${respawn_timeout:-5}" "${respawn_retry:-5}"
 		procd_close_instance
 		;;
 	restart_iface)
 		procd_open_instance "watchcat_${1}"
+		# shellcheck disable=SC2154
 		procd_set_param command /usr/bin/watchcat.sh "restart_iface" "$period" "$pinghosts" "$pingperiod" "$pingsize" "$interface" "$mmifacename" "$unlockbands" "$addressfamily"
 		procd_set_param respawn "${respawn_threshold:-3600}" "${respawn_timeout:-5}" "${respawn_retry:-5}"
 		procd_close_instance

--- a/utils/watchcat/files/watchcat.sh
+++ b/utils/watchcat/files/watchcat.sh
@@ -6,6 +6,9 @@
 # This is free software, licensed under the GNU General Public License v2.
 #
 
+# shellcheck shell=busybox
+
+# shellcheck source=/dev/null
 . /lib/network/config.sh
 
 get_ping_size() {
@@ -34,6 +37,7 @@ get_ping_size() {
 		echo "Corresponding ping packet sizes (bytes): small=1, windows=32, standard=56, big=248, huge=1492, jumbo=9000" 1>&2
 		;;
 	esac
+	# shellcheck disable=SC2086
 	echo $ps
 }
 
@@ -53,7 +57,7 @@ get_ping_family_flag() {
 		echo "Error: invalid address_family \"$family\". address_family should be one of: any, ipv4, ipv6" 1>&2
 		;;
 	esac
-	echo $family
+	echo "$family"
 }
 
 reboot_now() {
@@ -61,8 +65,8 @@ reboot_now() {
 
 	[ "$1" -ge 1 ] && {
 		sleep "$1"
-		echo 1 > /proc/sys/kernel/sysrq
-		echo b > /proc/sysrq-trigger # Will immediately reboot the system without syncing or unmounting your disks.
+		echo 1 >/proc/sys/kernel/sysrq
+		echo b >/proc/sysrq-trigger # Will immediately reboot the system without syncing or unmounting your disks.
 	}
 }
 
@@ -140,12 +144,14 @@ watchcat_monitor_network() {
 		for host in $ping_hosts; do
 			if [ "$iface" != "" ]; then
 				ping_result="$(
-					ping $ping_family -I "$iface" -s "$ping_size" -c 1 "$host" &> /dev/null
+					# shellcheck disable=SC2086
+					ping $ping_family -I "$iface" -s "$ping_size" -c 1 "$host" &>/dev/null
 					echo $?
 				)"
 			else
 				ping_result="$(
-					ping $ping_family -s "$ping_size" -c 1 "$host" &> /dev/null
+					# shellcheck disable=SC2086
+					ping $ping_family -s "$ping_size" -c 1 "$host" &>/dev/null
 					echo $?
 				)"
 			fi
@@ -222,12 +228,14 @@ watchcat_ping() {
 		for host in $ping_hosts; do
 			if [ "$iface" != "" ]; then
 				ping_result="$(
-					ping $ping_family -I "$iface" -s "$ping_size" -c 1 "$host" &> /dev/null
+					# shellcheck disable=SC2086
+					ping $ping_family -I "$iface" -s "$ping_size" -c 1 "$host" &>/dev/null
 					echo $?
 				)"
 			else
 				ping_result="$(
-					ping $ping_family -s "$ping_size" -c 1 "$host" &> /dev/null
+					# shellcheck disable=SC2086
+					ping $ping_family -s "$ping_size" -c 1 "$host" &>/dev/null
 					echo $?
 				)"
 			fi

--- a/utils/watchcat/files/watchcat.sh
+++ b/utils/watchcat/files/watchcat.sh
@@ -8,11 +8,13 @@
 
 # shellcheck shell=busybox
 
+# source=/dev/null is required as /lib/network/config.sh exists on the target
+# system, but not on the system on which shell check is run.
 # shellcheck source=/dev/null
-. /lib/network/config.sh
+. /lib/network/config.sh # Provides find_config on the OpenWrt target system
 
 get_ping_size() {
-	ps=$1
+	local ps="$1"
 	case "$ps" in
 	small)
 		ps="1"
@@ -37,12 +39,11 @@ get_ping_size() {
 		echo "Corresponding ping packet sizes (bytes): small=1, windows=32, standard=56, big=248, huge=1492, jumbo=9000" 1>&2
 		;;
 	esac
-	# shellcheck disable=SC2086
-	echo $ps
+	echo "$ps"
 }
 
 get_ping_family_flag() {
-	family=$1
+	local family="$1"
 	case "$family" in
 	any)
 		family=""
@@ -54,15 +55,19 @@ get_ping_family_flag() {
 		family="-6"
 		;;
 	*)
-		echo "Error: invalid address_family \"$family\". address_family should be one of: any, ipv4, ipv6" 1>&2
+		printf "Error: invalid address_family \"%s\". address_family should be one of: any, ipv4, ipv6" "$family" 1>&2
 		;;
 	esac
-	echo "$family"
+	printf "%s\n" "$family"
 }
 
 reboot_now() {
-	reboot &
+	# Attempt to reboot, but background so we can do a force reboot after a
+	# delay, in case the reboot attempt fails.
+	( reboot & )
 
+	# Do a forced reboot if the normal reboot has not yet completed after
+	# a delay.
 	[ "$1" -ge 1 ] && {
 		sleep "$1"
 		echo 1 >/proc/sys/kernel/sysrq
@@ -71,10 +76,12 @@ reboot_now() {
 }
 
 watchcat_periodic() {
-	failure_period="$1"
-	force_reboot_delay="$2"
+	local reboot_period="$1"
+	local force_reboot_delay="$2"
 
-	sleep "$failure_period" && reboot_now "$force_reboot_delay"
+	# After reboot_period (from service start), attempt a reboot, and if it doesn't succeed within
+	# the time specified by force_reboot_delay, do a forced reboot
+	sleep "$reboot_period" && reboot_now "$force_reboot_delay"
 }
 
 watchcat_restart_modemmanager_iface() {
@@ -105,15 +112,18 @@ watchcat_restart_all_network() {
 }
 
 watchcat_monitor_network() {
-	failure_period="$1"
-	ping_hosts="$2"
-	ping_frequency_interval="$3"
-	ping_size="$4"
-	iface="$5"
-	mm_iface_name="$6"
-	mm_iface_unlock_bands="$7"
-	address_family="$8"
-	script="$9"
+	local failure_period="$1"
+	local ping_hosts="$2"
+	local ping_frequency_interval="$3"
+	local ping_size="$4"
+	local iface="$5"
+	local mm_iface_name="$6"
+	local mm_iface_unlock_bands="$7"
+	local address_family="$8"
+	local script="$9"
+
+	local time_now time_lastcheck time_lastcheck_withinternet time_diff host
+	local ping_result
 
 	time_now="$(cat /proc/uptime)"
 	time_now="${time_now%%.*}"
@@ -141,18 +151,18 @@ watchcat_monitor_network() {
 		time_now="${time_now%%.*}"
 		time_lastcheck="$time_now"
 
+		# quoting ping_hosts is not necessary as hostnames, by definition, do not contain spaces or quotes
+		# in addition, adding quotes would break the for loop
 		for host in $ping_hosts; do
 			if [ "$iface" != "" ]; then
 				ping_result="$(
-					# shellcheck disable=SC2086
-					ping $ping_family -I "$iface" -s "$ping_size" -c 1 "$host" &>/dev/null
-					echo $?
+					ping $ping_family -I "$iface" -s "$ping_size" -c 1 "$host" >/dev/null 2>&1
+					printf "%s\n" "$?"
 				)"
 			else
 				ping_result="$(
-					# shellcheck disable=SC2086
-					ping $ping_family -s "$ping_size" -c 1 "$host" &>/dev/null
-					echo $?
+					ping $ping_family -s "$ping_size" -c 1 "$host" >/dev/null 2>&1
+					printf "%s\n" "$?"
 				)"
 			fi
 
@@ -191,13 +201,16 @@ watchcat_monitor_network() {
 }
 
 watchcat_ping() {
-	failure_period="$1"
-	force_reboot_delay="$2"
-	ping_hosts="$3"
-	ping_frequency_interval="$4"
-	ping_size="$5"
-	address_family="$6"
-	iface="$7"
+	local failure_period="$1"
+	local force_reboot_delay="$2"
+	local ping_hosts="$3"
+	local ping_frequency_interval="$4"
+	local ping_size="$5"
+	local address_family="$6"
+	local iface="$7"
+
+	local time_now time_lastcheck time_lastcheck_withinternet time_diff host
+	local ping_result
 
 	time_now="$(cat /proc/uptime)"
 	time_now="${time_now%%.*}"
@@ -225,17 +238,17 @@ watchcat_ping() {
 		time_now="${time_now%%.*}"
 		time_lastcheck="$time_now"
 
+		# quoting ping_hosts is not necessary as hostnames, by definition, do not contain spaces or quotes
+		# in addition, adding quotes would break the for loop
 		for host in $ping_hosts; do
 			if [ "$iface" != "" ]; then
 				ping_result="$(
-					# shellcheck disable=SC2086
-					ping $ping_family -I "$iface" -s "$ping_size" -c 1 "$host" &>/dev/null
+					ping $ping_family -I "$iface" -s "$ping_size" -c 1 "$host" >/dev/null 2>&1
 					echo $?
 				)"
 			else
 				ping_result="$(
-					# shellcheck disable=SC2086
-					ping $ping_family -s "$ping_size" -c 1 "$host" &>/dev/null
+					ping $ping_family -s "$ping_size" -c 1 "$host" >/dev/null 2>&1
 					echo $?
 				)"
 			fi
@@ -269,13 +282,13 @@ ping_reboot)
 	;;
 restart_iface)
 	# args from init script: period pinghosts pingperiod pingsize interface mmifacename unlockbands addressfamily
-	watchcat_monitor_network "$2" "$3" "$4" "$5" "$6" "$7" "$8" "$9" ""
+	watchcat_monitor_network "$2" "$3" "$4" "$5" "$6" "$7" "$8" "$9"
 	;;
 run_script)
 	# args from init script: period pinghosts pingperiod pingsize interface addressfamily script
 	watchcat_monitor_network "$2" "$3" "$4" "$5" "$6" "" "" "$7" "$8"
 	;;
 *)
-	echo "Error: invalid mode selected: $mode"
+	printf "Error: invalid mode selected: %s\n" "$mode"
 	;;
 esac

--- a/utils/watchcat/files/watchcat.sh
+++ b/utils/watchcat/files/watchcat.sh
@@ -49,16 +49,16 @@ get_ping_family_flag() {
 		family=""
 		;;
 	ipv4)
-		family="-4"
+		family="4"
 		;;
 	ipv6)
-		family="-6"
+		family="6"
 		;;
 	*)
 		printf "Error: invalid address_family \"%s\". address_family should be one of: any, ipv4, ipv6" "$family" 1>&2
 		;;
 	esac
-	printf "%s\n" "$family"
+	printf "%s" "$family"
 }
 
 reboot_now() {
@@ -73,6 +73,50 @@ reboot_now() {
 		echo 1 >/proc/sys/kernel/sysrq
 		echo b >/proc/sysrq-trigger # Will immediately reboot the system without syncing or unmounting your disks.
 	}
+}
+
+check_hosts() {
+	local ping_hosts="$1"
+	local time_now="$2"
+	local time_lastcheck_withinternet="$3"
+	local failure_period="$4"
+	local ping_family="$5"
+	local iface="$6"
+	local ping_size="$7"
+	local callback="$8"
+	local script="$9"
+
+	local host
+
+	# Avoid globbing while (intentionally) word-splitting in ash
+	set -f
+
+	# word splitting is intentional (in fact it is required) here
+	# shellcheck disable=SC2086
+	set -- $1
+
+	# restore default (pathname expansion/globbing)
+	set +f
+
+	local all_hosts_reachable="true"
+
+	while [ "$1" ]; do
+		host="$1"
+		shift || true
+
+		if ping ${ping_family:+-"${ping_family}"} ${iface:+-I "${iface}"} -s "$ping_size" -c 1 "$host" >/dev/null 2>&1; then
+			:
+		else
+			"$callback" "$host" "$iface" "$time_now" "$time_lastcheck_withinternet" "$failure_period" "$script"
+			all_hosts_reachable="false"
+		fi
+	done
+
+	if [ "$all_hosts_reachable" = "true" ]; then
+		time_lastcheck_withinternet="$time_now"
+	fi
+
+	echo "$time_lastcheck_withinternet"
 }
 
 watchcat_periodic() {
@@ -111,6 +155,33 @@ watchcat_restart_all_network() {
 	/etc/init.d/network restart
 }
 
+watchcat_ping_cb() {
+	local host="$1"
+	local iface="$2"
+	local time_now="$3"
+	local time_lastcheck_withinternet="$4"
+	local failure_period="$5"
+
+	logger -p daemon.info -t "watchcat[$$]" "Could not reach $host for $((time_now - time_lastcheck_withinternet)). Rebooting after reaching $failure_period"
+}
+
+watchcat_monitor_network_cb() {
+	local host="$1"
+	local iface="$2"
+	local time_now="$3"
+	local time_lastcheck_withinternet="$4"
+	local failure_period="$5"
+	local script="$6"
+
+	if [ "$script" != "" ]; then
+		logger -p daemon.info -t "watchcat[$$]" "Could not reach $host via \"$iface\" for \"$((time_now - time_lastcheck_withinternet))\" seconds. Running script after reaching \"$failure_period\" seconds"
+	elif [ "$iface" != "" ]; then
+		logger -p daemon.info -t "watchcat[$$]" "Could not reach $host via \"$iface\" for \"$((time_now - time_lastcheck_withinternet))\" seconds. Restarting \"$iface\" after reaching \"$failure_period\" seconds"
+	else
+		logger -p daemon.info -t "watchcat[$$]" "Could not reach $host for \"$((time_now - time_lastcheck_withinternet))\" seconds. Restarting networking after reaching \"$failure_period\" seconds"
+	fi
+}
+
 watchcat_monitor_network() {
 	local failure_period="$1"
 	local ping_hosts="$2"
@@ -123,7 +194,6 @@ watchcat_monitor_network() {
 	local script="$9"
 
 	local time_now time_lastcheck time_lastcheck_withinternet time_diff host
-	local ping_result
 
 	time_now="$(cat /proc/uptime)"
 	time_now="${time_now%%.*}"
@@ -151,33 +221,8 @@ watchcat_monitor_network() {
 		time_now="${time_now%%.*}"
 		time_lastcheck="$time_now"
 
-		# quoting ping_hosts is not necessary as hostnames, by definition, do not contain spaces or quotes
-		# in addition, adding quotes would break the for loop
-		for host in $ping_hosts; do
-			if [ "$iface" != "" ]; then
-				ping_result="$(
-					ping $ping_family -I "$iface" -s "$ping_size" -c 1 "$host" >/dev/null 2>&1
-					printf "%s\n" "$?"
-				)"
-			else
-				ping_result="$(
-					ping $ping_family -s "$ping_size" -c 1 "$host" >/dev/null 2>&1
-					printf "%s\n" "$?"
-				)"
-			fi
-
-			if [ "$ping_result" -eq 0 ]; then
-				time_lastcheck_withinternet="$time_now"
-			else
-				if [ "$script" != "" ]; then
-					logger -p daemon.info -t "watchcat[$$]" "Could not reach $host via \"$iface\" for \"$((time_now - time_lastcheck_withinternet))\" seconds. Running script after reaching \"$failure_period\" seconds"
-				elif [ "$iface" != "" ]; then
-					logger -p daemon.info -t "watchcat[$$]" "Could not reach $host via \"$iface\" for \"$((time_now - time_lastcheck_withinternet))\" seconds. Restarting \"$iface\" after reaching \"$failure_period\" seconds"
-				else
-					logger -p daemon.info -t "watchcat[$$]" "Could not reach $host for \"$((time_now - time_lastcheck_withinternet))\" seconds. Restarting networking after reaching \"$failure_period\" seconds"
-				fi
-			fi
-		done
+		time_lastcheck_withinternet="$(check_hosts "$ping_hosts" "$time_now" "$time_lastcheck_withinternet" "$failure_period" "$ping_family" \
+			"$iface" "$ping_size" watchcat_monitor_network_cb "$script")"
 
 		[ "$((time_now - time_lastcheck_withinternet))" -ge "$failure_period" ] && {
 			if [ "$script" != "" ]; then
@@ -210,7 +255,6 @@ watchcat_ping() {
 	local iface="$7"
 
 	local time_now time_lastcheck time_lastcheck_withinternet time_diff host
-	local ping_result
 
 	time_now="$(cat /proc/uptime)"
 	time_now="${time_now%%.*}"
@@ -238,27 +282,8 @@ watchcat_ping() {
 		time_now="${time_now%%.*}"
 		time_lastcheck="$time_now"
 
-		# quoting ping_hosts is not necessary as hostnames, by definition, do not contain spaces or quotes
-		# in addition, adding quotes would break the for loop
-		for host in $ping_hosts; do
-			if [ "$iface" != "" ]; then
-				ping_result="$(
-					ping $ping_family -I "$iface" -s "$ping_size" -c 1 "$host" >/dev/null 2>&1
-					echo $?
-				)"
-			else
-				ping_result="$(
-					ping $ping_family -s "$ping_size" -c 1 "$host" >/dev/null 2>&1
-					echo $?
-				)"
-			fi
-
-			if [ "$ping_result" -eq 0 ]; then
-				time_lastcheck_withinternet="$time_now"
-			else
-				logger -p daemon.info -t "watchcat[$$]" "Could not reach $host for $((time_now - time_lastcheck_withinternet)). Rebooting after reaching $failure_period"
-			fi
-		done
+		time_lastcheck_withinternet="$(check_hosts "$ping_hosts" "$time_now" "$time_lastcheck_withinternet" "$failure_period" "$ping_family" \
+			"$iface" "$ping_size" watchcat_ping_cb)"
 
 		[ "$((time_now - time_lastcheck_withinternet))" -ge "$failure_period" ] && reboot_now "$force_reboot_delay"
 	done


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @danielfdickinson 

@roger- @feckert 

**Description:**

We make sure the scripts are standardized by running through shellcheck and shellfmt and adjusting or overriding warnings as appropriate.

Also assume maintainership, replacing the no longer active previous maintainer (Roger D).

Finally, update after AI code reviews by Copilot and Devstral (under llama.cpp, using [LATE](https://github.com/mlhher/late-cli)).

Closes: #29391

I have a work in progress update that will enable tracking the status of watchcat in LuCI or CLI, but it will be a bit before it is ready.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** OpenWrt SNAPSHOT r34318-6018bd5b11
- **OpenWrt Target/Subtarget:** bcm27xx/bcm2712
- **OpenWrt Device:** Raspberry Pi 5 Model B Rev 1.0

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.