### PR TITLE
net-snmp: fix service not restarting on config change

### DIFF
--- a/net/net-snmp/Makefile
+++ b/net/net-snmp/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=net-snmp
 PKG_VERSION:=5.9.4
-PKG_RELEASE:=9
+PKG_RELEASE:=10
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/net-snmp

--- a/net/net-snmp/files/snmpd.init
+++ b/net/net-snmp/files/snmpd.init
@@ -455,6 +455,7 @@ start_service() {
 	procd_append_param command -C -c "$CONFIGFILE"
 	config_foreach snmpd_configure_logging log
 	procd_set_param respawn
+	procd_set_param file /etc/config/snmpd
 
 	for iface in $(ls /sys/class/net 2>/dev/null); do
 		procd_append_param netdev "$iface"


### PR DESCRIPTION
snmpd generates its runtime configuration in `/var/run/snmpd.conf` from
UCI during `start_service()`. However, since the procd instance command
line never changes, procd does not detect that a restart is needed when
the UCI config is modified.

Add `procd_set_param file /etc/config/snmpd` so procd tracks the config
file and restarts snmpd when it changes. Without this, `reload_service`
(triggered by `procd_add_reload_trigger`) re-creates an identical instance
definition and procd skips the restart, leaving stale configuration
active.

This also fixes a usability issue with SNMPv3: when changing a user's
authentication or privacy algorithm, net-snmp must restart to re-derive
localized keys via `createUser`. Without the restart, the daemon keeps
using cached key material and authentication fails.

Tested with net-snmp 5.9.4 on OpenWrt (aarch64 and ppc64).

Related: https://github.com/openwrt/luci/pull/8570