### PR TITLE
dnsdist: update to 2.0.6

### DIFF
--- a/libs/lmdb/test-version.sh
+++ b/libs/lmdb/test-version.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+pkg=$1
+ver=$2
+
+case "$pkg" in
+lmdb)
+	exit 0
+	;;
+lmdb-test)
+	exit 0
+	;;
+lmdb-utils)
+	mdb_dump -V 2>&1 | grep -qF "LMDB $ver" || exit 1
+	exit 0
+	;;
+*)
+	echo "test-version.sh: unhandled sub-package '$pkg'" >&2
+	exit 1
+	;;
+esac

--- a/net/dnsdist/Makefile
+++ b/net/dnsdist/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnsdist
-PKG_VERSION:=2.0.1
+PKG_VERSION:=2.0.6
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://downloads.powerdns.com/releases/
-PKG_HASH:=144e2356d07d6577a570782a6f79f426125344221dbdc4ddaaa7f9d468d51900
+PKG_HASH:=b861d74abb0da59cff4e58760266198196eee7c10f2bfe86a3f5ccbd6768626b
 
 PKG_MAINTAINER:=Peter van Dijk <peter.van.dijk@powerdns.com>, Remi Gacogne <remi.gacogne@powerdns.com>
 PKG_LICENSE:=GPL-2.0-only


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @Habbie 

**Description:**

Bump from 2.0.1 to the latest 2.0 LTS release. This pulls in upstream commit 53cb738795 ("dnsdist: make code boost-1.91 compatible", Otto Moerbeek, 2026-04-29), which fixes the build break against Boost 1.91 currently shipped by OpenWrt:

  dnsdist-lua.cc:3086:101: error: converting to
    'boost::optional<unordered_map<...>>' from initializer list
    would use explicit constructor 'constexpr boost::optional<T>::
    optional(U&&) [...]'

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [ ] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
