### PR TITLE
[24.10] fsh: update to 4.11.0

### DIFF
--- a/net/fsh/Makefile
+++ b/net/fsh/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fsh
-PKG_VERSION:=4.10.0
+PKG_VERSION:=4.11.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/heiher/hev-fsh/releases/download/$(PKG_VERSION)
-PKG_HASH:=6b041ccaa95a88b50fe25ede62925f815ba3f5f50c2ae0ba53c39d22ec5c4b40
+PKG_HASH:=767f493233cbad076fad5f837066eacdd50c92c807acdab258fd3fe418eeaeff
 
 PKG_MAINTAINER:=Ray Wang <git@hev.cc>
 PKG_LICENSE:=MIT

--- a/net/fsh/files/fsh.config
+++ b/net/fsh/files/fsh.config
@@ -3,6 +3,7 @@ config fshs
     option addr '[::]'
     option port '6339'
     option tokens '/etc/fsh'
+    option params ''
 
 config fshc
     option enable '0'

--- a/net/fsh/files/fshs.init
+++ b/net/fsh/files/fshs.init
@@ -12,6 +12,7 @@ validate_section_fshs() {
 		'addr:string' \
 		'port:port' \
 		'tokens:string'
+		'params:string' \
 }
 
 fshs_instance() {
@@ -28,6 +29,7 @@ fshs_instance() {
 	[ -n "$tokens" ] && [ -e "$tokens" ] && {
 		procd_append_param command -a "$tokens"
 	}
+	[ -n "$params" ] && procd_append_param command ${params}
 	procd_append_param command "$addr":"$port"
 
 	procd_set_param limits core="unlimited"


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @heiher (me)

**Description:** update to 4.11.0

Upstream changelog:
https://github.com/heiher/hev-fsh/releases/tag/4.11.0

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 24.10
- **OpenWrt Target/Subtarget:** armv8
- **OpenWrt Device:** armsr

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
