### PR TITLE
lvm2: update to 2.03.41

### DIFF
--- a/utils/lvm2/Makefile
+++ b/utils/lvm2/Makefile
@@ -9,15 +9,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=LVM2
-PKG_VERSION:=2.03.40
-PKG_VERSION_DM:=1.02.209
+PKG_VERSION:=2.03.41
+PKG_VERSION_DM:=1.02.215
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME).$(PKG_VERSION).tgz
 PKG_SOURCE_URL:=https://sourceware.org/pub/lvm2 \
                 https://www.mirrorservice.org/sites/sourceware.org/pub/lvm2
 
-PKG_HASH:=60c9bb5c0a109f20267bb40ba50c00c84a110fc14c129f21afb5566929bf5645
+PKG_HASH:=d58011b845df8ec13816ca13ea6c39d4cb3d038cd2d7d387acdf5681ad7d6637
 PKG_BUILD_DIR:=$(BUILD_DIR)/lvm2-$(BUILD_VARIANT)/$(PKG_NAME).$(PKG_VERSION)
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>

--- a/utils/lvm2/patches/002-const-stdio.patch
+++ b/utils/lvm2/patches/002-const-stdio.patch
@@ -1,6 +1,6 @@
 --- a/lib/commands/toolcontext.c
 +++ b/lib/commands/toolcontext.c
-@@ -1668,6 +1668,7 @@ struct cmd_context *create_toolcontext(u
+@@ -1665,6 +1665,7 @@ struct cmd_context *create_toolcontext(c
  	/* FIXME Make this configurable? */
  	reset_lvm_errno(1);
  
@@ -8,7 +8,7 @@
  	/* Set in/out stream buffering before glibc */
  	if (set_buffering
  	    && !cmd->running_on_valgrind /* Skipping within valgrind execution. */
-@@ -1712,6 +1713,7 @@ struct cmd_context *create_toolcontext(u
+@@ -1709,6 +1710,7 @@ struct cmd_context *create_toolcontext(c
  	} else if (!set_buffering)
  		/* Without buffering, must not use stdin/stdout */
  		init_silent(1);
@@ -16,7 +16,7 @@
  
  	/*
  	 * Environment variable LVM_SYSTEM_DIR overrides this below.
-@@ -2050,6 +2052,7 @@ void destroy_toolcontext(struct cmd_cont
+@@ -2047,6 +2049,7 @@ void destroy_toolcontext(struct cmd_cont
  	if (cmd->cft_def_hash)
  		dm_hash_destroy(cmd->cft_def_hash);
  
@@ -24,7 +24,7 @@
  	if (!cmd->running_on_valgrind && cmd->linebuffer) {
  		int flags;
  		/* Reset stream buffering to defaults */
-@@ -2073,6 +2076,7 @@ void destroy_toolcontext(struct cmd_cont
+@@ -2070,6 +2073,7 @@ void destroy_toolcontext(struct cmd_cont
  
  		free(cmd->linebuffer);
  	}
@@ -34,7 +34,7 @@
  
 --- a/tools/lvmcmdline.c
 +++ b/tools/lvmcmdline.c
-@@ -3394,6 +3394,7 @@ int lvm_split(char *str, int *argc, char
+@@ -3395,6 +3395,7 @@ int lvm_split(char *str, int *argc, char
  /* Make sure we have always valid filedescriptors 0,1,2 */
  static int _check_standard_fds(void)
  {
@@ -42,7 +42,7 @@
  	int err = is_valid_fd(STDERR_FILENO);
  
  	if (!is_valid_fd(STDIN_FILENO) &&
-@@ -3420,6 +3421,12 @@ static int _check_standard_fds(void)
+@@ -3421,6 +3422,12 @@ static int _check_standard_fds(void)
  		       strerror(errno));
  		return 0;
  	}

--- a/utils/lvm2/patches/003-no-mallinfo.patch
+++ b/utils/lvm2/patches/003-no-mallinfo.patch
@@ -1,6 +1,6 @@
 --- a/lib/mm/memlock.c
 +++ b/lib/mm/memlock.c
-@@ -201,12 +201,15 @@ static void _allocate_memory(void)
+@@ -209,12 +209,15 @@ static void _allocate_memory(void)
  	 *  memory on free(), this is good enough for our purposes.
  	 */
  	while (missing > 0) {
@@ -9,27 +9,27 @@
  		hblks = inf.hblks;
 +#endif
  
- 		if ((areas[area] = malloc(_size_malloc_tmp)))
- 			_touch_memory(areas[area], _size_malloc_tmp);
+ 		if ((areas[area] = malloc(alloc_size)))
+ 			_touch_memory(areas[area], alloc_size);
  
 +#ifdef __GLIBC__
  		inf = MALLINFO();
  
  		if (hblks < inf.hblks) {
-@@ -216,9 +219,12 @@ static void _allocate_memory(void)
+@@ -224,9 +227,12 @@ static void _allocate_memory(void)
  			free(areas[area]);
- 			_size_malloc_tmp /= 2;
+ 			alloc_size /= 2;
  		} else {
 +#endif
  			++ area;
- 			missing -= _size_malloc_tmp;
+ 			missing -= alloc_size;
 +#ifdef __GLIBC__
  		}
 +#endif
  
  		if (area == MAX_AREAS && missing > 0) {
  			/* Too bad. Warn the user and proceed, as things are
-@@ -552,8 +558,13 @@ static void _lock_mem(struct cmd_context
+@@ -560,8 +566,13 @@ static void _lock_mem(struct cmd_context
  	 * will not block memory locked thread
  	 * Note: assuming _memlock_count_daemon is updated before _memlock_count
  	 */


### PR DESCRIPTION
**Maintainer:** @dangowrt

Stable bug-fix release in the 2.03.x series. The bundled device-mapper library bumps from 1.02.209 to 1.02.215; track that in `PKG_VERSION_DM` as well so the libdevmapper package shows the correct upstream version.

Build-tested for arm_cortex-a7+neon-vfpv4 (mediatek/mt7623).