### PR TITLE
watchcat: fix restart_iface without mmifacename

### DIFF
--- a/utils/watchcat/Makefile
+++ b/utils/watchcat/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=watchcat
 PKG_VERSION:=1
-PKG_RELEASE:=22
+PKG_RELEASE:=23
 
 PKG_MAINTAINER:=Roger D <rogerdammit@gmail.com>
 PKG_LICENSE:=GPL-2.0

--- a/utils/watchcat/files/watchcat.init
+++ b/utils/watchcat/files/watchcat.init
@@ -39,7 +39,7 @@ config_watchcat() {
 	config_get forcedelay "$1" forcedelay "60"
 	config_get pingsize "$1" pingsize "standard"
 	config_get interface "$1" interface
-	config_get mmifacename "$1" mmifacename "null"
+	config_get mmifacename "$1" mmifacename
 	config_get_bool unlockbands "$1" unlockbands "0"
 	config_get addressfamily "$1" addressfamily "any"
 	config_get script "$1" script
@@ -73,7 +73,7 @@ config_watchcat() {
 				append_string "warn" "pingperiod cannot be a negative value." "; "
 			fi
 
-			if [ "$mmifacename" != "null" ] && [ "$period" -lt 30 ]; then
+			if [ -n "$mmifacename" ] && [ "$period" -lt 30 ]; then
 				append_string "error" "Check interval is less than 30s. For robust operation with ModemManager modem interfaces it is recommended to set the period to at least 30s."
 			fi
 		fi


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @roger- 

**Description:**
In `restart_iface` mode, `watchcat` currently defaults `mmifacename` to the literal string "null".
Since watchcat.sh only checks whether the value is non-empty [1], an unset `mmifacename` is treated as configured and the ModemManager restart path is used unexpectedly.

This changes `mmifacename` to default to an empty value.

[1] https://github.com/openwrt/packages/blob/master/utils/watchcat/files/watchcat.sh#L170

---

## 🧪 Run Testing Details

- **OpenWrt Version:** Snapshot r34792-a317079b57
- **OpenWrt Target/Subtarget:** ramips/mt76x8
- **OpenWrt Device:** Teltonika RUT976

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.