### PR TITLE
rsyslog: track config files for procd restart

### DIFF
--- a/admin/rsyslog/files/rsyslog.init
+++ b/admin/rsyslog/files/rsyslog.init
@@ -104,6 +104,7 @@ start_service() {
 	expand_config
 	procd_open_instance
 	procd_set_param command /usr/sbin/rsyslogd -f ${CONFIG_FILE} -n
+	procd_set_param file ${BASE_CONFIG_FILE} ${CONFIG_FILE}
 	procd_close_instance
 }
 


### PR DESCRIPTION
Add `procd_set_param file` for both the base config (`/etc/rsyslog.conf`) and the generated config file (`/var/etc/rsyslog.conf`) so procd detects config changes and restarts rsyslogd.

Without this, `procd_add_reload_trigger` fires on config changes but procd does not restart the service because the command line is identical. This leaves stale configuration active until a manual restart.