### PR TITLE
erlang: fix PKG_CPE_ID escaping for apk ADB format

### DIFF
--- a/lang/erlang/Makefile
+++ b/lang/erlang/Makefile
@@ -18,7 +18,7 @@ PKG_HASH:=2c7e8ca23e6864eb20eff5d44738bfa123aed8cd21ed6d98e533d751eee28d9c
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE.txt
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
-PKG_CPE_ID:=cpe:/a:erlang:erlang\/otp
+PKG_CPE_ID:=cpe:/a:erlang:erlang
 
 PKG_BUILD_DEPENDS:=erlang/host openssl unixodbc/host
 PKG_BUILD_FLAGS:=no-mips16


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me

**Description:**

apk's ADB binary package format rejects both the backslash-escape and the percent-encoding variants of the previous CPE id:

  cpe:/a:erlang:erlang\/otp     ERROR: info field 'tags' has invalid value
  cpe:/a:erlang:erlang%2Fotp    ERROR: info field 'tags' has invalid value

apk's tag value parser only accepts a restricted alphabet for ADB package format and neither '\' nor '%' make the cut. The result is that the package never produces an .apk.

Drop the '/otp' suffix entirely and use cpe:/a:erlang:erlang, which matches the higher-level Erlang CPE entry. cve scanners that walked the more specific erlang\/otp entry will fall back to this one.

This effectively reverts the product portion of bfdf01496 ("lang/erlang: fix PKG_CPE_ID"), which was correct against the NIST 2.3 string but incompatible with apk's tag parser.
---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [ ] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
