### PR TITLE
frp: bump to 0.69.0

### DIFF
--- a/net/frp/Makefile
+++ b/net/frp/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=frp
-PKG_VERSION:=0.68.1
+PKG_VERSION:=0.69.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/fatedier/frp/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=44ed7107bf35e4f68dc0e77cd5805102effa5301528b89ee5ab0ab379088edc6
+PKG_HASH:=b78879e74e44bb22805a8a4602c6f58b9f46971c003eb4079d5020f66e57ed37
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** N/A

**Description:**
Changes: https://github.com/fatedier/frp/releases/tag/v0.69.0

---

## 🧪 Run Testing Details

- **OpenWrt Version:** qualcommax/aarch64
- **OpenWrt Target/Subtarget:** qualcommax/aarch64
- **OpenWrt Device:** ipq6000-360v6

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
