### PR TITLE
[24.10] php8: update to 8.3.31

### DIFF
--- a/lang/php8/Makefile
+++ b/lang/php8/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=php
-PKG_VERSION:=8.3.29
+PKG_VERSION:=8.3.31
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Michael Heimpold <mhei@heimpold.de>
@@ -16,7 +16,7 @@ PKG_CPE_ID:=cpe:/a:php:php
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.php.net/distributions/
-PKG_HASH:=f7950ca034b15a78f5de9f1b22f4d9bad1dd497114d175cb1672a4ca78077af5
+PKG_HASH:=66410cee07f4b2baeb0843140bb2a2b52ef930b5cf9b3d6e6d158b33aae8fa37
 
 PKG_BUILD_PARALLEL:=1
 PKG_BUILD_FLAGS:=no-mips16


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me

**Description:**

This fixes:
    - CVE-2025-14179
    - CVE-2026-6722
    - CVE-2026-6735
    - CVE-2026-7258
    - CVE-2026-7259
    - CVE-2026-7261
    - CVE-2026-7262
    - CVE-2026-7568

Upstream changelogs
https://www.php.net/ChangeLog-8.php#8.3.30
https://www.php.net/ChangeLog-8.php#8.3.31

---

## 🧪 Run Testing Details

- **OpenWrt Version:** https://github.com/openwrt/openwrt/commit/d5ac5cdfb2461a8deb399504af4bba158b00a917
- **OpenWrt Target/Subtarget:** bcm27xx/bcm2708
- **OpenWrt Device:** Raspberry Pi Model B Rev 2
 
---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
