### PR TITLE
[25.12] python3: pin host curses to the SDK's narrow ncurses

### DIFF
--- a/lang/python/python3/Makefile
+++ b/lang/python/python3/Makefile
@@ -41,7 +41,7 @@ PKG_BUILD_DIR:=$(BUILD_DIR)/Python-$(PKG_VERSION)
 HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/Python-$(PKG_VERSION)
 
 PKG_BUILD_DEPENDS:=bluez python3/host python-build/host python-installer/host python-wheel/host
-HOST_BUILD_DEPENDS:=bzip2/host libffi/host
+HOST_BUILD_DEPENDS:=bzip2/host libffi/host ncurses/host
 
 include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk
@@ -293,10 +293,17 @@ endif
 # HOST_MAKE_VARS += \
 # 	PYTHONSTRICTEXTENSIONBUILD=1
 
-# Bypass configure test
+# Bypass configure test. Force every curses header check Python's
+# configure.ac runs to "no" so the host distro's headers stay out.
 HOST_CONFIGURE_VARS += \
 	py_cv_module__tkinter=n/a \
-	ac_cv_working_openssl_hashlib=yes
+	ac_cv_working_openssl_hashlib=yes \
+	ac_cv_header_curses_h=no \
+	ac_cv_header_ncurses_h=no \
+	ac_cv_header_panel_h=no \
+	ac_cv_header_ncursesw_curses_h=no \
+	ac_cv_header_ncursesw_ncurses_h=no \
+	ac_cv_header_ncursesw_panel_h=no
 
 ifeq ($(HOST_OS),Darwin)
 HOST_CONFIGURE_VARS += \
@@ -314,9 +321,8 @@ HOST_CONFIGURE_ARGS += \
 	--with-system-expat \
 	--without-cxx-main
 
-# ncurses and uuid have seemingly unsolvable issues with pkgconfig
+# uuid has seemingly unsolvable issues with pkgconfig
 HOST_CFLAGS += \
-	-I$(STAGING_DIR_HOSTPKG)/include/ncursesw \
 	-I$(STAGING_DIR_HOST)/include/uuid
 
 define Host/Configure


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:**  me

**Description:**

Removing the ncursesw path from include avoids seeing the wide-char
version of ncurses, so the host build picks up the narrow static lib
that the OpenWrt SDK stages. To keep that pin from leaking back in
through other curses headers the build host may have under
/usr/include, also force every header check in Python's configure.ac
AC_CHECK_HEADERS(curses.h ncurses.h ncursesw/ncurses.h
ncursesw/curses.h ncursesw/panel.h panel.h) line to "no" via cached
ac_cv_header_* variables.

The narrow ncursesw_* trio was enough on the original reporter's
host; Jan Kardell's review of the first cut hit a build where
`/usr/include/curses.h` and `/usr/include/ncurses.h` from the
distro's libncurses-dev were still being picked up. Adding the
non-wide entries (and panel.h for symmetry, in case a host also
ships /usr/include/panel.h alone) makes the override insensitive to
whichever curses dev packages the host distro happens to provide.

Reported-by: Jan Kardell <jan.kardell@telliq.com>
Signed-off-by: Alexandru Ardelean <alex@shruggie.ro>
(cherry picked from commit d883c02a41060adccde76719a882b1a2c9bd2d0e)

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [ ] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
