### PR TITLE
ola: fix host build by inheriting host PKG_CONFIG_PATH

### DIFF
--- a/net/ola/Makefile
+++ b/net/ola/Makefile
@@ -66,7 +66,7 @@ CONFIGURE_ARGS += \
 	--with-protoc=$(STAGING_DIR_HOSTPKG)/bin/protoc-compat
 
 HOST_CONFIGURE_VARS += \
-	PKG_CONFIG_PATH="$(STAGING_DIR_HOSTPKG)/usr/protobuf-compat/lib/pkgconfig:$(PKG_CONFIG_PATH)" \
+	PKG_CONFIG_PATH="$(STAGING_DIR_HOSTPKG)/usr/protobuf-compat/lib/pkgconfig:$$$$PKG_CONFIG_PATH" \
 	CPPFLAGS="-I$(STAGING_DIR_HOSTPKG)/usr/protobuf-compat/include $(HOST_CPPFLAGS)" \
 	CXXFLAGS="-I$(STAGING_DIR_HOSTPKG)/usr/protobuf-compat/include $(HOST_CXXFLAGS)" \
 	LDFLAGS="-L$(STAGING_DIR_HOSTPKG)/usr/protobuf-compat/lib $(HOST_LDFLAGS)"


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @bk138 


**Description:**

The ola host build (HostBuild path that produces ola_protoc_plugin)
failed in clean buildbot environments with:

  configure: error: Missing the uuid library

even though libuuid is provided by tools/util-linux and is staged
at $(STAGING_DIR_HOST)/lib/pkgconfig/uuid.pc.

Root cause: HOST_CONFIGURE_VARS overrode PKG_CONFIG_PATH with

  PKG_CONFIG_PATH="$(STAGING_DIR_HOSTPKG)/usr/protobuf-compat/lib/\
pkgconfig:$(PKG_CONFIG_PATH)"

$(PKG_CONFIG_PATH) here is the make-time variable, which is never
set for host context (include/host-build.mk only exports it as a
per-rule env variable, not a make variable). It therefore expanded
to the empty string, and the resulting single-entry PKG_CONFIG_PATH
overrode the exported defaults from host-build.mk, hiding uuid.pc
from the host pkg-config wrapper.

Fix: refer to the env variable via shell expansion ($$PKG_CONFIG_PATH)
instead of the make variable. The make recipe expands $$ to $, and
the shell resolves $PKG_CONFIG_PATH from the inherited environment
populated by include/host-build.mk (which sets it to
$(STAGING_DIR_HOST)/lib/pkgconfig:$(HOST_BUILD_PREFIX)/lib/pkgconfig).

Fixes: 5e4f937e ("ola: use protobuf-compat instead of protobuf")

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [ ] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
