### PR TITLE
https-dns-proxy: change START to 30 and STOP to 51

### DIFF
--- a/net/https-dns-proxy/files/etc/init.d/https-dns-proxy
+++ b/net/https-dns-proxy/files/etc/init.d/https-dns-proxy
@@ -3,9 +3,9 @@
 # shellcheck disable=SC1091,SC3043,SC3060
 
 # shellcheck disable=SC2034
-START=20
+START=30
 # shellcheck disable=SC2034
-STOP=15
+STOP=51
 # shellcheck disable=SC2034
 USE_PROCD=1
 


### PR DESCRIPTION
Updated START and STOP priorities in init script.

## 📦 Package Details

**Maintainer:**  @stangri 

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

Relative to "network", https-dns-proxy starts too early, i.e. when the network is not fully available yet.

In comparison, stubby has START=30, END=51.

https-dns-prxy should also use START=30, END=51.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12.2
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** Cudy WR3000H v1

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
