### PR TITLE
[25.12] bsbf-resources: update to GIT HEAD of 2026-05-14

### DIFF
--- a/net/bsbf-resources/Makefile
+++ b/net/bsbf-resources/Makefile
@@ -11,9 +11,9 @@ PKG_MAINTAINER:=Chester A. Unal <chester.a.unal@arinc9.com>
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/bondingshouldbefree/bsbf-resources.git
-PKG_SOURCE_DATE:=2026-05-11
-PKG_SOURCE_VERSION:=d4bad00854218e3ac8490ad288da6db9baf6cf1a
-PKG_MIRROR_HASH:=0927c07f092375db09d1911bd516c466f3eff6a0aca4e78332dc1837e966c1a2
+PKG_SOURCE_DATE:=2026-05-14
+PKG_SOURCE_VERSION:=3eece0a10ff73ca94bdedeacd063869c267aa3ca
+PKG_MIRROR_HASH:=d3e1094f27ba49a1f99045fb27724aaea51813260eaafebe255780336da57931
 
 include $(INCLUDE_DIR)/package.mk
 

--- a/net/bsbf-resources/files/usr/sbin/bsbf-bonding
+++ b/net/bsbf-resources/files/usr/sbin/bsbf-bonding
@@ -71,11 +71,17 @@ case "$1" in
 	ip mp e f
 	;;
 --uninstall)
-	# Uninstall BSBF packages.
-	apk del bsbf-bonding bsbf-client-web bsbf-mptcp bsbf-rate-limiting
-
 	# Delete nftables rules.
 	nft destroy table bsbf_bonding
+
+	# Stop bsbf-mptcp init.d service.
+	service bsbf-mptcp stop 2>/dev/null
+
+	# Delete bsbf-mptcp files.
+	rm -f /run/bsbf-mptcp-*
+
+	# Flush the MPTCP endpoint table.
+	ip mp e f
 
 	# Restore xray.
 	rm -f /etc/xray/config.json
@@ -83,11 +89,9 @@ case "$1" in
 	uci commit
 	service xray restart 2>/dev/null
 
-	# Delete bsbf-mptcp files.
-	rm -f /run/bsbf-mptcp-*
-
-	# Flush the MPTCP endpoint table.
-	ip mp e f
+	# Uninstall bsbf-bonding, bsbf-client-web, bsbf-mptcp, and
+	# bsbf-rate-limiting.
+	apk del bsbf-bonding bsbf-client-web bsbf-mptcp bsbf-rate-limiting
 	;;
 *)
 	usage


### PR DESCRIPTION
## 🧪 Run Testing Details

- **OpenWrt Version: 8d844758c20c2f3e60d8075dc97121dfc7cc444d**
- **OpenWrt Target/Subtarget: mediatek/mt7622**
- **OpenWrt Device: bananapi_bpi-r64**

## 🧪 Run Testing Details

- **OpenWrt Version: 8d844758c20c2f3e60d8075dc97121dfc7cc444d**
- **OpenWrt Target/Subtarget: mvebu/cortexa9**
- **OpenWrt Device: linksys_wrt32x**