### PR TITLE
kea: handle network reconfiguration without restarting

### DIFF
--- a/net/kea/Makefile
+++ b/net/kea/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=kea
 PKG_VERSION:=3.0.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://ftp.isc.org/isc/kea/$(PKG_VERSION)

--- a/net/kea/files/dhcp4.sh
+++ b/net/kea/files/dhcp4.sh
@@ -866,7 +866,7 @@ general_config() {
 	# will populate later
 	json_close_array		# interfaces
 
-	json_add_boolean "re-detect" 0
+	json_add_boolean "re-detect" 1
 	json_add_string "dhcp-socket-type" "raw"
 	json_add_string "outbound-interface" "same-as-inbound"
 	json_close_object		# interfaces-config


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me, @nmeyerhans 

**Description:**

Currently if a dynamic interface changes (VLAN, tunnel, etc) that Kea is listening on, it needs to be told externally to restart.  The re-detect option avoids this.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** HEAD
- **OpenWrt Target/Subtarget:** x86_64/generic
- **OpenWrt Device:** pc-engines-apu6

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

