### PR TITLE
gstreamer1: add libatomic dependency for 32-bit arm targets

### DIFF
--- a/multimedia/gstreamer1/Makefile
+++ b/multimedia/gstreamer1/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gstreamer1
 PKG_VERSION:=1.26.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=gstreamer-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://gstreamer.freedesktop.org/src/gstreamer
@@ -101,7 +101,7 @@ endef
 define Package/libgstreamer1
   $(call Package/gstreamer1/Default)
   TITLE+= library (core)
-  DEPENDS+= +glib2 +libpthread +libxml2 +(armeb||powerpc||mips||mipsel):libatomic
+  DEPENDS+= +glib2 +libpthread +libxml2 +(armeb||arm||powerpc||mips||mipsel):libatomic
   HIDDEN:=1
 endef
 


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @flyn-org 


**Description:**

arm926ej-s (ARMv5) does not have native lock-free atomics and the toolchain inserts calls to libatomic.so.1 for atomic operations. The libgstreamer1 DEPENDS only listed armeb, powerpc, mips and mipsel as needing libatomic, missing plain arm (little-endian 32-bit ARM).

Extend the condition to include arm so the package is properly declared on all 32-bit ARM targets that require libatomic.

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
