### PR TITLE
simple-captive-portal: order nft chains predictably

### DIFF
--- a/net/simple-captive-portal/Makefile
+++ b/net/simple-captive-portal/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=simple-captive-portal
 PKG_VERSION:=2025.06.22
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Etienne CHAMPETIER <champetier.etienne@gmail.com>
 PKG_LICENSE:=GPL-2.0-or-later

--- a/net/simple-captive-portal/files/etc/init.d/simple-captive-portal
+++ b/net/simple-captive-portal/files/etc/init.d/simple-captive-portal
@@ -21,7 +21,7 @@ table inet simple-captive-portal {
     }
 
     chain prerouting {
-        type nat hook prerouting priority mangle; policy drop;
+        type nat hook prerouting priority mangle - 5; policy drop;
         iif != ${INTF} accept
         ether saddr @guest_macs accept
         tcp dport 80 redirect to ${PORT_REDIRECT}


### PR DESCRIPTION
Adjust simple-captive-portal firewall chain priority to apply before default chain deterministically

##  Package Details

**Maintainer:** @champtar 

**Description:**  Provides a simple captive portal splash page.
---

##  Run Testing Details

- **OpenWrt Version:** 25.10.4 
- **OpenWrt Target/Subtarget:** x86/64 efi
- **OpenWrt Device:** vm

---

##  Formalities

- [x ] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x ] It is structured in a way that it is potentially upstreamable
