### PR TITLE
bind: bump to 9.20.23

### DIFF
--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -9,8 +9,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
-PKG_VERSION:=9.20.21
-PKG_RELEASE:=2
+PKG_VERSION:=9.20.23
+PKG_RELEASE:=1
 USERID:=bind=57:bind=57
 
 PKG_MAINTAINER:=Noah Meyerhans <frodo@morgul.net>
@@ -22,7 +22,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:= \
 	https://www.mirrorservice.org/sites/ftp.isc.org/isc/bind9/$(PKG_VERSION) \
 	https://ftp.isc.org/isc/bind9/$(PKG_VERSION)
-PKG_HASH:=15e1b5a227d2890f7c4e823a6ea018de70ee2f3a0e859cbff3d82aad8590de03
+PKG_HASH:=5d4475aed3f9e500ef554b2b14d972bdb83d33de214a9b3be92918ea46908371
 
 PKG_INSTALL:=1
 PKG_BUILD_FLAGS:=no-mips16

--- a/net/bind/patches/fix-usr-allow-rndc-addzone#1.patch
+++ b/net/bind/patches/fix-usr-allow-rndc-addzone#1.patch
@@ -13,15 +13,15 @@ restore the automatic zone to the view.
 
 --- a/bin/named/server.c
 +++ b/bin/named/server.c
-@@ -13931,6 +13931,7 @@ do_addzone(named_server_t *server, ns_cf
+@@ -13919,6 +13919,7 @@ do_addzone(named_server_t *server, ns_cf
  	   bool redirect, isc_buffer_t **text) {
  	isc_result_t result, tresult;
  	dns_zone_t *zone = NULL;
 +	dns_zone_t *oldzone = NULL;
+ 	bool locked = false;
  #ifndef HAVE_LMDB
  	FILE *fp = NULL;
- 	bool cleanup_config = false;
-@@ -13949,7 +13950,13 @@ do_addzone(named_server_t *server, ns_cf
+@@ -13937,7 +13938,13 @@ do_addzone(named_server_t *server, ns_cf
  	} else {
  		result = dns_view_findzone(view, name, DNS_ZTFIND_EXACT, &zone);
  		if (result == ISC_R_SUCCESS) {
@@ -36,7 +36,7 @@ restore the automatic zone to the view.
  		}
  	}
  	if (result != ISC_R_NOTFOUND) {
-@@ -13958,6 +13965,10 @@ do_addzone(named_server_t *server, ns_cf
+@@ -13946,6 +13953,10 @@ do_addzone(named_server_t *server, ns_cf
  
  	isc_loopmgr_pause(named_g_loopmgr);
  
@@ -47,7 +47,7 @@ restore the automatic zone to the view.
  #ifndef HAVE_LMDB
  	/*
  	 * Make sure we can open the configuration save file
-@@ -14062,6 +14073,11 @@ do_addzone(named_server_t *server, ns_cf
+@@ -14050,6 +14061,11 @@ do_addzone(named_server_t *server, ns_cf
  		/* Remove the zone from the zone table */
  		dns_view_delzone(view, zone);
  		goto cleanup;
@@ -59,7 +59,7 @@ restore the automatic zone to the view.
  	}
  
  	/* Flag the zone as having been added at runtime */
-@@ -14078,6 +14094,22 @@ do_addzone(named_server_t *server, ns_cf
+@@ -14066,6 +14082,22 @@ do_addzone(named_server_t *server, ns_cf
  
  cleanup:
  

--- a/net/bind/patches/fix-usr-allow-rndc-addzone#2.patch
+++ b/net/bind/patches/fix-usr-allow-rndc-addzone#2.patch
@@ -85,7 +85,7 @@ Subject: [PATCH 2/4] Check if adding new zone can replace an automatic empty
 +};
 --- a/bin/tests/system/addzone/tests.sh
 +++ b/bin/tests/system/addzone/tests.sh
-@@ -68,6 +68,35 @@ n=$((n + 1))
+@@ -88,6 +88,35 @@ n=$((n + 1))
  if [ $ret != 0 ]; then echo_i "failed"; fi
  status=$((status + ret))
  

--- a/net/bind/patches/fix-usr-allow-rndc-addzone#4.patch
+++ b/net/bind/patches/fix-usr-allow-rndc-addzone#4.patch
@@ -10,7 +10,7 @@ Subject: [PATCH 4/4] fixup! Check if adding new zone can replace an automatic
 
 --- a/bin/tests/system/addzone/tests.sh
 +++ b/bin/tests/system/addzone/tests.sh
-@@ -84,6 +84,23 @@ n=$((n + 1))
+@@ -104,6 +104,23 @@ n=$((n + 1))
  if [ $ret != 0 ]; then echo_i "failed"; fi
  status=$((status + ret))
  

--- a/net/bind/test-version.sh
+++ b/net/bind/test-version.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+
+# shellcheck shell=busybox
+
+case "$PKG_NAME" in
+bind-check)
+	named-checkconf -v 2>&1 | grep -F "$PKG_VERSION"
+	named-checkzone -v 2>&1 | grep -F "$PKG_VERSION"
+	;;
+
+bind-client)
+	nsupdate -V 2>&1 | grep -F "$PKG_VERSION"
+	;;
+
+bind-dig)
+	dig -v 2>&1 | grep -F "$PKG_VERSION"
+	;;
+
+bind-dnssec)
+	dnssec-keygen -V 2>&1 | grep -F "$PKG_VERSION"
+	dnssec-settime -V 2>&1 | grep -F "$PKG_VERSION"
+	dnssec-signzone -V 2>&1 | grep -F "$PKG_VERSION"
+	;;
+
+bind-host)
+	host -V 2>&1 | grep -F "$PKG_VERSION"
+	;;
+
+bind-nslookup)
+	nslookup -version 2>&1 | grep -F "$PKG_VERSION"
+	;;
+
+bind-rndc)
+	rndc -help 2>&1 | grep -F "$PKG_VERSION"
+	;;
+
+bind-server)
+	named -v 2>&1 | grep -F "$PKG_VERSION"
+	;;
+
+bind-tools)
+	delv -v 2>&1 | grep -F "$PKG_VERSION"
+	;;
+
+bind-ddns-confgen|\
+bind-libs|\
+bind-server-filter-aaaa)
+	exit 0
+	;;
+
+*)
+	echo "Untested package: $PKG_NAME" >&2
+	exit 1
+	;;
+esac


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @nmeyerhans 

**Description:**

Resolves several security issues:

- CVE-2026-3592: Limit resolver server list size.
- CVE-2026-3039: Fix GSS-API resource leak.
- CVE-2026-5950: Avoid unbounded recursion loop.
- CVE-2026-5947: Fix crash in resolver when SIG(0)-signed responses are received under load.
- CVE-2026-3593: Add system test for HTTP/2 SETTINGS frame flood.
- CVE-2026-5946: Disable recursion, UPDATE, and NOTIFY for non-IN views.

Complete list of changes is available upstream at
https://ftp.isc.org/isc/bind9/9.20.23/doc/arm/html/changelog.html

<!-- Briefly describe what this package does or what changes are introduced -->

---

## 🧪 Run Testing Details

- **OpenWrt Version:** master
- **OpenWrt Target/Subtarget:** x86/generic
- **OpenWrt Device:** qemu

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
- [ ] It is structured in a way that it is potentially upstreamable (**n/a**, patches are cherry-picked from upstream)

