### PR TITLE
rtl-sdr: update to 2.0.2

### DIFF
--- a/utils/rtl-sdr/Makefile
+++ b/utils/rtl-sdr/Makefile
@@ -7,13 +7,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rtl-sdr
-PKG_VERSION:=2.0.1
+PKG_VERSION:=2.0.2
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
-PKG_SOURCE_VERSION:=v2.0.1
+PKG_SOURCE_VERSION:=v2.0.2
 PKG_SOURCE_URL:=https://gitea.osmocom.org/sdr/rtl-sdr
-PKG_MIRROR_HASH:=731dfdf5ae70b3155b942c829467113a61590da90b643852ed82b73aae982094
+PKG_MIRROR_HASH:=a6193da128f7bcba83c2af95896e6e34a31b1ac3419c976a32a67f13a0f6e864
 
 PKG_MAINTAINER:=Vasilis Tsiligiannis <b_tsiligiannis@silverton.gr>
 PKG_LICENSE:=GPL-2.0-or-later

--- a/utils/rtl-sdr/test-version.sh
+++ b/utils/rtl-sdr/test-version.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# shellckeck shell=busybox
+
+case "$PKG_NAME" in
+rtl-sdr|librtlsdr)
+	exit 0
+	;;
+
+*)
+	echo "Untested package: $PKG_NAME" >&2
+	exit 1
+	;;
+esac

--- a/utils/rtl-sdr/test-version.sh
+++ b/utils/rtl-sdr/test-version.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# shellckeck shell=busybox
+# shellcheck shell=busybox
 
 case "$PKG_NAME" in
 rtl-sdr|librtlsdr)

--- a/utils/rtl-sdr/test.sh
+++ b/utils/rtl-sdr/test.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+# shellcheck shell=busybox
+
+case "$1" in
+rtl-sdr)
+    rtl_sdr 2>&1 | grep -q "RTL2832"
+    rtl_tcp -h 2>&1 | grep -q "RTL2832"
+    rtl_test -h 2>&1 | grep -q "RTL2832"
+    rtl_fm -h 2>&1 | grep -q "RTL2832"
+    rtl_eeprom -h 2>&1 | grep -q "RTL2832"
+    rtl_adsb -h 2>&1 | grep -q "ADS-B"
+    rtl_power -h 2>&1 | grep -q "RTL2832"
+    ;;
+librtlsdr)
+    # Pure shared library, checked by packaging and linking tools
+    exit 0
+    ;;
+*)
+    echo "test.sh: unknown subpackage '$1' — refusing to silently pass" >&2
+    echo "test.sh: update utils/rtl-sdr/test.sh to cover this subpackage" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
bump version to 2.0.2
fixes https://github.com/openwrt/packages/issues/29523

## 📦 Package Details

**Maintainer:** @acinonyx , but not really active here
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
normal version bump, I don't have device to test it: it did compile and minor version bump though.

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
