### PR TITLE
[25.12] nextdns: update to version 1.47.3

### DIFF
--- a/net/nextdns/Makefile
+++ b/net/nextdns/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nextdns
-PKG_VERSION:=1.47.2
+PKG_VERSION:=1.47.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=nextdns-$(PKG_VERSION).tar.gz
 PKG_SOURCE_VERSION:=v$(PKG_VERSION)
 PKG_SOURCE_URL:=https://codeload.github.com/nextdns/nextdns/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=d4a57f07f51a58ab57f8ff872678fc81be76c3985011ef0960b156df361ea44a
+PKG_HASH:=73a57ff41074d32a7707b751da36c0a618edc6d2b41ddf61ca565222448f567b
 
 PKG_MAINTAINER:=Olivier Poitrey <rs@nextdns.io>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Backport merged `nextdns` package changes from `master` into `openwrt-25.12`.

Current branch version: `1.47.2`
Target branch version: `1.47.3`
Cherry picked from commits:
- f5f2433dfe4852e691fac50157ac837d4e993b8e