### PR TITLE
alist: reintroduce package

### DIFF
--- a/net/alist/Makefile
+++ b/net/alist/Makefile
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Copyright (C) 2023-2026 ImmortalWrt.org
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=alist
+PKG_VERSION:=3.60.0
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/AlistGo/alist/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=beccffdfba65a168e796a1789b6bea11ca225101cbc4276451e02b9ad8751a82
+
+PKG_LICENSE:=AGPL-3.0-only
+PKG_LICENSE_FILES:=LICENSE
+PKG_MAINTAINER:=YUXIAO FAN <CN_QianShi@hotmail.com>
+
+PKG_BUILD_DEPENDS:=golang/host fuse
+PKG_BUILD_PARALLEL:=1
+PKG_BUILD_FLAGS:=no-mips16
+
+GO_PKG:=github.com/alist-org/alist/v3
+GO_PKG_LDFLAGS_X = \
+	$(GO_PKG)/internal/conf.Version=$(PKG_VERSION) \
+	$(GO_PKG)/internal/conf.WebVersion=$(WEB_VERSION)
+ifeq ($(filter aarch64 x86_64, $(ARCH)),)
+  GO_PKG_EXCLUDES:=drivers/lark
+endif
+
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/golang/golang-package.mk
+
+define Package/alist
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=A file list program that supports multiple storage
+  URL:=https://alistgo.com
+  DEPENDS:=$(GO_ARCH_DEPENDS) +ca-bundle +fuse-utils
+endef
+
+define Package/alist/description
+  A file list program that supports multiple storage, and supports
+  web browsing and webdav, powered by gin and Solidjs.
+  Users deploying AList on routers, NAS devices, or other sensitive
+  environments should review upstream privacy, security, and governance
+  discussions, including prior discussion of possible hardware information
+  collection, centralized governance or moderation concerns, and ongoing
+  transparency debates. Inclusion in OpenWrt package feeds should not be
+  interpreted as a full endorsement of the upstream project's trust or
+  governance posture.
+endef
+
+define Package/alist/conffiles
+/etc/alist/
+/etc/config/alist
+endef
+
+WEB_VERSION:=3.60.0
+WEB_FILE:=$(PKG_NAME)-web-$(WEB_VERSION).tar.gz
+define Download/alist-web
+	URL:=https://github.com/AlistGo/alist-web/releases/download/$(WEB_VERSION)/
+	URL_FILE:=dist.tar.gz
+	FILE:=$(WEB_FILE)
+	HASH:=35c4a218fce07c9ef5113b70ec93e385c57c2910de8852b2d0973129c12b0843
+endef
+
+define Build/Prepare
+	$(call Build/Prepare/Default)
+
+	( \
+		mkdir -p $(PKG_BUILD_DIR)/public ; \
+		gzip -dc $(DL_DIR)/$(WEB_FILE) | $(HOST_TAR) -C $(PKG_BUILD_DIR)/public $(TAR_OPTIONS) ; \
+	)
+endef
+
+ifneq ($(CONFIG_USE_MUSL),)
+  TARGET_CFLAGS += -D_LARGEFILE64_SOURCE
+endif
+
+define Package/alist/install
+	$(call GoPackage/Package/Install/Bin,$(PKG_INSTALL_DIR))
+
+	$(INSTALL_DIR) $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/alist $(1)/usr/bin/
+
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_CONF) $(CURDIR)/files/alist.config $(1)/etc/config/alist
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) $(CURDIR)/files/alist.init $(1)/etc/init.d/alist
+endef
+
+$(eval $(call Download,alist-web))
+$(eval $(call GoBinPackage,alist))
+$(eval $(call BuildPackage,alist))

--- a/net/alist/files/alist.config
+++ b/net/alist/files/alist.config
@@ -1,0 +1,37 @@
+
+config alist 'config'
+	option enabled '0'
+	option debug '0'
+
+	# listen
+	option listen_addr '0.0.0.0'
+	option listen_http_port '5244'
+	option listen_https_port '-1'
+	option listen_force_https '0'
+	option listen_cert_file ''
+	option listen_key_file ''
+	option listen_unix_file ''
+	option listen_unix_file_perm ''
+
+	# site
+	option site_url ''
+	option site_cdn ''
+	option site_login_expire '48'
+	option site_max_connections '0'
+	option site_tls_insecure '0'
+
+	# database
+	option db_type 'sqlite3'
+	option db_host ''
+	option db_port '0'
+	option db_user ''
+	option db_pass ''
+	option db_name ''
+	option db_table_prefix 'x_'
+	option db_ssl_mode ''
+
+	# log
+	option log_enable '1'
+	option log_max_size '5'
+	option log_max_backups '1'
+	option log_max_age '15'

--- a/net/alist/files/alist.init
+++ b/net/alist/files/alist.init
@@ -1,0 +1,113 @@
+#!/bin/sh /etc/rc.common
+
+USE_PROCD=1
+START=99
+
+CONF="alist"
+PROG="/usr/bin/alist"
+CONF_DIR="/etc/$CONF"
+RUN_DIR="/var/run/$CONF"
+
+uci_json_add_boolean() {
+	local enabled
+	config_get_bool enabled "${4:-config}" "$2" "${3:-0}"
+	json_add_boolean "$1" "$enabled"
+}
+
+uci_json_add_int() {
+	local value
+	config_get value "${4:-config}" "$2" "${3:-0}"
+	json_add_int "$1" "$value"
+}
+
+uci_json_add_string() {
+	local value
+	config_get value "${4:-config}" "$2" $3
+	json_add_string "$1" "$value"
+}
+
+start_service() {
+	config_load "$CONF"
+
+	local enabled
+	config_get_bool enabled "config" "enabled" "0"
+	[ "$enabled" -eq "1" ] || return 1
+
+	local jwt_secret
+	jwt_secret="$(jsonfilter -qi "$CONF_DIR/config.json" -e "@.jwt_secret")"
+	[ -n "$jwt_secret" ] || jwt_secret="$(tr -cd "a-zA-Z0-9" < "/dev/urandom" | head -c16)"
+
+	mkdir -p "$CONF_DIR"
+	mkdir -p "$RUN_DIR"
+
+	json_init
+	json_add_boolean "force" "1"
+	uci_json_add_string "site_url" "site_url"
+	uci_json_add_string "cdn" "site_cdn"
+	json_add_string "jwt_secret" "$jwt_secret"
+	uci_json_add_int "token_expires_in" "site_login_expire" "48"
+	json_add_object "database"
+		uci_json_add_string "type" "db_type" "sqlite3"
+		uci_json_add_string "host" "db_host"
+		uci_json_add_int "port" "db_port"
+		uci_json_add_string "user" "db_user"
+		uci_json_add_string "password" "db_pass"
+		uci_json_add_string "name" "db_name"
+		json_add_string "db_file" "$CONF_DIR/data.db"
+		uci_json_add_string "table_prefix" "db_table_prefix" "x_"
+		uci_json_add_string "ssl_mode" "db_ssl_mode"
+	json_close_object
+	json_add_object "scheme"
+		uci_json_add_string "address" "listen_addr" "0.0.0.0"
+		uci_json_add_int "http_port" "listen_http_port" "5244"
+		uci_json_add_int "https_port" "listen_https_port" "-1"
+		uci_json_add_boolean "force_https" "listen_force_https"
+		uci_json_add_string "cert_file" "listen_cert_file"
+		uci_json_add_string "key_file" "listen_key_file"
+		uci_json_add_string "unix_file" "listen_unix_file"
+		uci_json_add_string "unix_file_perm" "listen_unix_file_perm"
+	json_close_object
+	json_add_string "temp_dir" "$RUN_DIR/temp"
+	json_add_string "bleve_dir" "$CONF_DIR/bleve"
+	json_add_object "log"
+		uci_json_add_boolean "enable" "log_enable" "1"
+		json_add_string "name" "$RUN_DIR/log/alist.log"
+		uci_json_add_int "max_size" "log_max_size" "5"
+		uci_json_add_int "max_backups" "log_max_backups" "1"
+		uci_json_add_int "max_age" "log_max_age" "15"
+		json_add_boolean "compress" "0"
+	json_close_object
+	json_add_int "delayed_start" "0"
+	uci_json_add_int "max_connections" "site_max_connections"
+	uci_json_add_boolean "tls_insecure_skip_verify" "site_tls_insecure"
+	json_dump > "$CONF_DIR/config.json"
+
+	local db_type
+	config_get db_type "config" "db_type" "sqlite3"
+	[ "$db_type" != "sqlite3" -o -e "$CONF_DIR/data.db" ] || "$PROG" --data "$CONF_DIR" admin set "password" 2>"/dev/null"
+
+	procd_open_instance
+	procd_set_param command "$PROG"
+	procd_append_param command server
+	procd_append_param command --data "$CONF_DIR"
+	procd_append_param command --no-prefix
+
+	local debug
+	config_get_bool debug "config" "debug" "0"
+	[ "$debug" -eq "0" ] || procd_append_param command --debug
+
+	procd_set_param limits core="unlimited"
+	procd_set_param limits nofile="1000000 1000000"
+	procd_set_param respawn
+	[ "$debug" -eq "0" ] || procd_set_param stderr 1
+
+	procd_close_instance
+}
+
+stop_service() {
+	rm -rf "$RUN_DIR"
+}
+
+service_triggers() {
+	procd_add_reload_trigger "$CONF"
+}

--- a/net/alist/test.sh
+++ b/net/alist/test.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+alist version | grep "$PKG_VERSION"

--- a/net/openlist/Makefile
+++ b/net/openlist/Makefile
@@ -39,7 +39,6 @@ define Package/openlist
   TITLE:=A file list program that supports multiple storage
   URL:=https://docs.oplist.org
   DEPENDS:=$(GO_ARCH_DEPENDS) +ca-bundle
-  PROVIDES:=alist
 endef
 
 define Package/openlist/description


### PR DESCRIPTION
AList was previously available in OpenWrt packages and was later replaced by
OpenList. However, AList is still actively maintained upstream.

AList and OpenList are now separately maintained projects. They have different
feature sets, release lines, and upstream maintainers. Therefore OpenList
should not be treated as a direct replacement for AList.

This PR restores AList as an independent package in OpenWrt packages.

I am the current maintainer of AList and am willing to help maintain this
package.

Tested:
- Built with OpenWrt SDK: snapshot, x86/64, gcc-14.3.0_musl
- Target: x86/64
- Command: make package/alist/{clean,compile} V=s
- Result: success
- Output: bin/packages/x86_64/packages/alist-3.60.0-r1.apk
- Runtime verification: package installed and started in OpenWrt VM; http://127.0.0.1:5244/ served AList frontend