### PR TITLE
luci-app-calllog: add standalone call log viewer for modem

### DIFF
--- a/net/luci-app-calllog/Makefile
+++ b/net/luci-app-calllog/Makefile
@@ -1,0 +1,18 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=luci-app-calllog
+PKG_VERSION:=1.0.0
+PKG_RELEASE:=1
+
+LUCI_TITLE:=LuCI JS call log viewer for modem
+LUCI_DESCRIPTION:=Standalone call log viewer for modem devices. Displays incoming, missed and dialed calls collected by a background daemon with port configuration and daemon management.
+LUCI_PKGARCH:=all
+PKG_MAINTAINER:=devopenm <devopenm@proton.me>
+
+define Package/luci-app-calllog/conffiles
+/etc/config/sms_tool_js
+endef
+
+include $(TOPDIR)/feeds/luci/luci.mk
+
+# call BuildPackage - OpenWrt buildroot signature

--- a/net/luci-app-calllog/htdocs/luci-static/resources/view/calllog/calllog.js
+++ b/net/luci-app-calllog/htdocs/luci-static/resources/view/calllog/calllog.js
@@ -1,0 +1,182 @@
+'use strict';
+'require form';
+'require fs';
+'require ui';
+'require uci';
+'require view';
+
+return view.extend({
+	load: function() {
+		var self = this;
+		return Promise.all([
+			uci.load('sms_tool_js'),
+			L.resolveDefault(fs.read('/tmp/sms_tool_call_log.json'), '{"calls":[]}'),
+			L.resolveDefault(fs.list('/dev'), []).then(function(entries) {
+				var ports = [];
+				for (var i = 0; i < entries.length; i++) {
+					if (entries[i].name && entries[i].name.match(/^ttyUSB/))
+						ports.push('/dev/' + entries[i].name);
+				}
+				ports.sort();
+				self._ports = ports;
+			})
+		]).then(function(data) {
+			var callLogData;
+			try {
+				callLogData = JSON.parse(data[1] || '{"calls":[]}');
+			} catch (e) {
+				callLogData = { calls: [] };
+			}
+			self._calls = callLogData.calls || [];
+		});
+	},
+
+	render: function() {
+		var self = this;
+		var m = new form.Map('sms_tool_js', _('Call Log'),
+			_('View and manage modem call logs collected by the background daemon.'));
+
+		var s = m.section(form.TypedSection, 'sms_tool_js');
+		s.anonymous = true;
+		s.addremove = false;
+
+		s.tab('records', _('Call Records'));
+		s.tab('daemon', _('Daemon Configuration'));
+
+		var o = s.taboption('daemon', form.ListValue, 'callport', _('Call log reading port'),
+			_('Select one of the available ttyUSBX ports.'));
+		o.value('');
+		for (var i = 0; i < this._ports.length; i++)
+			o.value(this._ports[i]);
+
+		o = s.taboption('daemon', form.Flag, 'calllog_enabled', _('Enable call log daemon'),
+			_('Background process to log incoming and missed calls.'));
+		o.rmempty = false;
+		o.default = '0';
+		o.write = function(section_id, value) {
+			return uci.load('sms_tool_js').then(function() {
+				if (value == '1') {
+					uci.set('sms_tool_js', '@sms_tool_js[0]', 'calllog_enabled', '1');
+					return uci.save().then(function() {
+						return fs.exec_direct('/etc/init.d/sms_tool_calllogd', ['enable']);
+					}).then(function() {
+						return fs.exec_direct('/etc/init.d/sms_tool_calllogd', ['start']);
+					});
+				}
+				if (value == '0') {
+					uci.set('sms_tool_js', '@sms_tool_js[0]', 'calllog_enabled', '0');
+					return uci.save().then(function() {
+						return fs.exec_direct('/etc/init.d/sms_tool_calllogd', ['stop']);
+					}).then(function() {
+						return fs.exec_direct('/etc/init.d/sms_tool_calllogd', ['disable']);
+					});
+				}
+			}.bind(this)).then(function() {
+				return form.Flag.prototype.write.apply(this, [section_id, value]);
+			}.bind(this));
+		};
+
+		o = s.taboption('records', form.DummyValue, '_call_records');
+		o.rawhtml = true;
+		o.render = function() {
+			return self.renderRecords(self._calls);
+		};
+
+		return m.render();
+	},
+
+	renderRecords: function(calls) {
+		var self = this;
+
+		var filterOptions = [
+			E('option', { 'value': 'all' }, _('All calls')),
+			E('option', { 'value': 'missed' }, _('Missed calls')),
+			E('option', { 'value': 'received' }, _('Received calls')),
+			E('option', { 'value': 'dialed' }, _('Dialed calls'))
+		];
+
+		return E([], [
+			E('table', { 'class': 'cbi-section-table' }, [
+				E('tr', { 'class': 'cbi-section-table-row' }, [
+					E('td', { 'class': 'cbi-value-field' }, [
+						E('label', { 'class': 'cbi-value-title' }, _('Filter call type')),
+						E('div', { 'class': 'cbi-value-control' }, [
+							E('select', {
+								'class': 'cbi-input-select',
+								'id': 'call-log-type',
+								'change': function() {
+									var t = document.getElementById('callLogTable');
+									if (t) {
+										t.parentNode.replaceChild(
+											self.renderCallLogTable(calls, this.value),
+											t
+										);
+									}
+								}
+							}, filterOptions)
+						])
+					])
+				])
+			]),
+			E('div', { 'class': 'right' }, [
+				E('button', {
+					'class': 'cbi-button cbi-button-neutral',
+					'click': function() { window.location.reload(); }
+				}, [ _('Refresh') ]),
+				' ',
+				E('button', {
+					'class': 'cbi-button cbi-button-remove',
+					'click': ui.createHandlerFn(this, '_handleClear')
+				}, [ _('Clear Log') ])
+			]),
+			E('p'),
+			this.renderCallLogTable(calls, 'all')
+		]);
+	},
+
+	renderCallLogTable: function(calls, filter) {
+		var table = E('table', { 'class': 'table', 'id': 'callLogTable' }, [
+			E('tr', { 'class': 'tr table-titles' }, [
+				E('th', { 'class': 'th' }, _('Date')),
+				E('th', { 'class': 'th' }, _('Type')),
+				E('th', { 'class': 'th' }, _('Number')),
+				E('th', { 'class': 'th' }, _('Duration')),
+				E('th', { 'class': 'th' }, _('Name'))
+			])
+		]);
+
+		var hasRows = false;
+		for (var i = 0; i < calls.length; i++) {
+			if (filter && filter !== 'all' && (calls[i].type || '').toLowerCase() !== filter)
+				continue;
+			var row = table.insertRow(-1);
+			row.insertCell(0).textContent = calls[i].date || '';
+			row.insertCell(1).textContent = _(calls[i].type || '');
+			row.insertCell(2).textContent = calls[i].number || '';
+			row.insertCell(3).textContent = calls[i].duration || '';
+			row.insertCell(4).textContent = '-';
+			hasRows = true;
+		}
+
+		if (!hasRows) {
+			var row = table.insertRow(-1);
+			var cell = row.insertCell(0);
+			cell.colSpan = 5;
+			cell.style.textAlign = 'center';
+			cell.textContent = _('No call log entries found');
+		}
+
+		return table;
+	},
+
+	_handleClear: function() {
+		if (confirm(_('Clear all call log entries?'))) {
+			return Promise.all([
+				fs.write('/tmp/sms_tool_call_log.json', '{"calls":[]}'),
+				fs.write('/tmp/sms_tool_call_log.lines', '')
+			]).then(function() {
+				window.location.reload();
+			});
+		}
+	}
+});

--- a/net/luci-app-calllog/root/etc/init.d/sms_tool_calllogd
+++ b/net/luci-app-calllog/root/etc/init.d/sms_tool_calllogd
@@ -1,0 +1,31 @@
+#!/bin/sh /etc/rc.common
+#
+# Copyright 2026 Rafał Wabik (IceG) - From eko.one.pl forum
+# Licensed to the GNU General Public License v3.0.
+#
+
+START=99
+USE_PROCD=1
+
+PROG=/usr/bin/sms_tool_calllogd
+
+start_service() {
+    local enabled=$(uci -q get sms_tool_js.@sms_tool_js[0].calllog_enabled || echo "0")
+    [ "$enabled" = "1" ] || return
+
+    procd_open_instance
+    procd_set_param command "$PROG"
+    procd_set_param respawn
+    procd_set_param stdout 1
+    procd_set_param stderr 1
+    procd_close_instance
+}
+
+reload_service() {
+    stop
+    start
+}
+
+service_triggers() {
+    procd_add_reload_trigger "sms_tool_js"
+}

--- a/net/luci-app-calllog/root/etc/uci-defaults/luci-calllog
+++ b/net/luci-app-calllog/root/etc/uci-defaults/luci-calllog
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+if ! uci -q get sms_tool_js.@sms_tool_js[0] >/dev/null 2>&1; then
+	uci set sms_tool_js.config=sms_tool_js
+fi
+
+uci -q get sms_tool_js.@sms_tool_js[0].callport >/dev/null || uci set sms_tool_js.@sms_tool_js[0].callport=''
+uci -q get sms_tool_js.@sms_tool_js[0].calllog_enabled >/dev/null || uci set sms_tool_js.@sms_tool_js[0].calllog_enabled='0'
+uci commit sms_tool_js >/dev/null 2>&1
+
+rm -rf /tmp/luci-indexcache /tmp/luci-modulecache/ 2>/dev/null
+
+exit 0

--- a/net/luci-app-calllog/root/usr/bin/sms_tool_calllogd
+++ b/net/luci-app-calllog/root/usr/bin/sms_tool_calllogd
@@ -1,0 +1,157 @@
+#!/bin/sh
+#
+# Copyright 2026 Rafał Wabik (IceG) - From eko.one.pl forum
+# Licensed to the GNU General Public License v3.0.
+#
+
+. /usr/share/libubox/jshn.sh
+
+PORT=$(uci -q get sms_tool_js.@sms_tool_js[0].callport)
+[ -n "$PORT" ] || PORT=$(uci -q get sms_tool_js.@sms_tool_js[0].readport)
+[ -z "$PORT" ] && exit 1
+
+LOG_FILE="/tmp/sms_tool_call_log.json"
+LINES_FILE="/tmp/sms_tool_call_log.lines"
+MAX_ENTRIES=50
+LAST_NUMBER=""
+LAST_TIME=0
+
+# Ensure files exist
+[ -f "$LINES_FILE" ] || touch "$LINES_FILE"
+[ -f "$LOG_FILE" ] || echo '{"calls":[]}' > "$LOG_FILE"
+
+add_to_log() {
+    local type="$1"
+    local number="$2"
+    local duration="$3"
+    local date=$(date "+%Y-%m-%d %H:%M:%S")
+    local now=$(date +%s)
+
+    [ -z "$number" ] && number="Unknown"
+    [ -z "$duration" ] && duration="0"
+
+    if [ "$number" = "$LAST_NUMBER" ] && [ $((now - LAST_TIME)) -lt 10 ]; then
+        return
+    fi
+
+    LAST_NUMBER="$number"
+    LAST_TIME="$now"
+
+    json_init
+    json_add_string "type" "$type"
+    json_add_string "number" "$number"
+    json_add_string "date" "$date"
+    json_add_string "duration" "$duration"
+    local new_entry=$(json_dump)
+
+    echo "$new_entry" >> "$LINES_FILE"
+
+    # Keep only last MAX_ENTRIES
+    local count=$(wc -l < "$LINES_FILE")
+    if [ "$count" -gt "$MAX_ENTRIES" ]; then
+        tail -n "$MAX_ENTRIES" "$LINES_FILE" > "${LINES_FILE}.tmp"
+        mv "${LINES_FILE}.tmp" "$LINES_FILE"
+    fi
+
+    # Generate JSON for LuCI
+    echo "{\"calls\":[" > "$LOG_FILE"
+    # Reverse lines to have newest first, add commas
+    if [ -s "$LINES_FILE" ]; then
+        sed '1!G;h;$!d' "$LINES_FILE" | sed '$ ! s/$/,/' >> "$LOG_FILE"
+    fi
+    echo "]}" >> "$LOG_FILE"
+}
+
+handle_event() {
+    local line="$1"
+
+    if echo "$line" | grep -q "\^DSCI:"; then
+        local data=$(echo "$line" | sed 's/\^DSCI: //')
+        local id=$(echo "$data" | cut -d, -f1)
+        local dir=$(echo "$data" | cut -d, -f2)
+        local state=$(echo "$data" | cut -d, -f3)
+        local number=$(echo "$data" | cut -d, -f5 | tr -d '"')
+
+        case "$state" in
+            0|1) # setup / alerting
+                eval "CALL_${id}_STATE=ringing"
+                [ -n "$number" ] && eval "CALL_${id}_NUMBER=\"$number\""
+                eval "CALL_${id}_START=$(date +%s)"
+                ;;
+            2) # active
+                eval "CALL_${id}_STATE=active"
+                eval "CALL_${id}_START=$(date +%s)"
+                ;;
+            3) # released
+                eval "local old_state=\$CALL_${id}_STATE"
+                eval "local old_number=\$CALL_${id}_NUMBER"
+                eval "local old_start=\$CALL_${id}_START"
+
+                [ -z "$old_state" ] && return
+
+                local type="Unknown"
+                if [ "$dir" = "1" ]; then
+                    if [ "$old_state" = "ringing" ]; then
+                        type="Missed"
+                    else
+                        type="Received"
+                    fi
+                else
+                    type="Dialed"
+                fi
+
+                local end=$(date +%s)
+                local duration_sec=$((end - old_start))
+                local duration=$(printf "%02d:%02d:%02d" $((duration_sec/3600)) $(( (duration_sec%3600)/60 )) $((duration_sec%60)) )
+
+                add_to_log "$type" "$old_number" "$duration"
+
+                # Cleanup
+                eval "unset CALL_${id}_STATE"
+                eval "unset CALL_${id}_NUMBER"
+                eval "unset CALL_${id}_START"
+                ;;
+        esac
+    elif echo "$line" | grep -q "+CLIP:"; then
+        local number=$(echo "$line" | cut -d'"' -f2)
+        [ -n "$number" ] && add_to_log "Missed" "$number" "0"
+    elif echo "$line" | grep -q "+CLCC:"; then
+        local number=$(echo "$line" | cut -d'"' -f2)
+        local state=$(echo "$line" | cut -d, -f3)
+
+        if [ "$state" = "4" ] && [ -n "$number" ]; then
+            add_to_log "Missed" "$number" "0"
+        fi
+    fi
+}
+
+# Main
+if command -v stty >/dev/null 2>&1; then
+    stty -F "$PORT" 115200 raw -echo 2>/dev/null
+fi
+
+exec 3<>"$PORT"
+
+printf "ATE0\r" >&3
+sleep 1
+printf "AT+CLIP=1\r" >&3
+sleep 1
+printf "AT+CRC=1\r" >&3
+sleep 1
+printf "AT^DSCI=1\r" >&3
+sleep 1
+
+last_poll=0
+
+while true; do
+    if read -t 1 line <&3; then
+        line=$(printf "%s" "$line" | tr -d '\r\n')
+        [ -n "$line" ] && handle_event "$line"
+    fi
+
+    now=$(date +%s)
+    if [ $((now - last_poll)) -gt 2 ]; then
+        printf "AT+CLCC\r" >&3
+        last_poll=$now
+    fi
+done

--- a/net/luci-app-calllog/root/usr/share/luci/menu.d/luci-app-calllog.json
+++ b/net/luci-app-calllog/root/usr/share/luci/menu.d/luci-app-calllog.json
@@ -1,0 +1,19 @@
+{
+	"admin/modem": {
+		"title": "Modem",
+		"order": 30,
+		"action": {
+			"type": "firstchild",
+			"recurse": true
+		}
+	},
+
+	"admin/modem/luci-app-calllog": {
+		"title": "Call Log",
+		"order": 25,
+		"action": {
+			"type": "view",
+			"path": "calllog/calllog"
+		}
+	}
+}


### PR DESCRIPTION
## Package Details

**Maintainer:** @<devopnem>

**Description:**
luci-app-calllog: add standalone call log viewer for modem

A minimal LuCI2 JavaScript application for viewing modem call logs collected by a background daemon. Communicates directly with the modem via AT commands over the serial port.

Features:
- Real-time call log display (missed, received, dialed)
- Filter by call type
- Daemon configuration (port selection, enable/disable)
- Two-tab interface: Call Records + Daemon Configuration


---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12.4
- **OpenWrt Target/Subtarget:** ath79 mips24kc
- **OpenWrt Device:** hh40v

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
