### PR TITLE
[25.12] php8: update to 8.4.21

### DIFF
--- a/lang/php8/Makefile
+++ b/lang/php8/Makefile
@@ -6,8 +6,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=php
-PKG_VERSION:=8.4.16
-PKG_RELEASE:=4
+PKG_VERSION:=8.4.21
+PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Michael Heimpold <mhei@heimpold.de>
 PKG_LICENSE:=PHP-3.01
@@ -16,7 +16,7 @@ PKG_CPE_ID:=cpe:/a:php:php
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.php.net/distributions/
-PKG_HASH:=f66f8f48db34e9e29f7bfd6901178e9cf4a1b163e6e497716dfcb8f88bcfae30
+PKG_HASH:=7cf5d8ab12c3b2016875bcfaec71bef1ef0b07bed6148f2c447577074431f984
 
 PKG_BUILD_PARALLEL:=1
 PKG_BUILD_FLAGS:=no-mips16


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me

**Description:**

This fixes:
    - CVE-2025-14179
    - CVE-2026-6104
    - CVE-2026-6722
    - CVE-2026-6735
    - CVE-2026-7258
    - CVE-2026-7261
    - CVE-2026-7262
    - CVE-2026-7263
    - CVE-2026-7568

Upstream changelogs:
https://www.php.net/ChangeLog-8.php#8.4.17
https://www.php.net/ChangeLog-8.php#8.4.18
https://www.php.net/ChangeLog-8.php#8.4.19
https://www.php.net/ChangeLog-8.php#8.4.20
https://www.php.net/ChangeLog-8.php#8.4.21

---

## 🧪 Run Testing Details

- **OpenWrt Version:** https://github.com/openwrt/openwrt/commit/78c88ce188b3266757391c34948dffd805e91f78
- **OpenWrt Target/Subtarget:** bcm27xx/bcm2708
- **OpenWrt Device:** Raspberry Pi Model B Rev 2

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
