### PR TITLE
lpac: Fix env vars for lpac wrapper

### DIFF
--- a/utils/lpac/Makefile
+++ b/utils/lpac/Makefile
@@ -4,7 +4,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lpac
 PKG_VERSION:=2.3.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/estkme-group/lpac/tar.gz/refs/tags/v$(PKG_VERSION)?

--- a/utils/lpac/files/lpac.sh
+++ b/utils/lpac/files/lpac.sh
@@ -28,8 +28,8 @@ if [ "$APDU_BACKEND" = "at" ]; then
 elif [ "$APDU_BACKEND" = "uqmi" ]; then
     UQMI_DEV="$(uci_get lpac uqmi device /dev/cdc-wdm0)"
     UQMI_DEBUG="$(uci_get lpac uqmi debug 0)"
-    export LPAC_APDU_QMI_DEVICE="$UQMI_DEV"
-    export LPAC_APDU_UQMI_DEBUG="$UQMI_DEBUG"
+    export LPAC_QMI_DEV="$UQMI_DEV"
+    export LPAC_QMI_DEBUG="$UQMI_DEBUG"
 elif [ "$APDU_BACKEND" = "mbim" ]; then
     MBIM_DEVICE="$(uci_get lpac mbim device /dev/cdc-wdm0)"
     MBIM_PROXY="$(uci_get lpac mbim proxy 1)"
@@ -38,5 +38,12 @@ elif [ "$APDU_BACKEND" = "mbim" ]; then
 fi
 
 export LPAC_CUSTOM_ISD_R_AID="$CUSTOM_ISD_R_AID"
+
+case "$1" in
+    -\?|--help|-h|-V|--version)
+        shift
+        exec /usr/lib/lpac version "$@"
+        ;;
+esac
 
 /usr/lib/lpac "$@"

--- a/utils/lpac/test-version.sh
+++ b/utils/lpac/test-version.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+[ "$1" = "lpac" ] && /usr/bin/lpac --version | grep -F '"code":0'


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** David Bauer [david.bauer@uniberg.com](mailto:david.bauer@uniberg.com)  @blocktrron

**Description:**
This patch fixes usage of `LPAC_QMI_DEV` and `LPAC_QMI_DEBUG` environment variables.

OpenWRT patch [1](https://github.com/openwrt/packages/blob/master/utils/lpac/patches/0001-driver-add-uqmi-backend.patch#L67) [2](https://github.com/openwrt/packages/blob/master/utils/lpac/patches/0001-driver-add-uqmi-backend.patch#L129) provides `uqmi` backend that uses these vars instead of `LPAC_APDU_QMI_DEVICE` and `LPAC_APDU_QMI_DEBUG` respectively. 

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12.3
- **OpenWrt Target/Subtarget:**  Qualcomm Atheros QCA9533/mips
- **OpenWrt Device:** GL.iNET E750-v2 (Mudi)

