### PR TITLE
python-cryptography: add no-mips16 build flag

### DIFF
--- a/lang/python/python-cryptography/Makefile
+++ b/lang/python/python-cryptography/Makefile
@@ -20,6 +20,7 @@ PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_CPE_ID:=cpe:/a:cryptography.io:cryptography
 
 PKG_BUILD_DEPENDS:=libffi/host python-cffi/host python-maturin/host python-setuptools/host
+PKG_BUILD_FLAGS:=no-mips16
 
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me

**Description:**

On targets where CONFIG_USE_MIPS16 is enabled (e.g. mips32r2 targets with the mips16 feature), the build system injects -mips16 and -minterlink-mips16 into TARGET_CFLAGS. The cryptography-cffi Rust crate compiles C code via cc-rs and inherits these flags. When the host has Python 3.14 headers installed, the MIPS cross-compiler mixes MIPS system headers (LONG_BIT=32) with x86_64 Python headers (SIZEOF_LONG=8), failing pyport.h's consistency check with "LONG_BIT definition appears wrong for platform". python3 and python-gevent already carry this flag for the same reason.

Fixes: https://github.com/openwrt/packages/issues/29150


---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [ ] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
