### PR TITLE
dockerd: update configuration to select TFTP modules

### DIFF
--- a/utils/dockerd/Config.in
+++ b/utils/dockerd/Config.in
@@ -61,7 +61,7 @@ menu "Network"
 		bool "Includes ftp/tftp client kernel modules"
 		default n
 		select PACKAGE_kmod-nf-nathelper
-		select PACKAGE_kmod-nf-nathelper-extra
+		select PACKAGE_kmod-nf-nathelper-tftp
 endmenu
 
 menu "Storage"


### PR DESCRIPTION
PR https://github.com/openwrt/openwrt/pull/23690 introduces the ability to add PACKAGE_kmod-nf-nathelper-tftp instead of PACKAGE_kmod-nf-nathelper-extra to reduce space usage.

Depends on https://github.com/openwrt/openwrt/pull/23690