### PR TITLE
boinc: resolve openwrt release

### DIFF
--- a/net/boinc/Makefile
+++ b/net/boinc/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=boinc
 PKG_VERSION:=8.2.11
 PKG_VERSION_SHORT:=$(shell echo $(PKG_VERSION)| cut -f1,2 -d.)
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/BOINC/boinc
@@ -43,7 +43,7 @@ define Package/boinc/description
   desktop computers. The developers' web site at the University of
   Berkeley serves as a common portal to the otherwise independently run
   projects.
- 
+
   This package provides the BOINC core client program that is
   required to participate in any project that uses BOINC to control what
   projects to join and to determine constraints for the computation

--- a/net/boinc/files/boinc-client.init
+++ b/net/boinc/files/boinc-client.init
@@ -53,6 +53,7 @@ start_service() {
    procd_add_jail_mount /etc/TZ
    procd_add_jail_mount /proc/cpuinfo /proc/meminfo
    procd_add_jail_mount /etc/ssl/certs/ca-certificates.crt
+   procd_add_jail_mount /etc/os-release
    procd_add_jail_mount $PRESETDIR
    procd_add_jail_mount_rw $BOINCDIR
 


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @N30dG, @smoe 

**Description:**

Allow boinc to read /etc/os-release to resolve OpenWrt version

<img width="915" height="274" alt="Captura de pantalla 2026-05-23 a las 22 42 23" src="https://github.com/user-attachments/assets/8a869d48-c68e-4fcd-b2c2-edbbf00b660d" />

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12
- **OpenWrt Target/Subtarget:** mediatek/mt7622
- **OpenWrt Device:** Linksys E8450

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
