### PR TITLE
python-marshmallow: fix missing host-build dependencies

### DIFF
--- a/lang/python/python-marshmallow/Makefile
+++ b/lang/python/python-marshmallow/Makefile
@@ -15,6 +15,10 @@ PKG_LICENSE_FILES:=LICENSE
 
 HOST_BUILD_DEPENDS:= \
 	python3/host \
+	python-build/host \
+	python-installer/host \
+	python-wheel/host \
+	python-flit-core/host \
 	python-packaging/host
 
 include ../pypi.mk


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me

**Description:**

When python3 -m build is invoked during host-compile, it fails with:

  /builder/staging_dir/hostpkg/bin/python3.14: No module named build

The package's HOST_BUILD_DEPENDS only pulled in python3 and python-packaging, missing the actual host tooling for the new pyproject build flow:

  - python-build      : provides the 'build' module itself
  - python-installer  : installs the resulting wheel
  - python-wheel      : wheel format support
  - python-flit-core  : marshmallow's declared build-backend
                        (build-backend = "flit_core.buildapi" in
                        pyproject.toml)
---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [ ] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
