### PR TITLE
hwloc: update to 2.13.0

### DIFF
--- a/libs/hwloc/Makefile
+++ b/libs/hwloc/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=hwloc
-PKG_VERSION:=2.12.2
+PKG_VERSION:=2.13.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
-PKG_SOURCE_URL:=https://download.open-mpi.org/release/$(PKG_NAME)/v2.12
-PKG_HASH:=563e61d70febb514138af0fac36b97621e01a4aacbca07b86e7bd95b85055ba0
+PKG_SOURCE_URL:=https://download.open-mpi.org/release/$(PKG_NAME)/v2.13
+PKG_HASH:=52e936afb6ebd80f171f763fcf14f7b1f5ce98b125af5dd2f328b873b1fd0dab
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
This upstream release included CPU kind improvements and fixed CUDACoresPerMP on NVIDIA GPUs.

## 📦 Package Details

**Maintainer:** me

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.