### PR TITLE
strongswan: drop deprecated crypto protocols

### DIFF
--- a/net/strongswan/Config.in
+++ b/net/strongswan/Config.in
@@ -14,6 +14,11 @@ config STRONGSWAN_ROUTING_TABLE_PRIO
 	prompt "Set the IPsec routing table priority"
 	default "220"
 
+config STRONGSWAN_INCLUDE_INSECURE
+	bool
+	prompt "Include cryptographically weak protocols"
+	default !PACKAGE_libopenssl
+
 comment "Packages"
 
 endif

--- a/net/strongswan/Makefile
+++ b/net/strongswan/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=strongswan
 PKG_VERSION:=6.0.6
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://download.strongswan.org/ https://download2.strongswan.org/
@@ -26,7 +26,7 @@ PKG_MOD_AVAILABLE:= \
 	attr \
 	attr-sql \
 	blowfish \
-	ccm \
+	$(if $(CONFIG_STRONGSWAN_INCLUDE_INSECURE),ccm,) \
 	chapoly \
 	cmac \
 	constraints \
@@ -43,7 +43,7 @@ PKG_MOD_AVAILABLE:= \
 	eap-dynamic \
 	eap-identity \
 	eap-md5 \
-	eap-mschapv2 \
+	$(if $(CONFIG_STRONGSWAN_INCLUDE_INSECURE),eap-mschapv2,) \
 	eap-radius \
 	eap-tls \
 	farp \
@@ -62,7 +62,7 @@ PKG_MOD_AVAILABLE:= \
 	led \
 	load-tester \
 	lookip \
-	md4 \
+	$(if $(CONFIG_STRONGSWAN_INCLUDE_INSECURE),md4,) \
 	md5 \
 	mgf1 \
 	mysql \
@@ -103,7 +103,8 @@ PKG_MOD_AVAILABLE:= \
 PKG_CONFIG_DEPENDS:= \
 	CONFIG_STRONGSWAN_ROUTING_TABLE \
 	CONFIG_STRONGSWAN_ROUTING_TABLE_PRIO \
-	$(patsubst %,CONFIG_PACKAGE_strongswan-mod-%,$(PKG_MOD_AVAILABLE)) \
+	CONFIG_STRONGSWAN_INCLUDE_INSECURE \
+	$(patsubst %,CONFIG_PACKAGE_strongswan-mod-%,$(PKG_MOD_AVAILABLE))
 
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
@@ -130,7 +131,7 @@ define Package/strongswan
 $(call Package/strongswan/Default)
   MENU:=1
   DEPENDS:= +libpthread +ip \
-	+kmod-crypto-aead \
+	+STRONGSWAN_INCLUDE_INSECURE:kmod-crypto-aead \
 	+kmod-crypto-authenc \
 	+kmod-crypto-cbc \
 	+kmod-lib-zlib-inflate \
@@ -166,7 +167,7 @@ $(call Package/strongswan/Default)
 	+strongswan-mod-attr \
 	+strongswan-mod-attr-sql \
 	+strongswan-mod-blowfish \
-	+strongswan-mod-ccm \
+	+STRONGSWAN_INCLUDE_INSECURE:strongswan-mod-ccm \
 	+strongswan-mod-chapoly \
 	+strongswan-mod-cmac \
 	+strongswan-mod-constraints \
@@ -183,7 +184,7 @@ $(call Package/strongswan/Default)
 	+strongswan-mod-eap-dynamic \
 	+strongswan-mod-eap-identity \
 	+strongswan-mod-eap-md5 \
-	+strongswan-mod-eap-mschapv2 \
+	+STRONGSWAN_INCLUDE_INSECURE:strongswan-mod-eap-mschapv2 \
 	+strongswan-mod-eap-radius \
 	+strongswan-mod-eap-tls \
 	+strongswan-mod-farp \
@@ -200,7 +201,7 @@ $(call Package/strongswan/Default)
 	+strongswan-mod-led \
 	+strongswan-mod-load-tester \
 	+strongswan-mod-lookip \
-	+strongswan-mod-md4 \
+	+STRONGSWAN_INCLUDE_INSECURE:strongswan-mod-md4 \
 	+strongswan-mod-md5 \
 	+strongswan-mod-mgf1 \
 	+strongswan-mod-mysql \
@@ -467,7 +468,7 @@ CONFIGURE_ARGS+= \
 	--with-urandom-device=/dev/urandom \
 	--with-routing-table="$(call qstrip,$(CONFIG_STRONGSWAN_ROUTING_TABLE))" \
 	--with-routing-table-prio="$(call qstrip,$(CONFIG_STRONGSWAN_ROUTING_TABLE_PRIO))" \
-	$(foreach m,$(PKG_MOD_AVAILABLE), \
+	$(foreach m,$(PKG_MOD_AVAILABLE) ccm eap-mschapv2 md4, \
 	  $(if $(CONFIG_PACKAGE_strongswan-mod-$(m)),--enable-$(m),--disable-$(m)) \
 	) \
 	ac_cv_search___atomic_load=no

--- a/net/strongswan/test-version.sh
+++ b/net/strongswan/test-version.sh
@@ -1,0 +1,118 @@
+#!/bin/sh
+
+# shellcheck shell=busybox
+
+case "$PKG_NAME" in
+strongswan-charon-cmd)
+	charon-cmd --version 2>&1 | grep -F "$PKG_VERSION"
+	;;
+
+strongswan-ipsec)
+	ipsec --version 2>&1 | grep -F "$PKG_VERSION"
+	;;
+
+strongswan-pki)
+	pki --help 2>&1 | grep -F "$PKG_VERSION"
+	;;
+
+strongswan-swanctl)
+	# --version is trying to connect to something
+	swanctl --help 2>&1 | grep -F "$PKG_VERSION"
+	;;
+
+strongswan|\
+strongswan-charon|\
+strongswan-default|\
+strongswan-full|\
+strongswan-gencerts|\
+strongswan-isakmp|\
+strongswan-libtls|\
+strongswan-minimal|\
+strongswan-mod-addrblock|\
+strongswan-mod-aes|\
+strongswan-mod-af-alg|\
+strongswan-mod-agent|\
+strongswan-mod-attr|\
+strongswan-mod-attr-sql|\
+strongswan-mod-blowfish|\
+strongswan-mod-ccm|\
+strongswan-mod-chapoly|\
+strongswan-mod-cmac|\
+strongswan-mod-connmark|\
+strongswan-mod-constraints|\
+strongswan-mod-coupling|\
+strongswan-mod-ctr|\
+strongswan-mod-curl|\
+strongswan-mod-curve25519|\
+strongswan-mod-des|\
+strongswan-mod-dhcp|\
+strongswan-mod-dnskey|\
+strongswan-mod-drbg|\
+strongswan-mod-duplicheck|\
+strongswan-mod-eap-dynamic|\
+strongswan-mod-eap-identity|\
+strongswan-mod-eap-md5|\
+strongswan-mod-eap-mschapv2|\
+strongswan-mod-eap-radius|\
+strongswan-mod-eap-tls|\
+strongswan-mod-farp|\
+strongswan-mod-fips-prf|\
+strongswan-mod-forecast|\
+strongswan-mod-gcm|\
+strongswan-mod-gcrypt|\
+strongswan-mod-gmp|\
+strongswan-mod-gmpdh|\
+strongswan-mod-ha|\
+strongswan-mod-hmac|\
+strongswan-mod-kdf|\
+strongswan-mod-kernel-libipsec|\
+strongswan-mod-kernel-netlink|\
+strongswan-mod-ldap|\
+strongswan-mod-led|\
+strongswan-mod-load-tester|\
+strongswan-mod-lookip|\
+strongswan-mod-md4|\
+strongswan-mod-md5|\
+strongswan-mod-mgf1|\
+strongswan-mod-mysql|\
+strongswan-mod-openssl|\
+strongswan-mod-pem|\
+strongswan-mod-pgp|\
+strongswan-mod-pkcs1|\
+strongswan-mod-pkcs11|\
+strongswan-mod-pkcs12|\
+strongswan-mod-pkcs7|\
+strongswan-mod-pkcs8|\
+strongswan-mod-pubkey|\
+strongswan-mod-random|\
+strongswan-mod-rc2|\
+strongswan-mod-resolve|\
+strongswan-mod-revocation|\
+strongswan-mod-sha1|\
+strongswan-mod-sha2|\
+strongswan-mod-sha3|\
+strongswan-mod-smp|\
+strongswan-mod-socket-default|\
+strongswan-mod-socket-dynamic|\
+strongswan-mod-sql|\
+strongswan-mod-sqlite|\
+strongswan-mod-sshkey|\
+strongswan-mod-stroke|\
+strongswan-mod-test-vectors|\
+strongswan-mod-unity|\
+strongswan-mod-updown|\
+strongswan-mod-vici|\
+strongswan-mod-whitelist|\
+strongswan-mod-wolfssl|\
+strongswan-mod-x509|\
+strongswan-mod-xauth-eap|\
+strongswan-mod-xauth-generic|\
+strongswan-mod-xcbc)
+	exit 0
+	;;
+
+*)
+	echo "Untested package: $PKG_NAME" >&2
+	exit 1
+	;;
+esac


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me, @Thermi

**Description:**
AEAD, CCM, MD4, and MS CHAP v2 are all deprecated due to insecurity.


---

## 🧪 Run Testing Details

- **OpenWrt Version:** HEAD
- **OpenWrt Target/Subtarget:** x86_64/generic
- **OpenWrt Device:** pc-engines-apu6

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [X] It can be applied using `git am`
- [X] It has been refreshed to avoid offsets, fuzzes, etc., using
- [X] It is structured in a way that it is potentially upstreamable
