### PR TITLE
kea: ship admin-utils.sh and kea-shell Python modules

### DIFF
--- a/net/kea/Makefile
+++ b/net/kea/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=kea
 PKG_VERSION:=3.0.2
-PKG_RELEASE:=8
+PKG_RELEASE:=9
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://ftp.isc.org/isc/kea/$(PKG_VERSION)
@@ -25,6 +25,9 @@ PKG_BUILD_FLAGS:=gc-sections
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/meson.mk
+
+PYTHON3_PKG_BUILD:=0
+include ../../lang/python/python3-package.mk
 
 define Package/kea/Default
   SECTION:=net
@@ -181,7 +184,7 @@ endef
 define Package/kea-shell
 	$(call Package/kea/Default)
 	TITLE+=shell
-	DEPENDS:=+kea-libs
+	DEPENDS:=+kea-libs +python3-light +python3-urllib +python3-openssl
 endef
 define Package/kea-shell/description
      This simple text client uses the REST interface to connect to the Kea
@@ -236,8 +239,10 @@ define Package/kea-dhcp-ddns/install
 endef
 
 define Package/kea-admin/install
-	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_DIR) $(1)/usr/sbin $(1)/usr/share/kea/scripts
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/kea-admin $(1)/usr/sbin/kea-admin
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/share/kea/scripts/admin-utils.sh \
+		$(1)/usr/share/kea/scripts/admin-utils.sh
 endef
 
 define Package/kea-hook-ha/install
@@ -269,8 +274,15 @@ define Package/kea-perfdhcp/install
 endef
 
 define Package/kea-shell/install
-	$(INSTALL_DIR) $(1)/usr/sbin
+	$(SED) '1s,^#!/.*python.*,#!/usr/bin/python3,' \
+		$(PKG_INSTALL_DIR)/usr/sbin/kea-shell
+	$(SED) "s,^sys.path.append.*,sys.path.append('$(PYTHON3_PKG_DIR)/kea')," \
+		$(PKG_INSTALL_DIR)/usr/sbin/kea-shell
+	$(INSTALL_DIR) $(1)/usr/sbin $(1)$(PYTHON3_PKG_DIR)/kea
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/kea-shell $(1)/usr/sbin/kea-shell
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/src/bin/shell/kea_conn.py \
+		$(PKG_BUILD_DIR)/src/bin/shell/kea_connector3.py \
+		$(1)$(PYTHON3_PKG_DIR)/kea/
 endef
 
 define Package/kea-uci/install

--- a/net/kea/test.sh
+++ b/net/kea/test.sh
@@ -1,0 +1,104 @@
+#!/bin/sh
+
+set -e
+
+# kea's `-t` validator requires the control-socket parent dir (mirrors kea.init).
+mkdir -p -m 0750 /var/run/kea
+
+case "$1" in
+kea-dhcp4)
+	# Validate the shipped DHCPv4 config; the QEMU mips netlink path
+	# aborts after parsing succeeds, so tolerate that exact signature.
+	if ! out=$(kea-dhcp4 -t /etc/kea/kea-dhcp4.conf 2>&1); then
+		case "$out" in
+		*"Failed to parse RTATTR in netlink message"*) ;;
+		*) printf '%s\n' "$out" >&2; exit 1 ;;
+		esac
+	fi
+	;;
+
+kea-dhcp6)
+	# Same as kea-dhcp4 but for the DHCPv6 server config / parser;
+	# same QEMU netlink caveat applies.
+	if ! out=$(kea-dhcp6 -t /etc/kea/kea-dhcp6.conf 2>&1); then
+		case "$out" in
+		*"Failed to parse RTATTR in netlink message"*) ;;
+		*) printf '%s\n' "$out" >&2; exit 1 ;;
+		esac
+	fi
+	;;
+
+kea-dhcp-ddns)
+	# Validate the shipped DDNS config; exercises the D2 parser
+	# and its TSIG / DNS-update library closure.
+	kea-dhcp-ddns -t /etc/kea/kea-dhcp-ddns.conf
+	;;
+
+kea-ctrl)
+	# Exercise the ctrl-agent config parser + keactrl wrapper; the
+	# config requires an auth-password file so satisfy it with a stub.
+	echo test >/etc/kea/kea-api-password
+	kea-ctrl-agent -t /etc/kea/kea-ctrl-agent.conf
+	rm -f /etc/kea/kea-api-password
+	keactrl -v >/dev/null
+	;;
+
+kea-admin)
+	# kea-admin sources admin-utils.sh before usage(); --help proves
+	# both the script and helper are packaged. -h is reserved in 3.0.x.
+	kea-admin --help >/dev/null
+	;;
+
+kea-shell)
+	# Python wrapper that imports kea_conn / kea_connector3; --help
+	# exercises the interpreter, path rewrite and module imports.
+	kea-shell --help >/dev/null
+	;;
+
+kea-lfc)
+	# Exercise kea-lfc's argv parser and its libkea-util / libstdc++
+	# runtime closure.
+	kea-lfc -h >/dev/null
+	;;
+
+kea-perfdhcp)
+	# Exercise perfdhcp's argv parser; loads the libkea-dhcp / asio
+	# runtime closure used by every kea binary.
+	perfdhcp -h >/dev/null
+	;;
+
+kea-dhcp4-helper)
+	# Pure shell script under /usr/lib/kea/importers/; confirm it
+	# was packaged and is executable.
+	test -x /usr/lib/kea/importers/dhcp4.sh
+	;;
+
+kea-hook-ha)
+	# Hook is a .so loaded by kea-dhcp{4,6}; confirm it was packaged.
+	# Generic ELF / SONAME checks cover its dynamic linkage.
+	test -f /usr/lib/kea/hooks/libdhcp_ha.so
+	;;
+
+kea-hook-lease-cmds)
+	# Same shape as kea-hook-ha.
+	test -f /usr/lib/kea/hooks/libdhcp_lease_cmds.so
+	;;
+
+kea-uci)
+	# UCI integration: config defaults + init script. Confirm both
+	# were packaged at the expected paths.
+	test -f /etc/config/kea
+	test -x /etc/init.d/kea
+	;;
+
+kea-libs)
+	# Pure shared-library subpackage; the generic ELF / SONAME /
+	# linked-libraries checks already cover it.
+	;;
+
+*)
+	echo "test.sh: unknown subpackage '$1' — refusing to silently pass" >&2
+	echo "test.sh: update net/kea/test.sh to cover this subpackage" >&2
+	exit 1
+	;;
+esac


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @pprindeville  @fxdupont 

**Description:**

kea-admin's helper script /usr/share/kea/scripts/admin-utils.sh and kea-shell's accompanying Python modules (kea_conn, kea_connector3) were not packaged, leaving both binaries non-functional. kea-shell also lacked any python3 dependency and its meson-baked shebang and sys.path pointed at host-build absolutes.

Install the missing helper and modules, depend on
+python3-light +python3-urllib +python3-openssl for the stdlib modules kea-shell uses, and rewrite the shebang / sys.path to the on-target /usr/bin/python3 and $(PYTHON3_PKG_DIR)/kea paths.

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [ ] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
