### PR TITLE
valkey: bump to 9.1.0

### DIFF
--- a/libs/valkey/Makefile
+++ b/libs/valkey/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=valkey
-PKG_VERSION:=9.0.1
+PKG_VERSION:=9.1.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/valkey-io/valkey/archive/refs/tags/$(PKG_VERSION).tar.gz?
-PKG_HASH:=9cfbc5f32a2a6058ee0f8c532b9c4d24167cc49d719f091dd75f1bb8353a1fc5
+PKG_HASH:=7789fe1df257774457bafb4c1d56c9f7020c3879a7f5b4234af9030b2bd82dfd
 
 PKG_MAINTAINER:=Matthew Cather <mattbob4@gmail.com>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
includes server security related releases.

## 📦 Package Details

**Maintainer:** @MattCatz 

**Description:**
Jumping from 9.0.1 to 9.1.0 pulls in several security fixes.
---

## 🧪 Run Testing Details

- **OpenWrt Version:**r32661-530179bae3
- **OpenWrt Target/Subtarget:**mediatek/filogic
- **OpenWrt Device:**SDG-8733

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [x] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
