### PR TITLE
perl: fix miniperl missing execute permission (CI fix)

### DIFF
--- a/lang/perl/Makefile
+++ b/lang/perl/Makefile
@@ -135,6 +135,8 @@ define Build/Compile
 	# make depend is required to avoid race conditions: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=996953
 	+$(MAKE) -C $(PKG_BUILD_DIR) depend
 	+$(MAKE) $(PKG_JOBS) -C $(PKG_BUILD_DIR)
+	# miniperl may lack execute permission on some build systems, fix it for extension builds
+	chmod +x $(PKG_BUILD_DIR)/miniperl
 endef
 
 ifeq ($(CONFIG_arc),)


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @<github-user>


**Description:**

On some build systems, the miniperl binary is created without execute permission (errno 126 when running it as /bin/sh). This breaks building the mro extension and cascades to all dependent packages.

Fix by ensuring chmod +x on miniperl after the main build step. This matches how many other build systems handle this same issue.

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [ ] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

