### PR TITLE
perl: fix version check in test-version.sh

### DIFF
--- a/lang/perl/test-version.sh
+++ b/lang/perl/test-version.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
-# Perl script wrappers do not output the OpenWrt package version string
-case "$1" in
-	perlbase-archive|perlbase-pod|perlbase-test) exit 0 ;;
+case "$PKG_NAME" in
+perl)
+	perl -v 2>&1 | grep -q "v$PKG_VERSION"
+	;;
+perlbase-archive|perlbase-pod|perlbase-test)
+	# Perl script wrappers do not output the OpenWrt package version string
+	exit 0
+	;;
 esac


### PR DESCRIPTION
Enable version checking for the main perl package. Previously, the version check for perl was skipped. Add a check that runs perl -v and verifies that the output matches PKG_VERSION.
