### PR TITLE
ucode-utest: add unit testing framework for ucode

### DIFF
--- a/lang/ucode-utest/Makefile
+++ b/lang/ucode-utest/Makefile
@@ -1,12 +1,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ucode-utest
-PKG_VERSION:=0.9.0
+PKG_VERSION:=1.0.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=@GITHUB/m00qek/utest/v$(PKG_VERSION)
-PKG_HASH:=7c750dd3006c6b85886eb559842e5b5c5487f22b679ddced9d893f18eafc2bf9
+PKG_SOURCE_URL:=https://codeload.github.com/m00qek/utest/tar.gz/refs/tags/v$(PKG_VERSION)
+PKG_HASH:=b53fed829dd05cc513d18b8c1dae7e0ea3737aa5b68524ed192231bae97fa531
+PKG_SOURCE_SUBDIR:=utest-$(PKG_VERSION)
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_SOURCE_SUBDIR)
 
 PKG_MAINTAINER:=António Mora <m00qek@gmail.com>
 PKG_LICENSE:=MIT

--- a/lang/ucode-utest/Makefile
+++ b/lang/ucode-utest/Makefile
@@ -1,0 +1,44 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=ucode-utest
+PKG_VERSION:=0.9.0
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=@GITHUB/m00qek/utest/v$(PKG_VERSION)
+PKG_HASH:=7c750dd3006c6b85886eb559842e5b5c5487f22b679ddced9d893f18eafc2bf9
+
+PKG_MAINTAINER:=António Mora <m00qek@gmail.com>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/$(PKG_NAME)
+  SECTION:=devel
+  CATEGORY:=Development
+  TITLE:=Unit testing framework for ucode
+  URL:=https://github.com/m00qek/utest
+  DEPENDS:=+ucode
+  PKGARCH:=all
+endef
+
+define Package/$(PKG_NAME)/description
+  A modern, non-invasive testing framework for the ucode ecosystem.
+  Provides a describe/it DSL, built-in mock proxies for uci, ubus, fs,
+  uloop, and uclient, and both sequential and parallel test runners.
+endef
+
+define Build/Compile
+endef
+
+define Package/$(PKG_NAME)/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) ./src/utest.sh $(1)/usr/bin/utest
+
+	$(INSTALL_DIR) $(1)/usr/share/ucode
+	$(CP) ./src/utest.uc $(1)/usr/share/ucode/
+	$(CP) -r ./src/utest $(1)/usr/share/ucode/
+endef
+
+$(eval $(call BuildPackage,$(PKG_NAME)))

--- a/lang/ucode-utest/test.sh
+++ b/lang/ucode-utest/test.sh
@@ -7,7 +7,7 @@ case "$1" in
 import { describe, it, assert } from 'utest';
 describe("smoke", () => {
     it("framework is installed correctly", () => {
-        assert.equal(1 + 1, 2);
+        assert.match(2, 1 + 1);
     });
 });
 EOF

--- a/lang/ucode-utest/test.sh
+++ b/lang/ucode-utest/test.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+case "$1" in
+    "ucode-utest")
+        tmpdir=$(mktemp -d)
+        trap 'rm -rf "$tmpdir"' EXIT
+        cat > "$tmpdir/smoke_test.uc" <<'EOF'
+import { describe, it, assert } from 'utest';
+describe("smoke", () => {
+    it("framework is installed correctly", () => {
+        assert.equal(1 + 1, 2);
+    });
+});
+EOF
+        utest "$tmpdir/smoke_test.uc"
+        ;;
+esac


### PR DESCRIPTION
### Summary

Add `ucode-utest`, a modern, non-invasive testing framework for ucode, OpenWrt's scripting language.

### What it provides

- A `describe`/`it` DSL for structuring tests
- Built-in mock proxies for `uci`, `ubus`, `fs`, `uloop`, and `uclient`
- Sequential and parallel test runners
- JSON reporter for CI integration

### Package details

- **Location:** `lang/ucode-utest`
- **License:** MIT
- **Architecture:** `all` (pure ucode/shell, no C compilation)
- **Depends:** `ucode` (OpenWrt core)
- **Upstream:** https://github.com/m00qek/utest
- **Documentation:** https://m00qek.github.io/utest

### Testing

- Built and installed successfully against the OpenWrt 24.10 SDK (`x86-64`)
- `test.sh` runs an inline smoke test using the framework's own DSL