### PR TITLE
openfortivpn: Bump PKG_RELEASE

### DIFF
--- a/net/openfortivpn/Makefile
+++ b/net/openfortivpn/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openfortivpn
 PKG_VERSION:=1.23.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/adrienverge/openfortivpn/tar.gz/v$(PKG_VERSION)?


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @lucize
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**

Bump PKG_RELEASE for the newly added `realm` parameter support  (introduced in PR #29414).

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12.3
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** ASUS TUF-AX4200

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
