### PR TITLE
libedit: update to version 20260512-3.1

### DIFF
--- a/libs/libedit/Makefile
+++ b/libs/libedit/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 VERSION:=3.1
-RELEASE_DATE:=20250104
+RELEASE_DATE:=20260512
 
 PKG_NAME:=libedit
 PKG_VERSION:=$(RELEASE_DATE).$(VERSION)
@@ -21,7 +21,7 @@ PKG_CPE_ID:=cpe:/a:libedit_project:libedit
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(RELEASE_DATE)-$(VERSION)
 PKG_SOURCE:=$(PKG_NAME)-$(RELEASE_DATE)-$(VERSION).tar.gz
 PKG_SOURCE_URL:=https://thrysoee.dk/editline/
-PKG_HASH:=23792701694550a53720630cd1cd6167101b5773adddcb4104f7345b73a568ac
+PKG_HASH:=432d5e7ea8b0116dd39f2eca7bc11d0eed77faa6b77ea526ace89907c23ea4a0
 
 PKG_INSTALL:=1
 
@@ -45,7 +45,7 @@ define Build/InstallDev
 
 	$(INSTALL_DIR)						$(1)/usr/include/editline
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/editline/*.h	$(1)/usr/include/editline/
-	
+
 	$(INSTALL_DIR)						$(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libedit.{a,so*}	$(1)/usr/lib/
 


### PR DESCRIPTION
changelog at https://thrysoee.dk/editline/

## 📦 Package Details

**Maintainer:** Daniel Salzman / @salzmdan

**Description:**
update of the library on which `knot` depends on

---

## 🧪 Run Testing Details

- **OpenWrt Version:** TurrisOS 9.1.0
- **OpenWrt Target/Subtarget:** mvebu/cortexa9
- **OpenWrt Device:** Turris Omnia

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [x] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
