### PR TITLE
nfdump: update to 1.7.8

### DIFF
--- a/net/nfdump/Makefile
+++ b/net/nfdump/Makefile
@@ -6,13 +6,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nfdump
-PKG_VERSION:=1.7.7
+PKG_VERSION:=1.7.8
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_VERSION:=v$(PKG_VERSION)
 PKG_SOURCE_URL:=https://github.com/phaag/nfdump
-PKG_MIRROR_HASH:=9b0b0c3f44e2a70f44684f3f87d248870901cf8a47275a2c6bee5884e9734884
+PKG_MIRROR_HASH:=ea94dcd3f64c778d641fae814d1cb3d3cce58b00a20c58d9405a4a5447e138f8
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 PKG_LICENSE:=BSD-3-Clause
@@ -29,7 +29,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/nfdump
   SECTION:=net
   CATEGORY:=Network
-  DEPENDS:= +flex +libbz2 +USE_MUSL:musl-fts +libatomic +libzstd +liblz4
+  DEPENDS:= +flex +libbsd +libbz2 +USE_MUSL:musl-fts +libatomic +libzstd +liblz4
   TITLE:= nfdump
   URL:=https://github.com/phaag/nfdump/
 endef


### PR DESCRIPTION
Upstream list of changes is available at
https://github.com/phaag/nfdump/releases/tag/v1.7.8.

## 📦 Package Details

**Maintainer:** me

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.