### PR TITLE
libwebsockets: bump to 4.5.8

### DIFF
--- a/libs/libwebsockets/Makefile
+++ b/libs/libwebsockets/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libwebsockets
-PKG_VERSION:=4.4.1
+PKG_VERSION:=4.5.8
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
 PKG_SOURCE_URL:=https://codeload.github.com/warmcat/libwebsockets/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=472e6cfa77b6f80ff2cc176bc59f6cb2856df7e30e8f31afcbd1fc94ffd2f828
+PKG_HASH:=b6ade658f4af3a823d0dc806ae5ef0623f0f4f5e2aeb895a0f77c4783840c30e
 
 PKG_SOURCE_VERSION:=v$(PKG_VERSION)
 
@@ -22,6 +22,9 @@ PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
 
 PKG_BUILD_DEPENDS:=libubox
+
+# GCC 15 workaround for discarded-qualifiers warning
+TARGET_CFLAGS += -Wno-error=discarded-qualifiers
 
 CMAKE_INSTALL:=1
 


### PR DESCRIPTION
libwebsockets: bump to 4.5.8, add gcc15 workaround

Changelog:
https://libwebsockets.org/git/libwebsockets/tree/changelog?h=v4.5-stable