### PR TITLE
Revert "ci: cancel in-progress Test and Build runs on PR update"

### DIFF
--- a/.github/workflows/multi-arch-test-build.yml
+++ b/.github/workflows/multi-arch-test-build.yml
@@ -7,10 +7,6 @@ permissions:
   contents: read
   pull-requests: write
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   formalities:
     name: Test Formalities


### PR DESCRIPTION
The previous commit broke the CI/CD pipeline, which now fails with the following error:
```
Canceling since a deadlock was detected for concurrency group: 'Test and Build-refs/pull/foo/merge' between a top level workflow and 'Feeds Package Test Build'
```

This likely occurs because the reusable workflow [1] already defines its own concurrency group.

[1] https://github.com/openwrt/actions-shared-workflows/blame/7325a2849900f35af61a08ccd7311b0c8d439246/.github/workflows/multi-arch-test-build.yml#L13

This reverts commit 753e26a1312b5b318ae8bb976e1443428afda21a.

Revert of https://github.com/openwrt/packages/pull/29410
ping: @hauke