### PR TITLE
[24.10] unbound: update to 1.25.1 to resolve security vulnerabilities

### DIFF
--- a/net/unbound/Makefile
+++ b/net/unbound/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=unbound
-PKG_VERSION:=1.24.2
+PKG_VERSION:=1.25.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://nlnetlabs.nl/downloads/unbound
-PKG_HASH:=44e7b53e008a6dcaec03032769a212b46ab5c23c105284aa05a4f3af78e59cdb
+PKG_HASH:=0fe8b6277b0959cfd17562debac0aa5f71e0b02dc4ffa9c60271c583edab586f
 
 PKG_MAINTAINER:=Eric Luehrsen <ericluehrsen@gmail.com>
 PKG_LICENSE:=BSD-3-Clause

--- a/net/unbound/patches/010-configure-uname.patch
+++ b/net/unbound/patches/010-configure-uname.patch
@@ -3,7 +3,7 @@ Fix cross compile errors by inserting an environment variable for the
 target. Use "uname" on host only if "UNAME" variable is empty.
 --- a/configure.ac
 +++ b/configure.ac
-@@ -904,7 +904,7 @@ if test x_$ub_test_python != x_no; then
+@@ -984,7 +984,7 @@ if test x_$ub_test_python != x_no; then
     fi
  fi
  


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @EricLuehrsen

**Description:**
Update unbound to 1.25.1 to resolve security vulnerabilities, fixes #29549.

From upstream: 1.25.1 consolidates security fixes for issues
reported over a period of time. There are fixes for CVE-2026-33278,
CVE-2026-42944, CVE-2026-42959, CVE-2026-32792, CVE-2026-40622,
CVE-2026-41292, CVE-2026-42534, CVE-2026-42923, CVE-2026-42960,
CVE-2026-44390 and CVE-2026-44608.

Full details at 

https://www.nlnetlabs.nl/news/2026/May/20/unbound-1.25.1-released/

and

https://www.nlnetlabs.nl/news/2026/Apr/29/unbound-1.25.0-released/

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 24.10.5
- **OpenWrt Target/Subtarget:** qualcommax/ipq807x
- **OpenWrt Device:** Dynalink DL-WRX36

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

Edited to correct maintainer and add full change details.