### PR TITLE
kea: bump to 3.0.3

### DIFF
--- a/net/kea/Makefile
+++ b/net/kea/Makefile
@@ -9,12 +9,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=kea
-PKG_VERSION:=3.0.2
-PKG_RELEASE:=9
+PKG_VERSION:=3.0.3
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://ftp.isc.org/isc/kea/$(PKG_VERSION)
-PKG_HASH:=29f4e44fa48f62fe15158d17411e003496203250db7b3459c2c79c09f379a541
+PKG_HASH:=09702ddb078b637e85de9236cbedd3fb9d7af7c6e797026c538b45748ad4d631
 
 PKG_MAINTAINER:=Philip Prindeville <philipp@redfish-solutions.com>, Noah Meyerhans <frodo@morgul.net>
 PKG_LICENSE:=MPL-2.0


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @pprindeville 


**Description:**

3.0.3 is a security/vulnerability release on the stable 3.0 series.

Notable fixes since 3.0.2:

* **CVE-2026-3608** — A large number of bracket pairs in a JSON payload
  sent to any endpoint caused a stack overflow during recursive parsing.
  The exploit does not need a syntactically valid command, so it bypasses
  RBAC and the command filters on the High-Availability endpoints
  (upstream #4275 / #4288 / #4387).

* Null dereference when configuring the Control Agent with a socket
  entry that lacks the mandatory ``socket-name`` is now caught
  (#4388, #4365).

* UNIX command sockets are created group-writable so Stork 2.4.0+ and
  other tooling using the configured group can talk to the daemon
  (#4398, #4260).

Upstream's release notes flag "no incompatible changes" and "no known
issues" for this bump.

All current patches still apply cleanly.

Release notes:
https://ftp.isc.org/isc/kea/3.0.3/Kea-3.0.3-ReleaseNotes.txt


---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [ ] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
