### PR TITLE
qemu-ga: skip starting on bare-metal device

### DIFF
--- a/utils/qemu/Makefile
+++ b/utils/qemu/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=qemu
 PKG_VERSION:=10.1.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://download.qemu.org/
 PKG_HASH:=fbaa7a0d7a9a1deb5695b125916746ec28fe0de6275d4454f3e3bbaf8b339b53

--- a/utils/qemu/files/qemu-ga.init
+++ b/utils/qemu/files/qemu-ga.init
@@ -7,6 +7,10 @@ USE_PROCD=1
 BIN=/usr/bin/qemu-ga
 
 start_service() {
+	if [ ! -d /dev/virtio-ports ];then
+		logger -t qemu-ga -p daemon.notice "/dev/virtio-ports not found. Skipping qemu-ga (this is normal on bare metal device)."
+		return 0
+	fi
 	procd_open_instance
 	procd_set_param command $BIN
 	procd_set_param respawn


### PR DESCRIPTION
The same firmware image may be deployed on either bare metal device or virtualized platforms (e.g., Proxmox VE).

On bare metal device, `qemu-ga` may still be started even though no virtio-serial channel is available, resulting in repeated attempts to access /dev/virtio-ports/org.qemu.guest_agent.0.

This causes continuous service respawning by procd and unnecessary log spam.

This commit adds a pre-check for /dev/virtio-ports to avoid starting `qemu-ga` when virtio-serial support is not present.

related logs:
```
daemon.err: qemu-ga[6259]: 1779119060.919739: critical: error opening channel '/dev/virtio-ports/org.qemu.guest_agent.0': No such file or directory
daemon.err: qemu-ga[6259]: 1779119060.919757: critical: failed to create guest agent channel
daemon.err: qemu-ga[6259]: 1779119060.919762: critical: failed to initialize guest agent channel
daemon.err: qemu-ga[6259]: 1779119060.919791: critical: error initializing guest agent
daemon.err: qemu-ga[7016]: 1779119065.934454: critical: error opening channel '/dev/virtio-ports/org.qemu.guest_agent.0': No such file or directory
daemon.err: qemu-ga[7016]: 1779119065.934475: critical: failed to create guest agent channel
daemon.err: qemu-ga[7016]: 1779119065.934481: critical: failed to initialize guest agent channel
daemon.err: qemu-ga[7016]: 1779119065.934486: critical: error initializing guest agent
daemon.err: qemu-ga[7313]: 1779119070.973746: critical: error opening channel '/dev/virtio-ports/org.qemu.guest_agent.0': No such file or directory
daemon.err: qemu-ga[7313]: 1779119070.973761: critical: failed to create guest agent channel
daemon.err: qemu-ga[7313]: 1779119070.973766: critical: failed to initialize guest agent channel
daemon.err: qemu-ga[7313]: 1779119070.973791: critical: error initializing guest agent
daemon.err: qemu-ga[8164]: 1779119076.013910: critical: error opening channel '/dev/virtio-ports/org.qemu.guest_agent.0': No such file or directory
daemon.err: qemu-ga[8164]: 1779119076.013928: critical: failed to create guest agent channel
daemon.err: qemu-ga[8164]: 1779119076.013934: critical: failed to initialize guest agent channel
daemon.err: qemu-ga[8164]: 1779119076.013939: critical: error initializing guest agent
daemon.err: qemu-ga[9531]: 1779119081.043780: critical: error opening channel '/dev/virtio-ports/org.qemu.guest_agent.0': No such file or directory
daemon.err: qemu-ga[9531]: 1779119081.043796: critical: failed to create guest agent channel
daemon.err: qemu-ga[9531]: 1779119081.043801: critical: failed to initialize guest agent channel
daemon.err: qemu-ga[9531]: 1779119081.043806: critical: error initializing guest agent
daemon.err: qemu-ga[10502]: 1779119086.103792: critical: error opening channel '/dev/virtio-ports/org.qemu.guest_agent.0': No such file or directory
daemon.err: qemu-ga[10502]: 1779119086.103810: critical: failed to create guest agent channel
daemon.err: qemu-ga[10502]: 1779119086.103815: critical: failed to initialize guest agent channel
daemon.err: qemu-ga[10502]: 1779119086.103820: critical: error initializing guest agent
daemon.info: procd: Instance qemu-ga::instance1 s in a crash loop 6 crashes, 0 seconds since last crash
```
## 📦 Package Details

**Maintainer:** @<github-user>
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** N100

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
