### PR TITLE
netatalk: update to 4.4.3

### DIFF
--- a/net/netatalk/Makefile
+++ b/net/netatalk/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netatalk
-PKG_VERSION:=4.3.2
-PKG_RELEASE:=2
+PKG_VERSION:=4.4.3
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@SF/netatalk
-PKG_HASH:=2977b4fd113182f0cc183337ba23d5701fb2be4e0dfcec7ee575b4d73a738d3a
+PKG_HASH:=863d640ecc99f4923ead6c58e8d3406ab3a1ca9dd3b0d47ccdf6fdebb6efe3ab
 
 PKG_MAINTAINER:=Antonio Pastor <antonio.pastor@gmail.com>
 PKG_LICENSE:=GPL-2.0-or-later
@@ -31,7 +31,7 @@ define Package/netatalk/Default
   TITLE:=Apple Filing Protocol
   PROVIDES:=netatalk
   URL:=https://netatalk.io
-  DEPENDS:=+libevent2 +libdb47 +libgcrypt +iniparser
+  DEPENDS:=+libevent2 +libdb47 +libgcrypt +iniparser +libatomic
 endef
 
 define Package/netatalk-small


### PR DESCRIPTION
Version bump.

## 📦 Package Details

**Maintainer:** @APCCV (me)

**Description:**
Security fixes (from upstream release notes):
CVE-2026-44047, CVE-2026-44048, CVE-2026-44049, CVE-2026-44050, CVE-2026-44051, CVE-2026-44052, CVE-2026-44054, CVE-2026-44055, CVE-2026-44057, CVE-2026-44060, CVE-2026-44062, CVE-2026-44064, CVE-2026-44066, CVE-2026-44068, CVE-2026-44076, CVE-2026-45354, CVE-2026-45355, CVE-2026-45356, CVE-2026-45698, CVE-2026-45699

As of v.4.4.2, upstream added a dependency on libatomic.

UAM hardening improvements also included.

Release notes at:
https://github.com/Netatalk/netatalk/releases/tag/netatalk-4-4-3

---

## 🧪 Run Testing Details

- **OpenWrt Version:** OpenWrt 25.12.3, r32912-6639b15f62 Dave's Guitar
- **OpenWrt Target/Subtarget:** kirkwood/generic
- **OpenWrt Device:** dlink,dns-320-a1

AFP sharing works as expected, CNID backend tested only.
atalkd, a2boot, macipgw, papd, timelord work as expected and show registered on nbplkup.

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch: 

None included