### PR TITLE
perl: fix missing line numbers in error messages

### DIFF
--- a/lang/perl/Makefile
+++ b/lang/perl/Makefile
@@ -11,7 +11,7 @@ include perlver.mk
 
 PKG_NAME:=perl
 PKG_VERSION:=$(PERL_VERSION)
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE_URL:=https://www.cpan.org/src/5.0
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz

--- a/lang/perl/files/architecture.config
+++ b/lang/perl/files/architecture.config
@@ -33,6 +33,7 @@ alignbytes='8'
 	use64bitall='undef'
 	use64bitint='undef'
 	
+	u32uformat='"lu"'
 	uidformat='"lu"'
 	gidformat='"lu"'
 	
@@ -83,6 +84,7 @@ alignbytes='8'
 	
 	sizesize='8'
 	
+	u32uformat='"u"'
 	uidformat='"u"'
 	gidformat='"u"'
 	

--- a/lang/perl/perlbase.mk
+++ b/lang/perl/perlbase.mk
@@ -42,10 +42,6 @@ endef
 define Package/perlbase-archive/install
 $(call perlmod/Install,$(1),Archive,)
 $(call perlmod/InstallBaseTests,$(1),cpan/Archive-Tar/bin cpan/Archive-Tar/t)
-	$(INSTALL_DIR) $(1)/usr/bin
-	$(CP) $(PKG_INSTALL_DIR)/usr/bin/ptar $(1)/usr/bin/
-	$(CP) $(PKG_INSTALL_DIR)/usr/bin/ptardiff $(1)/usr/bin/
-	$(CP) $(PKG_INSTALL_DIR)/usr/bin/ptargrep $(1)/usr/bin/
 endef
 
 $(eval $(call BuildPackage,perlbase-archive))
@@ -1128,9 +1124,6 @@ define Package/perlbase-pod/install
 $(call perlmod/Install,$(1),Pod,Pod/Usage.pm)
 $(call perlmod/Install/NoStrip,$(1),Pod/Usage.pm,)
 $(call perlmod/InstallBaseTests,$(1),cpan/Pod-Checker/t cpan/Pod-Escapes/t cpan/Pod-Perldoc/t cpan/Pod-Simple/t cpan/Pod-Usage/scripts cpan/Pod-Usage/t cpan/podlators/t ext/Pod-Functions/Functions.pm ext/Pod-Functions/t ext/Pod-Html/t lib/Pod/t)
-	$(INSTALL_DIR) $(1)/usr/bin
-	$(CP) $(PKG_INSTALL_DIR)/usr/bin/pod2man $(1)/usr/bin/
-	$(CP) $(PKG_INSTALL_DIR)/usr/bin/pod2text $(1)/usr/bin/
 endef
 
 $(eval $(call BuildPackage,perlbase-pod))
@@ -1369,8 +1362,6 @@ define Package/perlbase-test/install
 $(call perlmod/Install,$(1),Test Test2 Test.pm Test2.pm ok.pm,Test/Builder.pm Test/More.pm Test/Tutorial.pod Test2/Transition.pod)
 $(call perlmod/Install/NoStrip,$(1),Test/Builder.pm Test/More.pm,)
 $(call perlmod/InstallBaseTests,$(1),cpan/Test-Harness/t cpan/Test-Simple/t dist/Test/t)
-	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/prove $(1)/usr/bin
 endef
 
 $(eval $(call BuildPackage,perlbase-test))


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @pprindeville
**Description:**
Adds some type definitions to architecture.config, that caused perl to return '%' instead of actual line numbers when missing. https://github.com/openwrt/packages/issues/25912

Also fixes some perlbase dependencies:
perlbase-archive https://github.com/openwrt/packages/issues/29425
perlbase-pod https://github.com/openwrt/packages/issues/29426
perlbase-test https://github.com/openwrt/packages/issues/29427

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12.0-rc2
- **OpenWrt Target/Subtarget:** bcm27xx/bcm2710
- **OpenWrt Device:** Raspberry Pi 3 Model B Rev 1.2

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
