### PR TITLE
nmap: update to version 7.99

### DIFF
--- a/net/nmap/Makefile
+++ b/net/nmap/Makefile
@@ -13,13 +13,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nmap
-PKG_VERSION:=7.95
+PKG_VERSION:=7.99
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Nuno Gonçalves <nunojpg@gmail.com>
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://nmap.org/dist/
-PKG_HASH:=e14ab530e47b5afd88f1c8a2bac7f89cd8fe6b478e22d255c5b9bddb7a1c5778
+PKG_HASH:=df512492ffd108e53a27a06f26d8635bbe89e0e569455dc8ffef058c035d51b2
 
 PKG_LICENSE:=NPSL-0.94-or-NPSL-0.95
 PKG_LICENSE_FILES:=LICENSE
@@ -29,7 +29,6 @@ PKG_BUILD_PARALLEL:=1
 PKG_BUILD_DEPENDS:=python-setuptools/host
 PKG_INSTALL:=1
 PYTHON3_PKG_BUILD:=0
-PYTHON3_PKG_FORCE_DISTUTILS_SETUP:=1
 
 include $(INCLUDE_DIR)/package.mk
 include ../../lang/python/python3-package.mk
@@ -147,7 +146,7 @@ CONFIGURE_VARS += \
 	ac_cv_dnet_bsd_bpf=no
 
 PYTHON3_PKG_SETUP_DIR:=ndiff
-PYTHON3_PKG_SETUP_ARGS:=
+PYTHON3_PKG_WHEEL_NAME:=ndiff
 
 define Build/Compile
 	$(call Build/Compile/Default,)

--- a/net/nmap/patches/030-ncat-drop-ca-bundle.patch
+++ b/net/nmap/patches/030-ncat-drop-ca-bundle.patch
@@ -23,7 +23,7 @@ Also remove references to NCAT_CA_CERTS_FILE and NCAT_CA_CERTS_PATH in order to 
  ifneq ($(NOLUA),yes)
 --- a/ncat/ncat_posix.c
 +++ b/ncat/ncat_posix.c
-@@ -357,28 +357,17 @@ void set_lf_mode(void)
+@@ -409,28 +409,17 @@ void set_lf_mode(void)
  
  #ifdef HAVE_OPENSSL
  

--- a/net/nmap/patches/100-nsock-Fix-compilation-error-with-OPENSSL_NO_DTLS.patch
+++ b/net/nmap/patches/100-nsock-Fix-compilation-error-with-OPENSSL_NO_DTLS.patch
@@ -54,7 +54,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
           without the SSL_OP_NO_SSLv2 option set. */
 --- a/nsock/src/nsock_pool.c
 +++ b/nsock/src/nsock_pool.c
-@@ -178,8 +178,10 @@ nsock_pool nsock_pool_new(void *userdata
+@@ -173,8 +173,10 @@ nsock_pool nsock_pool_new(void *userdata
  
  #if HAVE_OPENSSL
    nsp->sslctx = NULL;


### PR DESCRIPTION

## 📦 Package Details

**Maintainer:**  @nunojpg
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

- Patches automatically rebased
- Release notes: https://nmap.org/changelog.html#7.99
- Update Makefile due to ndiff dropped setup.py using pyproject.toml. Remove `PYTHON3_PKG_FORCE_DISTUTILS_SETUP` and set `PYTHON3_PKG_WHEEL_NAME` to match the ndiff package name rather than PKG_NAME (nmap).

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** x86/64-glibc
- **OpenWrt Device:** Generic PC

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [X] It can be applied using `git am`
- [X] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [X] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
