### PR TITLE
libxerces-c: fix CI build/test failures for apk + samples

### DIFF
--- a/libs/libxerces-c/Makefile
+++ b/libs/libxerces-c/Makefile
@@ -18,7 +18,7 @@ PKG_HASH:=6239e6035645b21bc9bf7f02004db334dce3fe6d85428ee4fe7e180c2d948230
 PKG_MAINTAINER:=Álvaro Fernández Rojas <noltari@gmail.com>
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
-PKG_CPE_ID:=cpe:/a:apache:xerces-c\+\+
+PKG_CPE_ID:=cpe:/a:apache:xerces-c
 
 include $(INCLUDE_DIR)/nls.mk
 include $(INCLUDE_DIR)/package.mk

--- a/libs/libxerces-c/test-version.sh
+++ b/libs/libxerces-c/test-version.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+pkg=$1
+ver=$2
+
+case "$pkg" in
+libxerces-c)
+	exit 0
+	;;
+libxerces-c-samples)
+	exit 0
+	;;
+*)
+	echo "test-version.sh: unhandled sub-package '$pkg'" >&2
+	exit 1
+	;;
+esac


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @Noltari 



**Description:**

Two unrelated issues both fixed here so the package + its samples sub-package land in CI green:

1. PKG_CPE_ID escaping. apk's ADB binary package format rejects both the backslash-escape and the percent-encoding variants of the previous CPE id:

     cpe:/a:apache:xerces-c\+\+     ERROR: info field 'tags' has invalid value
     cpe:/a:apache:xerces-c%2B%2B   ERROR: info field 'tags' has invalid value

   apk's tag value parser only accepts a restricted alphabet for ADB package format and neither '\' nor '%' make the cut. With xerces-c unable to build, downstream consumers (notably sumo) also fail at cmake configure time with "Failed to find XercesC".

   Drop the '++' suffix entirely and use cpe:/a:apache:xerces-c, which matches the higher-level Apache Xerces-C CPE entry. cve scanners that walked the more specific xerces-c++ entry will fall back to this one.

2. Generic version-check override for libxerces-c-samples. The samples sub-package ships upstream demo programs (CreateDOMDocument, DOMCount, DOMPrint, SAX2Count, ...) which do not accept --version / -v / -V and therefore fail the framework's "executable prints PKG_VERSION" probe, making the package overall report "Generic tests failed". Add a minimal test-version.sh that exits 0 so the version-probe is skipped and the remaining generic checks (executable, no hardcoded paths, stripped, linked libs) still run for every binary.
---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [ ] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
