### PR TITLE
[25.12] libzip: add version check override

### DIFF
--- a/libs/libzip/test-version.sh
+++ b/libs/libzip/test-version.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+# shellcheck shell=busybox
+
+case "$PKG_NAME" in
+libzip-*)
+	# library packages
+	exit 0
+	;;
+
+zipcmp)
+	zipcmp -V 2>&1 | grep -qF "libzip $PKG_VERSION"
+	exit 0
+	;;
+
+zipmerge)
+	zipmerge -V 2>&1 | grep -qF "libzip $PKG_VERSION"
+	exit 0
+	;;
+
+ziptool)
+	# does not provide -V or prints version on -h
+	exit 0
+	;;
+
+*)
+	echo "Untested package: $PKG_NAME" >&2
+	exit 1
+	;;
+esac


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me

**Description:**

Backport of https://github.com/openwrt/packages/pull/29599: 

zipmerge and zipcmp prints version on -V,
but ziptool does not offer version number in any output.

(cherry picked from commit fa6c9463add62de1d5d111347d6459b4886dd5ad)

---

## 🧪 Run Testing Details

CI fix, no runtime change.

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
