### PR TITLE
[25.12] gstreamer1,knot,libtheora: backport build fixes for older ARM targets

### DIFF
--- a/libs/libtheora/Makefile
+++ b/libs/libtheora/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libtheora
 PKG_VERSION:=1.2.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://downloads.xiph.org/releases/theora/
 PKG_HASH:=ebdf77a8f5c0a8f7a9e42323844fa09502b34eb1d1fece7b5f54da41fe2122ec
@@ -48,8 +48,11 @@ CONFIGURE_ARGS += \
 	--disable-vorbistest \
 	--disable-sdltest
 
-ifneq ($(findstring armeb,$(CONFIG_ARCH)),)
+# --disable-asm on pre-ARMv7 ARM so we don't emit assembler which cannot be executed
+ifeq ($(ARCH),arm)
+ifeq ($(findstring armv7,$(TARGET_CFLAGS))$(findstring armv8,$(TARGET_CFLAGS)),)
 CONFIGURE_ARGS += --disable-asm
+endif
 endif
 
 define Build/InstallDev

--- a/multimedia/gstreamer1/Makefile
+++ b/multimedia/gstreamer1/Makefile
@@ -101,7 +101,7 @@ endef
 define Package/libgstreamer1
   $(call Package/gstreamer1/Default)
   TITLE+= library (core)
-  DEPENDS+= +glib2 +libpthread +libxml2 +(powerpc||mips||mipsel):libatomic
+  DEPENDS+= +glib2 +libpthread +libxml2 +(armeb||powerpc||mips||mipsel):libatomic
   HIDDEN:=1
 endef
 

--- a/multimedia/gstreamer1/Makefile
+++ b/multimedia/gstreamer1/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gstreamer1
 PKG_VERSION:=1.26.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=gstreamer-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://gstreamer.freedesktop.org/src/gstreamer
@@ -101,7 +101,7 @@ endef
 define Package/libgstreamer1
   $(call Package/gstreamer1/Default)
   TITLE+= library (core)
-  DEPENDS+= +glib2 +libpthread +libxml2 +(armeb||powerpc||mips||mipsel):libatomic
+  DEPENDS+= +glib2 +libpthread +libxml2 +(armeb||arm||powerpc||mips||mipsel):libatomic
   HIDDEN:=1
 endef
 

--- a/net/knot/Makefile
+++ b/net/knot/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=knot
-PKG_VERSION:=3.5.2
+PKG_VERSION:=3.5.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://secure.nic.cz/files/knot-dns/
-PKG_HASH:=6f577c247ef870a55fe3377246bc1c2d643c673cd32de6c26231ff51d3fc7093
+PKG_HASH:=e003ad1eef229c4e65a6cac876ee773e25a06177ecdc83795a26617a6eebe471
 
 PKG_MAINTAINER:=Daniel Salzman <daniel.salzman@nic.cz>
 PKG_LICENSE:=GPL-2.0-or-later LGPL-2.0-or-later MIT ISC BSD-3-Clause

--- a/net/knot/Makefile
+++ b/net/knot/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=knot
-PKG_VERSION:=3.5.3
+PKG_VERSION:=3.5.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://secure.nic.cz/files/knot-dns/
-PKG_HASH:=e003ad1eef229c4e65a6cac876ee773e25a06177ecdc83795a26617a6eebe471
+PKG_HASH:=4a0bc892dfaa5a150ff2855f0a88f2267124bc271818eae9a2b1f6da487c34e4
 
 PKG_MAINTAINER:=Daniel Salzman <daniel.salzman@nic.cz>
 PKG_LICENSE:=GPL-2.0-or-later LGPL-2.0-or-later MIT ISC BSD-3-Clause

--- a/net/knot/Makefile
+++ b/net/knot/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=knot
 PKG_VERSION:=3.5.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://secure.nic.cz/files/knot-dns/

--- a/net/knot/patches/01_zscanner_tests.patch
+++ b/net/knot/patches/01_zscanner_tests.patch
@@ -20,5 +20,5 @@
 -ZSCANNER_TOOL="$BUILD"/zscanner-tool
 +ZSCANNER_TOOL="$SOURCE"/zscanner-tool
  
- plan 88
+ plan 89
  

--- a/net/knot/patches/01_zscanner_tests.patch
+++ b/net/knot/patches/01_zscanner_tests.patch
@@ -20,5 +20,5 @@
 -ZSCANNER_TOOL="$BUILD"/zscanner-tool
 +ZSCANNER_TOOL="$SOURCE"/zscanner-tool
  
- plan 89
+ plan 90
  

--- a/net/knot/patches/03_rrl_drop_static_assert.patch
+++ b/net/knot/patches/03_rrl_drop_static_assert.patch
@@ -1,0 +1,10 @@
+--- a/src/knot/modules/rrl/kru.inc.c
++++ b/src/knot/modules/rrl/kru.inc.c
+@@ -462,7 +462,6 @@ static inline bool kru_limited_update(st
+ 		load_at = (_Atomic uint16_t *)ctx->load;
+ 	}
+ 
+-	static_assert(ATOMIC_CHAR16_T_LOCK_FREE == 2, "insufficient atomics");
+ 	const uint16_t price = ctx->price16;
+ 	const uint32_t limit = ctx->limit16;  // 2^16 has to be representable
+ 	uint16_t load_orig = atomic_load_explicit(load_at, memory_order_relaxed);


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @flyn-org, @salzmdan @Payne-X6 

**Description:**

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [ ] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

