### PR TITLE
rsync: update to 3.4.3

### DIFF
--- a/net/rsync/Makefile
+++ b/net/rsync/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rsync
-PKG_VERSION:=3.4.2
+PKG_VERSION:=3.4.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://download.samba.org/pub/$(PKG_NAME)/src
-PKG_HASH:=ff10aa2c151cd4b2dbbe6135126dbc854046113d2dfb49572a348233267eb315
+PKG_HASH:=c72e63ca3021cbc80ba86ec30102773f4c5631fbc492b52e773b3958f82a53d3
 
 PKG_MAINTAINER:=Maxim Storchak <m.storchak@gmail.com>
 PKG_LICENSE:=GPL-3.0-or-later


### PR DESCRIPTION

## 📦 Package Details

**Maintainer:** @mstorchak
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

Changelog: https://download.samba.org/pub/rsync/NEWS#3.4.3

This is an important update fixing 6 CVEs: CVE-2026-29518, CVE-2026-43617, CVE-2026-43619, CVE-2026-43618,
CVE-2026-43620, and CVE-2026-4523

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** x86/64-glibc
- **OpenWrt Device:** Intel N150

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
