### PR TITLE
netifd: add pending PR to fix GCC16 builds

### DIFF
--- a/net/nlbwmon/Makefile
+++ b/net/nlbwmon/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nlbwmon
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/jow-/nlbwmon.git

--- a/net/nlbwmon/patches/020-fix-discarded-qualifiers-warning-with-GCC-16.patch
+++ b/net/nlbwmon/patches/020-fix-discarded-qualifiers-warning-with-GCC-16.patch
@@ -1,0 +1,25 @@
+From 7af6798a218737db7efc46dd4b9ae74b4c6a48f8 Mon Sep 17 00:00:00 2001
+From: John Audia <therealgraysky@proton.me>
+Date: Tue, 26 May 2026 09:22:30 -0400
+Subject: [PATCH] fix discarded-qualifiers warning with GCC 16
+
+strchr() returns char * even when passed a const char *, a known
+C standard wart. Explicitly cast the return value to char * to
+satisfy -Werror=discarded-qualifiers
+
+Signed-off-by: John Audia <therealgraysky@proton.me>
+---
+ subnets.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/subnets.c
++++ b/subnets.c
+@@ -36,7 +36,7 @@ parse_subnet(const char *addr, struct su
+ 	unsigned long int n;
+ 	uint8_t i, b;
+ 
+-	mask = strchr(addr, '/');
++	mask = (char *)strchr(addr, '/');
+ 
+ 	if (mask)
+ 		memcpy(tmp, addr, mask++ - addr);


### PR DESCRIPTION

## 📦 Package Details

**Maintainer:** @jow- 
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

Add pending https://github.com/jow-/nlbwmon/pull/75

This is needed for: https://github.com/openwrt/openwrt/pull/23194

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** x86/64-glibc
- **OpenWrt Device:** Intel N150

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [x] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
