### PR TITLE
libdmapsharing: always install dmap-transcode-stream.h

### DIFF
--- a/libs/libdmapsharing/Makefile
+++ b/libs/libdmapsharing/Makefile
@@ -11,7 +11,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libdmapsharing
 PKG_VERSION:=3.9.13
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=libdmapsharing-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.flyn.org/projects/libdmapsharing/

--- a/libs/libdmapsharing/patches/002-always-install-transcode-stream-header.patch
+++ b/libs/libdmapsharing/patches/002-always-install-transcode-stream-header.patch
@@ -1,0 +1,16 @@
+--- a/libdmapsharing/Makefile.am
++++ b/libdmapsharing/Makefile.am
+@@ -106,12 +106,8 @@ maintained_headers = \
+ 	dmap-utils.h \
+ 	dmap-image-connection.h \
+ 	dmap-image-record.h \
+-	dmap-image-share.h
+-
+-if USE_GSTREAMERAPP
+-maintained_headers += \
++	dmap-image-share.h \
+ 	dmap-transcode-stream.h
+-endif
+ 
+ generated_headers = \
+ 	dmap-enums.h


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @flyn-org 

**Description:**

Upstream gates dmap-transcode-stream.h's install on USE_GSTREAMERAPP,
but the always-installed dmap.h includes it unconditionally, breaking
consumers like dmapd on targets where gst1-plugins-base is missing
(e.g. arm_arm926ej-s). The header only pulls gio + glib-object, so
shipping it unconditionally is safe; only the .c stays gst-gated.

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [ ] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
