### PR TITLE
python-orjson: update to 3.11.9

### DIFF
--- a/lang/python/python-orjson/Makefile
+++ b/lang/python/python-orjson/Makefile
@@ -1,11 +1,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-orjson
-PKG_VERSION:=3.11.8
+PKG_VERSION:=3.11.9
 PKG_RELEASE:=1
 
 PYPI_NAME:=orjson
-PKG_HASH:=96163d9cdc5a202703e9ad1b9ae757d5f0ca62f4fa0cc93d1f27b0e180cc404e
+PKG_HASH:=4fef17e1f8722c11587a6ef18e35902450221da0028e65dbaaa543619e68e48f
 
 PKG_MAINTAINER:=Timothy Ace <openwrt@timothyace.com>
 PKG_LICENSE:=Apache-2.0 MIT


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @ecammit 

**Description:**

3.11.8 failed to build against the SDK's stable rust 1.96.0: build.rs enabled
orjson's "cold_path" cargo feature for rustc >= 1.95.0, activating an unstable
feature gate that errors with E0554. 3.11.9 drops it; plain version bump.


---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [ ] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

