### PR TITLE
dust: add new package

### DIFF
--- a/utils/dust/Makefile
+++ b/utils/dust/Makefile
@@ -1,0 +1,65 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=dust
+PKG_VERSION:=1.2.4
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/bootandy/dust/tar.gz/refs/tags/v$(PKG_VERSION)?
+PKG_HASH:=2f6768534bd01727234e67f1dd3754c9547aa18c715f6ee52094e881ebac50e3
+
+PKG_MAINTAINER:=John Audia <therealgraysky@proton.me>
+PKG_LICENSE:=Apache-2.0
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_DEPENDS:=rust/host
+PKG_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/rust/rust-package.mk
+
+define Package/dust
+  SECTION:=utils
+  CATEGORY:=Utilities
+  DEPENDS:=$(RUST_ARCH_DEPENDS)
+  TITLE:=A more intuitive version of du in Rust
+  URL:=https://github.com/bootandy/dust
+endef
+
+define Package/dust/description
+  A more intuitive, modern take on the classic 'du' command. Written
+  in Rust, it offers a human readable overview of disk space using a
+  top-down size sorting, graphical tree layout, and multi-threaded
+  scanning for high-performance directory analysis.
+endef
+
+define Package/dust-completions
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=Shell completions for dust
+  URL:=https://github.com/bootandy/dust
+  DEPENDS:=dust
+endef
+
+define Package/dust-completions/description
+  Fish and Zsh shell completions for dust.
+endef
+
+define Package/dust/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/bin/dust $(1)/usr/bin/dust
+endef
+
+define Package/dust-completions/install
+	$(INSTALL_DIR) $(1)/usr/share/fish/vendor_completions.d
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/completions/dust.fish \
+		$(1)/usr/share/fish/vendor_completions.d/dust.fish
+
+	$(INSTALL_DIR) $(1)/usr/share/zsh/site-functions
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/completions/_dust \
+		$(1)/usr/share/zsh/site-functions/_dust
+endef
+
+$(eval $(call RustBinPackage,dust))
+$(eval $(call BuildPackage,dust))
+$(eval $(call BuildPackage,dust-completions))


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

Dust is the modern equivalent of du, and is much faster returning results particularly on solid-state disks thanks to its utilization of parallel processing. It simply "does the right thing" when handling large numbers of small files and directories by keeping the output simple and only showing large entries.

Beyond the speed benefits, it's worth noting that tools like ncdu or baobab give a view of directory sizes but abstract away where the largest individual files are. Dust remedies this by isolating the largest files explicitly within a visual tree hierarchy. Merging dust allows supplying a highly intuitive, fast alternative to du for users targeting modern storage layouts.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** x86/64-glibc
- **OpenWrt Device:** generic PC

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
