### PR TITLE
gst1-plugins-base: pin GStreamer GL to the GLES2/EGL API

### DIFF
--- a/multimedia/gst1-plugins-base/Makefile
+++ b/multimedia/gst1-plugins-base/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gst1-plugins-base
 PKG_VERSION:=1.26.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=gst-plugins-base-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://gstreamer.freedesktop.org/src/gst-plugins-base
@@ -139,6 +139,8 @@ MESON_ARGS += \
 	$(call GST_COND_SELECT,encoding) \
 	$(call GST_COND_SELECT,gio) \
 	-Dgl=$(if $(CONFIG_PACKAGE_libgst1gl),en,dis)abled \
+	-Dgl_api=gles2 \
+	-Dgl_platform=egl \
 	$(call GST_COND_SELECT,overlaycomposition) \
 	$(call GST_COND_SELECT,pbtypes) \
 	$(call GST_COND_SELECT,playback) \


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @thess @flyn-org

**Description:**

The `gl_api` meson option was left at its `auto` default, so the GL plugin probed for desktop OpenGL. OpenWrt's Mesa is built with `-Dglx=disabled` and `-Dglvnd=disabled` on every target, so it ships no linkable desktop-GL library (no `libGL.so`, no `gl.pc`) — desktop GL is only reachable through EGL. With nothing in the sysroot to satisfy the probe, meson's `cc.find_library('GL')` fallback escaped into the build host's `/usr/lib` and, on a host that has a desktop `libGL` installed, put that foreign library on the link line:

```
mold: fatal: /usr/lib/libGL.so: incompatible file type: riscv64 is expected but got x86_64
```

Pinning `-Dgl_api=gles2` and `-Dgl_platform=egl` matches what Mesa actually provides (`libGLESv2` + `libEGL`). This is correct on every target, including x86_64+amdgpu: the desktop-GL link path was never functional on OpenWrt and only ever "succeeded" by picking up a host library.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** master
- **OpenWrt Target/Subtarget:** riscv64/generic
- **OpenWrt Device:** build-tested only

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

This PR does not contain a patch; it only adjusts meson configuration in the package Makefile.