### PR TITLE
ddns-scripts: fix log noise and add fallback for default values

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.3
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_LICENSE:=GPL-2.0
 

--- a/net/ddns-scripts/files/etc/hotplug.d/iface/ddns
+++ b/net/ddns-scripts/files/etc/hotplug.d/iface/ddns
@@ -9,8 +9,7 @@ start_ddns_service() {
 
 	local interface
 
-	config_get interface $cfg interface
-	[ -z "$interface" ] && return
+	config_get interface $cfg interface wan
 
 	[ "$interface" != "$interface_event" ] && return
 

--- a/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_functions.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_functions.sh
@@ -1022,8 +1022,6 @@ get_registered_ip() {
 			write_log 14 "Busybox nslookup - no support for 'DNS over TCP'"
 		[ -n "$NSLOOKUP_MUSL" -a -n "$dns_server" ] && \
 			write_log 14 "Busybox compiled with musl - nslookup don't support the use of DNS Server"
-		[ $force_ipversion -ne 0 ] && \
-			write_log 5 "Busybox nslookup - no support to 'force IP Version' (ignored)"
 
 		__RUNPROG="$NSLOOKUP $lookup_host $dns_server >$DATFILE 2>$ERRFILE"
 		__PROG="BusyBox nslookup"


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @feckert
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->
fix log noise:
When fetching the IP via a URL with `force_ipversion` enabled, a `Busybox nslookup - no support to 'force IP Version' (ignored)` log is generated periodically. This log is redundant, in this scenario `force_ipversion` only affects the results fetched by wget/uclient-fetch/curl. It is perfectly fine for nslookup to query both A/AAAA records simultaneously.

add fallback for default values:
In luci, the `interface` value has `o.default = 'wan'` configured. Due to a behavior fix in 'o.default', values matching the default are no longer saved. Currently, this is workedaround by disabling 'o.rmempty' in luci, but handling this compatibility fallback on the backend is a cleaner and superior approach.

Ref: https://github.com/openwrt/luci/commit/b004197a277804ec0c8f092412b91c1d3e5936fa

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** N100

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
