### PR TITLE
nginx: update to 1.30.2

### DIFF
--- a/lang/lua/luajit2/test-version.sh
+++ b/lang/lua/luajit2/test-version.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# shellcheck shell=busybox
+
+case "$PKG_NAME" in #luajit2 use build number at -v but releases are named by date
+luajit2)
+	exit 0
+	;;
+
+*)
+	echo "Untested package: $PKG_NAME" >&2
+	exit 1
+	;;
+esac

--- a/libs/libxslt/test-version.sh
+++ b/libs/libxslt/test-version.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# shellcheck shell=busybox
+
+#xsltproc doesn't say it's own version but only depends
+case "$PKG_NAME" in
+xsltproc|libxslt|libexslt)
+	exit 0
+	;;
+
+*)
+	echo "Untested package: $PKG_NAME" >&2
+	exit 1
+	;;
+esac

--- a/net/nginx/Makefile
+++ b/net/nginx/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nginx
-PKG_VERSION:=1.26.3
-PKG_RELEASE:=4
+PKG_VERSION:=1.30.2
+PKG_RELEASE:=1
 
 PKG_SOURCE:=nginx-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://nginx.org/download/
-PKG_HASH:=69ee2b237744036e61d24b836668aad3040dda461fe6f570f1787eab570c75aa
+PKG_HASH:=7df3090907fca3cc0e456d6dc00ceb230da74ea88026ceff0affc29dbbd9ac4c
 
 PKG_MAINTAINER:=Thomas Heil <heil@terminal-consulting.de> \
 				Christian Marangi <ansuelsmth@gmail.com>

--- a/net/nginx/patches/nginx/101-feature_test_fix.patch
+++ b/net/nginx/patches/nginx/101-feature_test_fix.patch
@@ -87,7 +87,7 @@
  ngx_feature_libs=
 --- a/auto/unix
 +++ b/auto/unix
-@@ -853,7 +853,7 @@ ngx_feature_test="void *p; p = memalign(
+@@ -835,7 +835,7 @@ ngx_feature_test="void *p; p = memalign(
  
  ngx_feature="mmap(MAP_ANON|MAP_SHARED)"
  ngx_feature_name="NGX_HAVE_MAP_ANON"
@@ -96,7 +96,7 @@
  ngx_feature_incs="#include <sys/mman.h>"
  ngx_feature_path=
  ngx_feature_libs=
-@@ -866,7 +866,7 @@ ngx_feature_test="void *p;
+@@ -848,7 +848,7 @@ ngx_feature_test="void *p;
  
  ngx_feature='mmap("/dev/zero", MAP_SHARED)'
  ngx_feature_name="NGX_HAVE_MAP_DEVZERO"
@@ -105,7 +105,7 @@
  ngx_feature_incs="#include <sys/mman.h>
                    #include <sys/stat.h>
                    #include <fcntl.h>"
-@@ -881,7 +881,7 @@ ngx_feature_test='void *p; int  fd;
+@@ -863,7 +863,7 @@ ngx_feature_test='void *p; int  fd;
  
  ngx_feature="System V shared memory"
  ngx_feature_name="NGX_HAVE_SYSVSHM"
@@ -114,7 +114,7 @@
  ngx_feature_incs="#include <sys/ipc.h>
                    #include <sys/shm.h>"
  ngx_feature_path=
-@@ -895,7 +895,7 @@ ngx_feature_test="int  id;
+@@ -877,7 +877,7 @@ ngx_feature_test="int  id;
  
  ngx_feature="POSIX semaphores"
  ngx_feature_name="NGX_HAVE_POSIX_SEM"

--- a/net/nginx/patches/nginx/105-optional-libexslt.patch
+++ b/net/nginx/patches/nginx/105-optional-libexslt.patch
@@ -1,6 +1,6 @@
 --- a/auto/options
 +++ b/auto/options
-@@ -165,6 +165,7 @@ USE_PERL=NO
+@@ -166,6 +166,7 @@ USE_PERL=NO
  NGX_PERL=perl
  
  USE_LIBXSLT=NO
@@ -8,7 +8,7 @@
  USE_LIBGD=NO
  USE_GEOIP=NO
  
-@@ -370,6 +371,7 @@ use the \"--with-mail_ssl_module\" optio
+@@ -372,6 +373,7 @@ use the \"--with-mail_ssl_module\" optio
          --with-pcre-opt=*)               PCRE_OPT="$value"          ;;
          --with-pcre-jit)                 PCRE_JIT=YES               ;;
          --without-pcre2)                 PCRE2=DISABLED             ;;

--- a/net/nginx/patches/nginx/201-ignore-invalid-options.patch
+++ b/net/nginx/patches/nginx/201-ignore-invalid-options.patch
@@ -1,6 +1,6 @@
 --- a/auto/options
 +++ b/auto/options
-@@ -415,8 +415,7 @@ $0: warning: the \"--with-sha1-asm\" opt
+@@ -417,8 +417,7 @@ $0: warning: the \"--with-sha1-asm\" opt
          --test-build-solaris-sendfilev)  NGX_TEST_BUILD_SOLARIS_SENDFILEV=YES ;;
  
          *)

--- a/net/nginx/patches/nginx/300-fix-deprecated-openssl-3_0.patch
+++ b/net/nginx/patches/nginx/300-fix-deprecated-openssl-3_0.patch
@@ -1,6 +1,6 @@
 --- a/src/event/quic/ngx_event_quic_protection.c
 +++ b/src/event/quic/ngx_event_quic_protection.c
-@@ -510,7 +510,7 @@ ngx_quic_crypto_common(ngx_quic_secret_t
+@@ -520,7 +520,7 @@ ngx_quic_crypto_common(ngx_quic_secret_t
          }
      }
  


### PR DESCRIPTION

## 📦 Package Details

**Maintainer:** @Ansuel, @heil cc: @ptpt52
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
Large version jump from 1.26.3 to 1.30.2 (upstream stable). changelogs at https://nginx.org/en/CHANGES-1.30 and 1.28, include many security cve fixs
<!-- Briefly describe what this package does or what changes are introduced -->

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
snapshot
- **OpenWrt Target/Subtarget:**
x86-64
- **OpenWrt Device:**
kvm vm
---

## ✅ Formalities

- [ x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
