### PR TITLE
fontconfig: fix build with SDK producing -dD style output

### DIFF
--- a/utils/fontconfig/Makefile
+++ b/utils/fontconfig/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fontconfig
 PKG_VERSION:=2.16.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.freedesktop.org/software/fontconfig/release/

--- a/utils/fontconfig/patches/001-cutout-strip-preprocessor-artifacts.patch
+++ b/utils/fontconfig/patches/001-cutout-strip-preprocessor-artifacts.patch
@@ -1,0 +1,11 @@
+--- a/src/cutout.py
++++ b/src/cutout.py
+@@ -19,6 +19,8 @@ if __name__== '__main__':
+ 
+             if write and l:
+                 stripped = re.sub(r'^\s+', '', l)
++                if stripped.startswith('#'):
++                    continue
+                 stripped = re.sub(r'\s*,\s*', ',', stripped)
+                 if not stripped.isspace() and stripped:
+                     out.write('%s\n' % stripped)


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me

**Description:**

Some SDK/host GCC configurations, when meson invokes cc.preprocess() to expand fcobjshash.gperf.h, produce output that includes predefined macro dumps (e.g. #define __STDC__ 1) alongside linemarker lines. The upstream cutout.py script, which strips CUT_OUT_BEGIN/END-delimited sections from the preprocessed output before feeding it to gperf, passes these lines through verbatim into fcobjshash.gperf.

gperf then copies them into the declarations section of fcobjshash.h. When fcobjs.c includes fcobjshash.h, the compiler encounters #define redefinitions and stray # tokens, causing a build failure.

Fix cutout.py to skip any line starting with # (C preprocessor linemarkers and predefined macro definitions) before writing to the output gperf file.

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [ ] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
