### PR TITLE
fontconfig: update to 2.17.1

### DIFF
--- a/utils/fontconfig/Makefile
+++ b/utils/fontconfig/Makefile
@@ -8,15 +8,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fontconfig
-PKG_VERSION:=2.16.0
-PKG_RELEASE:=2
+PKG_VERSION:=2.17.1
+PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_SOURCE_URL:=https://www.freedesktop.org/software/fontconfig/release/
-PKG_HASH:=6a33dc555cc9ba8b10caf7695878ef134eeb36d0af366041f639b1da9b6ed220
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
+PKG_SOURCE_URL:=https://gitlab.freedesktop.org/fontconfig/fontconfig/-/archive/$(PKG_VERSION)
+PKG_HASH:=bc1a90697eb8ec6c3eed118105ef9cbdfdd676e563905bf1cb571a705598300e
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
-PKG_LICENSE:=
+PKG_LICENSE:=MIT-Modern-Variant
 PKG_LICENSE_FILES:=
 PKG_CPE_ID:=cpe:/a:fontconfig_project:fontconfig
 


### PR DESCRIPTION
Update to the newest stable version
* adjust download URL to gitlab, as upstream moved download there:
   > The current stable series is 2.17.1. Releases until 2.16.0 are available in the [release](http://fontconfig.org/release) directory and Releases after that are available in the [GitLab](https://gitlab.freedesktop.org/fontconfig/fontconfig/-/releases).
* add license info  (info from: https://gitlab.freedesktop.org/fontconfig/fontconfig/-/blob/main/COPYING)


**Maintainer:** @commodo 

Run Testing: main/master mediatek/filogic MT-6000
