### PR TITLE
open-iscsi: fix binary paths and dbroot for 25.12

### DIFF
--- a/net/open-iscsi/Makefile
+++ b/net/open-iscsi/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=open-iscsi
 PKG_VERSION:=2.1.10
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/open-iscsi/open-iscsi
@@ -47,7 +47,8 @@ define Build/Prepare
 endef
 
 MESON_ARGS += \
-	-Dno_systemd=true
+	-Dno_systemd=true \
+	-Ddbroot=/etc/iscsi
 
 define Package/open-iscsi/conffiles
 /etc/iscsi/

--- a/net/open-iscsi/files/iscsi-gen-initiatorname
+++ b/net/open-iscsi/files/iscsi-gen-initiatorname
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# /sbin/iscsi-gen-initiatorname
+# /usr/sbin/iscsi-gen-initiatorname
 #
 # Generate a default iSCSI Initiatorname for SUSE installations.
 #
@@ -27,7 +27,7 @@ if [ -f /etc/iscsi/initiatorname.iscsi -a -z "$FORCE" ] ; then
 	eval $(cat /etc/iscsi/initiatorname.iscsi | sed -e '/^#/d')
 	if [ "$iSCSI_INITIATOR_NAME" != "$InitiatorName" ] ; then
 	    echo "iSCSI Initiatorname from iBFT is different from the current setting."
-	    echo "Please call '/sbin/iscsi-gen-initiatorname -f' to update the iSCSI Initiatorname."
+	    echo "Please call '/usr/sbin/iscsi-gen-initiatorname -f' to update the iSCSI Initiatorname."
 	    exit 1
 	fi
     fi
@@ -45,7 +45,7 @@ if [ "$iSCSI_INITIATOR_NAME" ] ; then
 ## Any change here will not be reflected to the iBFT BIOS tables.
 ## If a different initiatorname is required please change the 
 ## initiatorname in the BIOS setup and call
-## /sbin/iscsi-gen-initiatorname -f
+## /usr/sbin/iscsi-gen-initiatorname -f
 ## to recreate an updated version of this file.
 ##
 InitiatorName=$iSCSI_INITIATOR_NAME

--- a/net/open-iscsi/files/open-iscsi
+++ b/net/open-iscsi/files/open-iscsi
@@ -4,8 +4,8 @@ START=50
 STOP=50
 #USE_PROCD=1
 
-DAEMON=/sbin/iscsid
-ADM=/sbin/iscsiadm
+DAEMON=/usr/sbin/iscsid
+ADM=/usr/sbin/iscsiadm
 PIDFILE=/var/run/iscsid.pid
 
 log()


### PR DESCRIPTION
Adjust paths from /sbin to /usr/sbin for OpenWrt 25.12 compatibility and force dbroot to /etc/iscsi for persistence.

## 📦 Package Details

Martin Bauer baui@gmx.ch

**Description:**
Problem: OpenWrt 25.12 has moved binaries to /usr/sbin. Start scripts are pointing to /sbin.
And upstream moved database to non-persistent /var/lib.

Updated script paths and forced dbroot to /etc/iscsi.

---

## 🧪 Run Testing Details

- **OpenWrt Version:*25.12.3*
- **OpenWrt Target/Subtarget:*mediatek/filogic*  (all affected)
- **OpenWrt Device:*OpenWrt One*

---

## ✅ Formalities
@lucize
@rosenp

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [X] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/net/open-iscsi/refresh V=s
  ```
- [X] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
