### PR TITLE
perl: fix arch in powerpc64 config

### DIFF
--- a/lang/perl/files/powerpc64.config
+++ b/lang/perl/files/powerpc64.config
@@ -1,4 +1,4 @@
-owrt:arch=powerpc
+owrt:arch=powerpc64
 owrt:bits=64
 owrt:endian=big
 


### PR DESCRIPTION
The `powerpc64.config` file incorrectly sets `arch=powerpc` instead of `arch=powerpc64`, causing Perl to misidentify the architecture on 64-bit PowerPC targets.