### PR TITLE
libexif: update 0.6.26

### DIFF
--- a/libs/libexif/Makefile
+++ b/libs/libexif/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libexif
-PKG_VERSION:=0.6.25
+PKG_VERSION:=0.6.26
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://github.com/libexif/libexif/releases/download/v$(PKG_VERSION)
-PKG_HASH:=7c9eba99aed3e6594d8c3e85861f1c6aaf450c218621528bc989d3b3e7a26307
+PKG_HASH:=0830ed253fceeb60444fb309598bc8a9491d3007dc054aad3a50a347c5597c57
 
 PK_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 PKG_LICENSE:=LGPL-2.1-or-later

--- a/libs/libexif/patches/100-no_doc.patch
+++ b/libs/libexif/patches/100-no_doc.patch
@@ -1,9 +1,9 @@
 --- a/Makefile.in
 +++ b/Makefile.in
-@@ -418,7 +418,7 @@ target_alias = @target_alias@
- top_build_prefix = @top_build_prefix@
- top_builddir = @top_builddir@
+@@ -433,7 +433,7 @@ top_builddir = @top_builddir@
  top_srcdir = @top_srcdir@
+ valgrind_enabled_tools = @valgrind_enabled_tools@
+ valgrind_tools = @valgrind_tools@
 -SUBDIRS = m4m po libexif test doc binary-dist contrib
 +SUBDIRS = m4m po libexif test binary-dist contrib
  EXTRA_DIST = @PACKAGE_TARNAME@.spec README-Win32.txt libexif.pc.in \


### PR DESCRIPTION
Upstream list of changes is available at
https://github.com/libexif/libexif/releases/tag/v0.6.26.

## 📦 Package Details

**Maintainer:** me

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.