### PR TITLE
libsoup3: depend on libzstd

### DIFF
--- a/libs/libsoup3/Makefile
+++ b/libs/libsoup3/Makefile
@@ -30,7 +30,7 @@ define Package/libsoup3
   CATEGORY:=Libraries
   TITLE:=libsoup3
   URL:=https://wiki.gnome.org/Projects/libsoup
-  DEPENDS:=+glib2 +libxml2 +libgnutls +libsqlite3 +libpsl +libnghttp2
+  DEPENDS:=+glib2 +libxml2 +libgnutls +libsqlite3 +libpsl +libnghttp2 +libzstd
 endef
 
 MESON_ARGS += \


### PR DESCRIPTION
Libsoup3 3.7.1 added support for zstd content encoding, and that requires libzstd. Add dependency on the library to build this feature.

## 📦 Package Details

**Maintainer:** me

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.