### PR TITLE
openvpn: add missing host routes

### DIFF
--- a/net/openvpn/files/usr/libexec/openvpn-hotplug
+++ b/net/openvpn/files/usr/libexec/openvpn-hotplug
@@ -45,13 +45,14 @@ parse_cidr6() {
 
 case "$script_type" in
 	up)
+		nohostroute="$(uci_get network "$INTERFACE" nohostroute)"
 		proto_init_update "$dev" 1
 
 		[ -n "$ifconfig_local" ] && proto_add_ipv4_address "$ifconfig_local" "${ifconfig_netmask:-255.255.255.255}"
 
 		[ -n "$trusted_ip" ] && {
-			if [ -n "$route_net_gateway" -a "$route_net_gateway" != "0.0.0.0" ]; then
-				proto_add_ipv4_route "$trusted_ip" 32 "$route_net_gateway"
+			if [ -n "$route_net_gateway" -a "$route_net_gateway" != "0.0.0.0" -a "${nohostroute}" != "1" ]; then
+				proto_add_host_dependency "$INTERFACE" "$trusted_ip"
 			fi
 		}
 
@@ -77,8 +78,10 @@ case "$script_type" in
 			fi
 
 			[ -n "$trusted_ip6" ] && {
-				if [ -n "$route_ipv6_gateway" -a "$route_ipv6_gateway" != "::" ]; then
-					proto_add_ipv6_route "$trusted_ip6" 128 "$route_ipv6_gateway"
+				# to detect net_gateway_ipv6, source routing on wan6 has to be disabled
+				# consider removing check for net_gateway_ipv6
+				if [ -n "$net_gateway_ipv6" -a "$net_gateway_ipv6" != "::" -a "${nohostroute}" != "1" ]; then
+					proto_add_host_dependency "$INTERFACE" "$trusted_ip6"
 				fi
 			}
 


### PR DESCRIPTION
Maintainer: Alexandru Ardelean <ardeleanalex@gmail.com>

ping @feckert @commodo 

First of all big thanks to all involved devs, porting this to proto is not a minor task and besides some small quirks it is working well. (Not all that happy with the use of a default route instead of /1 routes, because you loose internet if the tunnel goes down but that is just me nitpicking)

However I had problems with default routing as the host routes to the server endpoint were missing.

I tracked it down to code in the `openvpn-hotplug` script and made some changes and in my testing it appears to work now. As a bonus I also added code for a future implementation of the `nohostroute` option.

Problem:
The host routes were created by just using route setup this however does not work.

Solution:
using `proto_add_host_dependency` seems the better solution.

Furthermore the correct guard for IPv6 seems to be `net_gateway_ipv6` instead of `route_ipv6_gateway` however even the correct guard is only working if ipv6 source routing is disabled on wan6, so perhaps we should consider removing the guard entirely. For now I left it in place with a warning.

I have tested it on X86 running master build from 5 days ago, both for IPv4 and IPv6

Please have a look and consider implementing.

Thanks

---

## 🧪 Run Testing Details

- **OpenWrt Version: Master**
- **OpenWrt Target/Subtarget: X86**
- **OpenWrt Device: X86**

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [X] It can be applied using `git am`
- [X] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [X] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
