### PR TITLE
admin/rsyslog: add missing libyaml dependency

### DIFF
--- a/admin/rsyslog/Config.in
+++ b/admin/rsyslog/Config.in
@@ -1,4 +1,12 @@
 if PACKAGE_rsyslog
+	config RSYSLOG_libyaml
+		bool "Enable libyaml support (YAML config + file-based rate-limit policies)"
+		default n
+		help
+		  Enable libyaml support in rsyslog. Required to load YAML
+		  (.yaml/.yml) configuration files and to load rate-limiting
+		  policies from external files. Disable to drop the libyaml
+		  runtime dependency (~50KB).
 	config RSYSLOG_gssapi_krb5
 		bool "Enable GSSAPI Kerberos 5 support"
 		default n

--- a/admin/rsyslog/Makefile
+++ b/admin/rsyslog/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rsyslog
 PKG_VERSION:=8.2604.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= \
@@ -22,6 +22,7 @@ PKG_LICENSE:=GPL-3.0-or-later
 PKG_LICENSE_FILES:=COPYING
 PKG_CPE_ID:=cpe:/a:rsyslog:rsyslog
 
+PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
 
@@ -37,7 +38,7 @@ define Package/rsyslog
 	+RSYSLOG_libdbi:libdbi +libestr +libfastjson +RSYSLOG_gnutls:libgnutls \
 	+RSYSLOG_mmdblookup:libmaxminddb +RSYSLOG_mysql:libmysqlclient \
 	+RSYSLOG_omhttp:libcurl +RSYSLOG_openssl:libopenssl \
-	+RSYSLOG_pgsql:libpq +libuuid +zlib
+	+RSYSLOG_pgsql:libpq +RSYSLOG_libyaml:libyaml +libuuid +zlib
   MENU:=1
 endef
 
@@ -51,6 +52,7 @@ CONFIGURE_ARGS+= \
 	--disable-default-tests \
 	--disable-libsystemd \
 	--disable-impstats-push \
+	$(if $(CONFIG_RSYSLOG_libyaml),--enable-libyaml,--disable-libyaml) \
 	$(if $(CONFIG_RSYSLOG_gssapi_krb5),--enable-gssapi-krb5) \
 	$(if $(CONFIG_RSYSLOG_mysql),--enable-mysql) \
 	$(if $(CONFIG_RSYSLOG_pgsql),--enable-pgsql) \

--- a/admin/rsyslog/patches/001-configure-make-libyaml-default-on-explicit.patch
+++ b/admin/rsyslog/patches/001-configure-make-libyaml-default-on-explicit.patch
@@ -1,0 +1,53 @@
+From c5c2448617e72d088e818a5581a8a6cc85e81963 Mon Sep 17 00:00:00 2001
+From: Rainer Gerhards <rgerhards@adiscon.com>
+Date: Sat, 16 May 2026 10:44:45 +0200
+Subject: [PATCH] configure: make libyaml default-on explicit
+
+Why: Distro builds must not silently change rsyslog features based
+on whether libyaml development files happen to be installed.
+
+Impact: Default builds now require yaml-0.1 unless --disable-libyaml
+is passed explicitly.
+
+Before/After: Before, configure auto-disabled libyaml features;
+after, the default fails fast and opt-out builds are explicit.
+
+Closes https://github.com/rsyslog/rsyslog/issues/6914
+
+Upstream-Status: Backport [v8.2604.0 -> 8.2606.0]
+Upstream-Commit: c5c2448617e72d088e818a5581a8a6cc85e81963
+---
+ configure.ac | 17 +++++++++++++----
+ 1 file changed, 13 insertions(+), 4 deletions(-)
+
+--- a/configure.ac
++++ b/configure.ac
+@@ -166,11 +166,24 @@ AC_COMPILE_IFELSE( [AC_LANG_PROGRAM([[#i
+                  )
+ 
+ # Checks for libraries.
+-PKG_CHECK_MODULES([LIBYAML], [yaml-0.1], [
+-	AC_DEFINE([HAVE_LIBYAML], [1], [Define if libyaml is available])
+-	have_libyaml=yes
++AC_ARG_ENABLE(libyaml,
++	[AS_HELP_STRING([--disable-libyaml],
++		[Disable libyaml-backed YAML configuration and policy file support @<:@default=enabled@:>@])],
++	[case "${enableval}" in
++	 yes) enable_libyaml="yes" ;;
++	  no) enable_libyaml="no" ;;
++	   *) AC_MSG_ERROR(bad value ${enableval} for --enable-libyaml) ;;
++	 esac],
++	[enable_libyaml="yes"]
++)
++AS_IF([test "x$enable_libyaml" = "xyes"], [
++	PKG_CHECK_MODULES([LIBYAML], [yaml-0.1], [
++		AC_DEFINE([HAVE_LIBYAML], [1], [Define if libyaml is available])
++		have_libyaml=yes
++	], [
++		AC_MSG_ERROR([libyaml support is enabled by default but yaml-0.1 was not found. Install libyaml development files or configure with --disable-libyaml.])
++	])
+ ], [
+-	AC_MSG_WARN([libyaml not found, rate limiting policies from files and YAML configuration support will be disabled])
+ 	have_libyaml=no
+ ])
+ AM_CONDITIONAL(HAVE_LIBYAML, test x$have_libyaml = xyes)


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:**  me

**Description:**


   The rsyslog build requires libyaml-0.so.2 at runtime, but the
    package Makefile was missing this dependency in the DEPENDS list.
    This caused the build to fail with:
    
      Package rsyslog is missing dependencies for the following libraries:
      libyaml-0.so.2
    
    Add +libyaml to DEPENDS alongside the existing dependency on libfastjson.
    The libyaml C library (0.2.5) is already available in the packages feed.
    
    Signed-off-by: Alexandru Ardelean <alex@shruggie.ro>

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [ ] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
