### PR TITLE
libgpg-error: update to 1.61

### DIFF
--- a/libs/libgpg-error/Makefile
+++ b/libs/libgpg-error/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libgpg-error
-PKG_VERSION:=1.58
+PKG_VERSION:=1.61
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://www.gnupg.org/ftp/gcrypt/libgpg-error \
 		https://mirrors.dotsrc.org/gcrypt/libgpg-error
-PKG_HASH:=f943aea9a830a8bd938e5124b579efaece24a3225ff4c3d27611a80ce1260c27
+PKG_HASH:=7a85413f2bc354f4f8aa832b718af122e48965e9e0eb9012ee659c13c6385c93
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 PKG_LICENSE:=LGPL-2.1-or-later


### PR DESCRIPTION
Upstream list of changes is available at
https://github.com/gpg/libgpg-error/blob/master/NEWS.

## 📦 Package Details

**Maintainer:** me

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.