### PR TITLE
tor: update to 0.4.9.9 stable

### DIFF
--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tor
-PKG_VERSION:=0.4.9.8
+PKG_VERSION:=0.4.9.9
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://dist.torproject.org/ \
 	https://archive.torproject.org/tor-package-archive
-PKG_HASH:=ac1f394e2dd2ab0877d27d928fd0d9e86662fe3ca6afdffb9fd9b6f0f96d05de
+PKG_HASH:=bd75ba7fd68f607c7806fcf70156a300aa926e9ad69a5e56a8e6414f5227e833
 PKG_MAINTAINER:=Rui Salvaterra <rsalvaterra@gmail.com>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
Minor release, see the changelog [1] for what's new.

[1] https://gitlab.torproject.org/tpo/core/tor/-/blob/tor-0.4.9.9/ChangeLog

Signed-off-by: Rui Salvaterra \<rsalvaterra@gmail.com\>