### PR TITLE
syncthing: bump to 2.1.0

### DIFF
--- a/utils/syncthing/Makefile
+++ b/utils/syncthing/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=syncthing
-PKG_VERSION:=2.0.16
+PKG_VERSION:=2.1.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=syncthing-source-v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/syncthing/syncthing/releases/download/v$(PKG_VERSION)
-PKG_HASH:=f93836f943967c8fe608e90fd6dc2c419ce00cfa0ca5266caa86c22ae290f169
+PKG_HASH:=9fe7ed66682e3662593a68571e8f13c45158e0997dd0aca28f07ed883a6e0a27
 
 PKG_BUILD_DIR=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)/$(PKG_NAME)
 


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me

**Description:**

Bump Syncthing to 2.1.0.

Changes: https://github.com/syncthing/syncthing/releases/tag/v2.1.0

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12.4
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** QEMU/Vadas

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.