### PR TITLE
boinc: fix can't open /proc/stat

### DIFF
--- a/net/boinc/Makefile
+++ b/net/boinc/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=boinc
 PKG_VERSION:=8.2.11
 PKG_VERSION_SHORT:=$(shell echo $(PKG_VERSION)| cut -f1,2 -d.)
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/BOINC/boinc

--- a/net/boinc/files/boinc-client.init
+++ b/net/boinc/files/boinc-client.init
@@ -49,7 +49,7 @@ start_service() {
    procd_set_param stderr 1
    procd_set_param pidfile $PID_FILE
 
-   procd_add_jail $BOINCEXE_NAME log requirejail
+   procd_add_jail $BOINCEXE_NAME log procfs requirejail
    procd_add_jail_mount /etc/TZ
    procd_add_jail_mount /proc/cpuinfo /proc/meminfo
    procd_add_jail_mount /etc/ssl/certs/ca-certificates.crt

--- a/net/boinc/test.sh
+++ b/net/boinc/test.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+[ "$1" = "boinc" ] || exit 0
+
+boinc_client --version 2>&1 | grep "$2"


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @N30dG, @smoe 

**Description:**

Add procfs to boinc jail to allow access /proc/stat

Add test.sh to test boinc package

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12
- **OpenWrt Target/Subtarget:** mediatek/mt7622
- **OpenWrt Device:** Linksys E8450

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
