### PR TITLE
[25.12] hev-socks5-tproxy: update to 2.11.0

### DIFF
--- a/net/hev-socks5-tproxy/Makefile
+++ b/net/hev-socks5-tproxy/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=hev-socks5-tproxy
-PKG_VERSION:=2.10.0
+PKG_VERSION:=2.11.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/heiher/hev-socks5-tproxy/releases/download/$(PKG_VERSION)
-PKG_HASH:=4f495a7393afe4b4d36f86e94faddf992def010ff67c02e8ce09693a3a1bd20d
+PKG_HASH:=2f89204b38b3248d43b5a603978fb1c361c6a8310961f22794dc71e93e21519d
 
 PKG_MAINTAINER:=Ray Wang <git@hev.cc>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @heiher (me)

**Description:** update to 2.11.0

Upstream changelog:
https://github.com/heiher/hev-socks5-tproxy/releases/tag/2.11.0

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12
- **OpenWrt Target/Subtarget:** armv8
- **OpenWrt Device:** armsr

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
