### PR TITLE
conmon: update to 2.2.1

### DIFF
--- a/utils/conmon/Makefile
+++ b/utils/conmon/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=conmon
-PKG_VERSION:=2.1.12
+PKG_VERSION:=2.2.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/containers/conmon/archive/v$(PKG_VERSION)
-PKG_HASH:=842f0b5614281f7e35eec2a4e35f9f7b9834819aa58ecdad8d0ff6a84f6796a6
+PKG_HASH:=814fb5979a3a4b8576b1f901e606b482bebb41cb7e57926e6d5765ee786b96d3
 
 PKG_MAINTAINER:=Oskari Rauta <oskari.rauta@gmail.com>
 PKG_LICENSE:=Apache-2.0
@@ -36,7 +36,7 @@ endef
 
 define Package/conmon/install
 	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/libexec/podman/conmon $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/conmon $(1)/usr/bin
 endef
 
 $(eval $(call BuildPackage,conmon))

--- a/utils/conmon/patches/010-remove-libdl-dep.patch
+++ b/utils/conmon/patches/010-remove-libdl-dep.patch
@@ -7,5 +7,5 @@
 -           dependencies : [glib, libdl, sd_journal, seccomp],
 +           dependencies : [glib, sd_journal, seccomp],
             install : true,
-            install_dir : join_paths(get_option('libexecdir'), 'podman'),
+            install_dir : get_option('bindir'),
  )


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @oskarirauta

**Description:**
Update `conmon` (OCI container runtime monitor used by Podman/CRI-O) from 2.1.12 to upstream stable 2.2.1.

Release notes: https://github.com/containers/conmon/releases/tag/v2.2.1

Notable packaging-relevant change: upstream moved the install target from `libexecdir/podman` to `bindir`. `Package/conmon/install` is updated accordingly, and `010-remove-libdl-dep.patch` is refreshed for the new context.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** master
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** build-tested (apk produced cleanly: `conmon-2.2.1-r1.apk`)

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/conmon/refresh V=s
  ```
- [x] It is structured in a way that it is potentially upstreamable