### PR TITLE
gstreamer1: fix build failures when cross-compiling

### DIFF
--- a/multimedia/gstreamer1/Makefile
+++ b/multimedia/gstreamer1/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gstreamer1
 PKG_VERSION:=1.26.4
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=gstreamer-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://gstreamer.freedesktop.org/src/gstreamer
@@ -125,6 +125,7 @@ MESON_ARGS += \
 	-Dpoisoning=false \
 	-Dmemory-alignment=malloc \
 	-Dcheck=enabled \
+	-Dtests=disabled \
 	-Dlibunwind=disabled \
 	-Dlibdw=disabled \
 	-Ddbghelp=disabled \

--- a/multimedia/gstreamer1/patches/020-meson-no-solaris-network-libs-on-linux.patch
+++ b/multimedia/gstreamer1/patches/020-meson-no-solaris-network-libs-on-linux.patch
@@ -1,0 +1,43 @@
+From: Daniel Golle <daniel@makrotopia.org>
+Date: Thu, 22 May 2026 00:00:00 +0100
+Subject: [PATCH] meson: only probe Solaris network libraries on Solaris
+
+The '-lsocket' / '-lnsl' networking libraries are a Solaris and
+Illumos peculiarity, as the comment right above the probe already
+states. Probing for them unconditionally with cc.find_library()
+is harmful when cross-compiling: if the build host happens to have
+a 'libnsl' package installed, meson locates the host's
+/usr/lib/libnsl.so and puts its absolute path on the link line,
+which then fails the cross link with an "incompatible file type"
+error.
+
+Gate the probe on host_machine.system() == 'sunos' so it is only
+performed where those split libraries actually exist.
+
+Signed-off-by: Daniel Golle <daniel@makrotopia.org>
+--- a/meson.build
++++ b/meson.build
+@@ -589,14 +589,16 @@ rt_lib = cc.find_library('rt', required
+ # into '-lsocket -lnsl'.  Anything that calls socketpair(), getifaddr(),
+ # etc. probably needs to include network_deps
+ #
+-socket_lib = cc.find_library('socket', required: false)
+-nsl_lib    = cc.find_library('nsl',    required: false)
+ network_deps = []
+-if socket_lib.found()
+-  network_deps += socket_lib
+-endif
+-if nsl_lib.found()
+-  network_deps += nsl_lib
++if host_machine.system() == 'sunos'
++  socket_lib = cc.find_library('socket', required: false)
++  nsl_lib    = cc.find_library('nsl',    required: false)
++  if socket_lib.found()
++    network_deps += socket_lib
++  endif
++  if nsl_lib.found()
++    network_deps += nsl_lib
++  endif
+ endif
+ 
+ # Check for libatomic for use of C11 atomics: some architectures need


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @thess @flyn-org

**Description:**

Fixes two pre-existing issues that prevented gstreamer1 from building on some host/target combinations:

- `meson.build` probed for the Solaris/Illumos networking libraries (`-lsocket` / `-lnsl`) unconditionally via `cc.find_library()`, although the comment right above the probe already scopes it to those platforms. When the build host has a `libnsl` package installed (e.g. Arch Linux), meson locates the host's `/usr/lib/libnsl.so` and adds its absolute path to the link line, breaking the cross link with `mold: fatal: /usr/lib/libnsl.so: incompatible file type`. A patch gates the probe on `host_machine.system() == 'sunos'`.
- The unit test suite was built because the `tests` meson option was left at its `auto` default. `tests/check/gst/gstutils.c` pulls in `<gsl/gsl_rng.h>` from the GNU Scientific Library, which is not packaged. `-Dtests=disabled` is now passed; the `libgstcheck` helper library is still built via `-Dcheck=enabled`.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** master
- **OpenWrt Target/Subtarget:** riscv64/generic
- **OpenWrt Device:** build-tested only

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/gstreamer1/refresh V=s
  ```
- [x] It is structured in a way that it is potentially upstreamable