### PR TITLE
django: bump to version 6.0.6

### DIFF
--- a/lang/python/django/Makefile
+++ b/lang/python/django/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django
-PKG_VERSION:=6.0.5
+PKG_VERSION:=6.0.6
 PKG_RELEASE:=1
 
 PYPI_NAME:=django
-PKG_HASH:=bc6d6872e98a2864c836e42edd644b362db311147dd5aa8d5b82ba7a032f5269
+PKG_HASH:=ad03916ba59523d781ae5c3f631960c23d69a9d9c43cecda52fc23b47e953713
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>, Peter Stadler <peter.stadler@student.uibk.ac.at>
 PKG_LICENSE:=BSD-3-Clause

--- a/lang/python/django/test.sh
+++ b/lang/python/django/test.sh
@@ -18,4 +18,3 @@ if (django.__version__) != "$GOT_VER":
 
 sys.exit(0)
 EOF
-


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @commodo, @peter-stadler

**Description:**
Bump to version 6.0.6.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** master
- **OpenWrt Target/Subtarget:** Arm SystemReady (EFI) compliant / 64-bit (armv8) machines
- **OpenWrt Device:** QEMU

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.