### PR TITLE
unbound: allow split config files for "ext" and "srv"

### DIFF
--- a/net/unbound/Makefile
+++ b/net/unbound/Makefile
@@ -192,6 +192,8 @@ define Package/unbound-daemon/conffiles
 /etc/unbound/unbound.conf
 /etc/unbound/unbound_ext.conf
 /etc/unbound/unbound_srv.conf
+/etc/unbound/unbound_ext-*.conf
+/etc/unbound/unbound_srv-*.conf
 endef
 
 define Build/InstallDev

--- a/net/unbound/files/unbound_ext.conf
+++ b/net/unbound/files/unbound_ext.conf
@@ -5,5 +5,9 @@
 # file is appended to the end of 'unbound.conf' with an include: statement.
 # Notice that it is not part of the server: clause. Use 'unbound_srv.conf' to
 # place custom option statements in the server: clause.
+#
+# For convenience, you have the option to further split this file into smaller
+# chunks, naming them unbound_ext-*.conf so they get backed up:
+# include: unbound_ext-foo.conf
+#
 ##############################################################################
-

--- a/net/unbound/files/unbound_srv.conf
+++ b/net/unbound/files/unbound_srv.conf
@@ -5,5 +5,10 @@
 # file is placed _inside_ the server: clause with an include: statement. Do
 # not start other clauses here, because that would break the server: clause.
 # Use 'unbound_ext.conf' to start new clauses at the end of 'unbound.conf'.
+#
+# For convenience, you have the option to further split this file into smaller
+# chunks, naming them unbound_srv-*.conf so they get backed up:
+# include: unbound_srv-foo.conf
+#
 ##############################################################################
 


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @EricLuehrsen 

**Description:**
allow splitting of "ext" and "srv" config files

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [ ] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
