### PR TITLE
meshtasticd: add python-pyelftools to host build deps

### DIFF
--- a/lang/python/python-pyelftools/Makefile
+++ b/lang/python/python-pyelftools/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-pyelftools
 PKG_VERSION:=0.32
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=pyelftools
 PKG_HASH:=6de90ee7b8263e740c8715a925382d4099b354f29ac48ea40d840cf7aa14ace5
@@ -36,11 +36,16 @@ define Package/python3-pyelftools
   SUBMENU:=Python
   TITLE:=Library for analyzing ELF files and DWARF debugging information
   URL:=https://pypi.org/project/pyelftools
-  DEPENDS:=+python3-light +python3-logging
+  DEPENDS:=+python3-light +python3-logging +python3-asyncio +python3-codecs
 endef
 
 define Package/python3-pyelftools/description
 Library for analyzing ELF files and DWARF debugging information
+endef
+
+define Py3Package/python3-pyelftools/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/readelf.py $(1)/usr/bin/pyreadelf
 endef
 
 $(eval $(call Py3Package,python3-pyelftools))

--- a/lang/python/python-pyelftools/Makefile
+++ b/lang/python/python-pyelftools/Makefile
@@ -15,10 +15,13 @@ PKG_MAINTAINER:=Austin Lane <vidplace7@gmail.com>
 PKG_LICENSE:=Unlicense
 PKG_LICENSE_FILES:=LICENSE
 
+PKG_BUILD_DEPENDS:=python-setuptools/host
+
 HOST_BUILD_DEPENDS:= \
 	python3/host \
 	python-build/host \
 	python-installer/host \
+	python-setuptools/host \
 	python-wheel/host
 
 include ../pypi.mk

--- a/net/meshtasticd/Makefile
+++ b/net/meshtasticd/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=meshtasticd
 PKG_VERSION:=2.7.15
 PKG_SOURCE_VERSION:=v$(PKG_VERSION).567b8ea
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
 PKG_SOURCE_PROTO:=git
@@ -20,6 +20,7 @@ FRONTEND_HASH:=a34f4360a0486543a698de20de533557492e763ab459fc27fcea95d0495144ed
 PKG_BUILD_DEPENDS:= \
 	python3/host \
 	python-platformio/host \
+	python-pyelftools/host \
 	!USE_GLIBC:argp-standalone
 
 PKG_MAINTAINER:=Austin Lane <vidplace7@gmail.com>, George Sapkin <george@sapk.in>


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @GeorgeSapkin  @vidplace7 

**Description:**

PlatformIO's SCons builder loads its tool modules at the start of 'pio run', including platformio/builder/tools/piosize.py which imports elftools.elf. python-platformio's HOST_BUILD_DEPENDS already lists python-pyelftools/host so it is installed alongside platformio in staging_dir/hostpkg, but the dependency does not always reach meshtasticd's compile step via that indirect chain, leading to:

  ModuleNotFoundError: No module named 'elftools'
    File ".../site-packages/platformio/builder/tools/piosize.py", line 22:
      from elftools.elf.descriptions import describe_sh_flags

Declare python-pyelftools/host directly in meshtasticd's build deps so the host install is guaranteed before 'pio run' is invoked.

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [ ] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
