### PR TITLE
zstd: add test-version.sh to fix CI version check failure

### DIFF
--- a/utils/zstd/test-version.sh
+++ b/utils/zstd/test-version.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# zstdgrep and zstdless are shell script wrappers; only the zstd binary reports
+# a version string
+[ "$1" = "zstd" ] || exit 0
+
+/usr/bin/zstd --version | grep -qF "$2"


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me

**Description:**

zstdgrep and zstdless are shell script wrappers around the zstd binary; they do not output a version string.  The generic CI version checker warns on both, which causes a "Some tests failed" exit in the CI runner.

Add test-version.sh to override per-file version checks.  The override verifies that /usr/bin/zstd --version contains the expected version and exits 0, which satisfies the CI infrastructure without falsely flagging the shell wrapper scripts.

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
