### PR TITLE
vala: update to 0.56.19

### DIFF
--- a/lang/vala/Makefile
+++ b/lang/vala/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=vala
-PKG_VERSION:=0.56.18
+PKG_VERSION:=0.56.19
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNOME/vala/$(basename $(PKG_VERSION))
-PKG_HASH:=f2affe7d40ab63db8e7b9ecc3f6bdc9c2fc7e3134c84ff2d795f482fe926a382
+PKG_HASH:=5ad7cbbfcc0de61b403d6797c9ef60455bfbebd8e162aec33b5b0b097adfb9d5
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 PKG_LICENSE:=LGPL-2.1-or-later


### PR DESCRIPTION
Upstream list of changes is available at
https://gitlab.gnome.org/GNOME/vala/-/blob/main/NEWS.

## 📦 Package Details

**Maintainer:** me

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.