### PR TITLE
prometheus-node-exporter-lua: fixup uci_dhcp_host

### DIFF
--- a/utils/prometheus-node-exporter-lua/Makefile
+++ b/utils/prometheus-node-exporter-lua/Makefile
@@ -4,7 +4,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=prometheus-node-exporter-lua
-PKG_VERSION:=2026.05.07
+PKG_VERSION:=2026.05.08
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Etienne CHAMPETIER <champetier.etienne@gmail.com>

--- a/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/uci_dhcp_host.lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/uci_dhcp_host.lua
@@ -5,8 +5,16 @@ local function scrape()
   local metric_uci_host = metric("uci_dhcp_host", "gauge")
 
   curs:foreach("dhcp", "host", function(s)
-    if s[".type"] == "host" then
-      labels = {name=s["name"], mac=string.upper(s["mac"]), dns=s["dns"], ip=s["ip"]}
+    local labels = {name=s["name"], dns=s["dns"], ip=s["ip"], duid=s["duid"]}
+
+    if s["mac"] == nil then
+      metric_uci_host(labels, 1)
+      return
+    end
+
+    local macs = type(s["mac"]) == "table" and s["mac"] or {s["mac"]}
+    for _, mac in ipairs(macs) do
+      labels["mac"] = string.upper(mac)
       metric_uci_host(labels, 1)
     end
   end)


### PR DESCRIPTION
Handle cases where 'mac' is missing (nil), a single string, or an array (table).

Additionally, add support for the 'duid' field.

## 📦 Package Details

**Maintainer:** me

**Description:**
This combine both #27026 and #29331

## 🧪 Run Testing Details

- **OpenWrt Version:** `OpenWrt SNAPSHOT r34571+1-67a870c9c6 / LuCI Master 26.138.28093~01d0617`
- **OpenWrt Target/Subtarget:** `mediatek/filogic`
- **OpenWrt Device:** `OpenWrt One`

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
