### PR TITLE
exfatprogs: add test-version.sh

### DIFF
--- a/utils/exfatprogs/test-version.sh
+++ b/utils/exfatprogs/test-version.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# fsck.exfat and mkfs.exfat print the version but exit non-zero when called
+# with -V (FSCK_EXIT_SYNTAX_ERROR / EXIT_FAILURE), so the generic per-file
+# version check skips their output.  Check the version here instead.
+case "$1" in
+exfat-fsck)
+	fsck.exfat -V 2>&1 | grep -qF "$2"
+	;;
+exfat-mkfs)
+	mkfs.exfat -V 2>&1 | grep -qF "$2"
+	;;
+*)
+	exit 0
+	;;
+esac


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @dangowrt 

**Description:**

Add test-version.sh: fsck.exfat and mkfs.exfat both print the version string via show_version() but exit non-zero when invoked with -V (fsck exits with FSCK_EXIT_SYNTAX_ERROR, mkfs exits with EXIT_FAILURE).  The CI generic version checker uses '|| continue' to skip failed commands, so it never sees the printed version and reports "No executables in the package provided version X.Y.Z".

test-version.sh captures the output regardless of exit code and greps for the expected version string, fixing the generic test failure.

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [ ] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
