### PR TITLE
openal-soft: update to 1.25.2

### DIFF
--- a/sound/openal-soft/Makefile
+++ b/sound/openal-soft/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openal-soft
-PKG_VERSION:=1.25.1
+PKG_VERSION:=1.25.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/kcat/openal-soft/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=5f8efe8dfba5e9307a50251ba615ace857c7fa9dddfe34130b83e213d7f7cf24
+PKG_HASH:=fb27e5839aa11f0e5b9d33756965291fad5d6909ab928ea1f796f4a1a6877894
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=LGPL-2.0-only BSD-3-Clause


### PR DESCRIPTION
**Maintainer:** @dangowrt

Stable bug-fix release in the 1.25.x series. Highlights from upstream's ChangeLog:

 * Fix STL hardening assertion in the reverb effect.
 * Fix a potential crash with older PipeWire headers.
 * Fix capturing mono from a stereo or greater WASAPI input device.
 * Add capture support to the SDL3 backend.
 * Implement 3D processing for Distortion, Chorus, Flanger, Pitch Shifter and Frequency Shifter effects.

Build-tested for arm_cortex-a7+neon-vfpv4 (mediatek/mt7623).