### PR TITLE
ola: fix host compilation in buildbot

### DIFF
--- a/net/ola/Makefile
+++ b/net/ola/Makefile
@@ -66,10 +66,10 @@ CONFIGURE_ARGS += \
 	--with-protoc=$(STAGING_DIR_HOSTPKG)/bin/protoc-compat
 
 HOST_CONFIGURE_VARS += \
-	PKG_CONFIG_PATH="$(STAGING_DIR_HOSTPKG)/usr/protobuf-compat/lib/pkgconfig:$(PKG_CONFIG_PATH)" \
-	CPPFLAGS="-I$(STAGING_DIR_HOSTPKG)/usr/protobuf-compat/include $(HOST_CPPFLAGS)" \
-	CXXFLAGS="-I$(STAGING_DIR_HOSTPKG)/usr/protobuf-compat/include $(HOST_CXXFLAGS)" \
-	LDFLAGS="-L$(STAGING_DIR_HOSTPKG)/usr/protobuf-compat/lib $(HOST_LDFLAGS)"
+	PKG_CONFIG_PATH="$(STAGING_DIR_HOSTPKG)/usr/protobuf-compat/lib/pkgconfig:$(STAGING_DIR_HOST)/lib/pkgconfig:$(PKG_CONFIG_PATH)" \
+	CPPFLAGS="-I$(STAGING_DIR_HOSTPKG)/usr/protobuf-compat/include -I$(STAGING_DIR_HOST)/include $(HOST_CPPFLAGS)" \
+	CXXFLAGS="-I$(STAGING_DIR_HOSTPKG)/usr/protobuf-compat/include -I$(STAGING_DIR_HOST)/include $(HOST_CXXFLAGS)" \
+	LDFLAGS="-L$(STAGING_DIR_HOSTPKG)/usr/protobuf-compat/lib -L$(STAGING_DIR_HOST)/lib $(HOST_LDFLAGS)"
 
 CONFIGURE_VARS += \
 	PKG_CONFIG_PATH="$(STAGING_DIR)/usr/protobuf-compat/lib/pkgconfig:$(PKG_CONFIG_PATH)" \


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @bk138 
**Description:**

Add explicit host includes to fix uuid.h lookup in buildbot.

Fixes: 5e4f937e ("ola: use protobuf-compat instead of protobuf")

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

Compile-tested only.

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.