### PR TITLE
python-certifi: update to 2026.4.22

### DIFF
--- a/lang/python/python-certifi/Makefile
+++ b/lang/python/python-certifi/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-certifi
-PKG_VERSION:=2026.2.25
+PKG_VERSION:=2026.4.22
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Eneas U de Queiroz <cotequeiroz@gmail.com>
@@ -15,7 +15,7 @@ PKG_LICENSE_FILES:=LICENSE
 PKG_CPE_ID:=cpe:/a:certifi:certifi
 
 PYPI_NAME:=certifi
-PKG_HASH:=e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7
+PKG_HASH:=8d455352a37b71bf76a79caa83a3d6c25afee4a385d632127b6afb3963f1c580
 
 HOST_BUILD_DEPENDS:= \
 	python3/host \


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @cotequeiroz

**Description:**
Use the latest CA bundle from Mozilla.

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.