### PR TITLE
libtheora: disable ARM assembly on pre-ARMv7 targets only

### DIFF
--- a/libs/libtheora/Makefile
+++ b/libs/libtheora/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libtheora
 PKG_VERSION:=1.2.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://downloads.xiph.org/releases/theora/
 PKG_HASH:=ebdf77a8f5c0a8f7a9e42323844fa09502b34eb1d1fece7b5f54da41fe2122ec
@@ -49,8 +49,11 @@ CONFIGURE_ARGS += \
 	--disable-vorbistest \
 	--disable-sdltest
 
-ifneq ($(findstring armeb,$(CONFIG_ARCH)),)
+# --disable-asm on pre-ARMv7 ARM so we don't emit assembler which cannot be executed
+ifeq ($(ARCH),arm)
+ifeq ($(findstring armv7,$(TARGET_CFLAGS))$(findstring armv8,$(TARGET_CFLAGS)),)
 CONFIGURE_ARGS += --disable-asm
+endif
 endif
 
 define Build/InstallDev


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @flyn-org 

**Description:**

libtheora's configure probes the host assembler for NEON support rather than the target CPU, so on pre-ARMv7 (arm926ej-s, etc.) it falsely succeeds and the build emits NEON the CPU can't execute. Force --disable-asm only when the ARM target's TARGET_CFLAGS does not advertise armv7 or armv8, so cortex-a* keeps the NEON path.

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
