### PR TITLE
perl: install libperl.so using $(INSTALL_BIN) to enable stripping

### DIFF
--- a/lang/perl/Makefile
+++ b/lang/perl/Makefile
@@ -11,7 +11,7 @@ include perlver.mk
 
 PKG_NAME:=perl
 PKG_VERSION:=$(PERL_VERSION)
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE_URL:=https://www.cpan.org/src/5.0
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
@@ -152,7 +152,7 @@ define Package/perl/install
 	ln -nsf perl$(PKG_VERSION) $(1)/usr/bin/perl
 	
 	$(INSTALL_DIR) $(1)/usr/lib/perl5/$(PERL_VERSION)/CORE
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/perl5/$(PERL_VERSION)/CORE/libperl.so $(1)/usr/lib/perl5/$(PERL_VERSION)/CORE/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/perl5/$(PERL_VERSION)/CORE/libperl.so $(1)/usr/lib/perl5/$(PERL_VERSION)/CORE/
 endef
 
 


### PR DESCRIPTION
Maintainer: @jw2013 
✅ Compile and Run tested: Turris 1.1, powerpc8540, OpenWrt 24.10
Issue discovered by CI/CD:
```
perl: [warn] Binary /usr/lib/perl5/5.40/CORE/libperl.so contains a hardcoded build path
/usr/lib/perl5/5.40/CORE/libperl.so: ELF 64-bit LSB shared object, ARM aarch64, version 1 (SYSV), dynamically linked, with debug_info, not stripped
perl: [warn] Binary /usr/lib/perl5/5.40/CORE/libperl.so is not stripped
```

Commit:
_____

Install libperl.so with executable permissions (0755) instead of copying it as-is.

This allows the OpenWrt build system to recognize the library as a binary and automatically run the "strip" utility on it. Stripping removes unnecessary debugging metadata and helper symbols that are only needed for development but not for running Perl on the router.

This change reduces the installed size of libperl.so on the device:
- Before (not stripped): 3.7 MB (3,929,652 bytes)

```
root@turris:~# file /usr/lib/perl5/5.40/CORE/libperl.so
/usr/lib/perl5/5.40/CORE/libperl.so: ELF 32-bit MSB shared object, PowerPC or cisco 4500, version 1 (SYSV), dynamically linked, with debug_info, not stripped
```

- After (stripped):     3.5 MB (3,674,081 bytes)

```
root@turris:~# file /usr/lib/perl5/5.40/CORE/libperl.so
/usr/lib/perl5/5.40/CORE/libperl.so: ELF 32-bit MSB shared object, PowerPC or cisco 4500, version 1 (SYSV), dynamically linked, no section header
```

Saving ~255 KB of flash storage space on target devices.
