### PR TITLE
minidlna: fix creation of /var/etc on start

### DIFF
--- a/multimedia/minidlna/Makefile
+++ b/multimedia/minidlna/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=minidlna
 PKG_VERSION:=1.3.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/minidlna

--- a/multimedia/minidlna/files/minidlna.init
+++ b/multimedia/minidlna/files/minidlna.init
@@ -45,6 +45,7 @@ minidlna_create_config() {
 	{ [ -z "$interface" ] || [ -t "$port" ]; } && return 1
 
 	mkdir -p /var/etc
+	{
 	echo "# this file is generated automatically, don't edit"
 
 	echo "port=$port"
@@ -67,9 +68,10 @@ minidlna_create_config() {
 	minidlna_cfg_addstr "$cfg" root_container '.'
 	minidlna_cfg_addstr "$cfg" uuid '019f9a56-ff60-44c0-9edc-eae88d09fa05'
 	config_list_foreach "$cfg" "media_dir" minidlna_cfg_add_media_dir
+	} > "$MINIDLNA_CONFIG_FILE"
 
 	return 0
-} > "$MINIDLNA_CONFIG_FILE"
+}
 
 start_service() {
 	local enabled


### PR DESCRIPTION
## 📦 Package Details
**Maintainer:** @commodo
**Description:** Fixed creation of /var/etc on start. When the service is started and dnsmasq is disabled, /var/etc doesn't exist, this was causing start to fail.

## 🧪 Run Testing Details
- **OpenWrt Version:** 25.12.4
- **OpenWrt Target/Subtarget:** kirkwood/generic
- **OpenWrt Device:** seagate,goflexnet

## ✅ Formalities
- [✅] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
