### PR TITLE
lsof: update to 4.99.6

### DIFF
--- a/utils/lsof/Makefile
+++ b/utils/lsof/Makefile
@@ -7,12 +7,12 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=lsof
-PKG_VERSION:=4.99.5
-PKG_RELEASE:=2
+PKG_VERSION:=4.99.6
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/lsof-org/lsof/releases/download/$(PKG_VERSION)
-PKG_HASH:=4682c2491ec8b3d62f84e135afc1d9ead1bad5f034b50716f0c3826a4ee7d229
+PKG_HASH:=6081dedf841cd61f8a022ff7cbe04ed78918a47dea3c39528c8571474167aa0f
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Maxim Storchak <m.storchak@gmail.com>

--- a/utils/lsof/test.sh
+++ b/utils/lsof/test.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+lsof -v 2>&1 | grep "$2"


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->
- Treat NFS ESTALE fds as unlinked for +L selection
- Fix null pointer exception
- Add test.sh

---

## 🧪 Run Testing Details

- **OpenWrt Version:** r34703+2-aa96b3ad55
- **OpenWrt Target/Subtarget:** qualcommax/ipq807x
- **OpenWrt Device:** Dynalink DL-WRX36

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
