### PR TITLE
bcm27xx-eeprom: update to 2026-05-27

### DIFF
--- a/utils/bcm27xx-eeprom/Makefile
+++ b/utils/bcm27xx-eeprom/Makefile
@@ -5,9 +5,9 @@ PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/raspberrypi/rpi-eeprom
-PKG_SOURCE_DATE:=2025-05-08
-PKG_SOURCE_VERSION:=1bb6edeff52c6d30c358f0a7e7a0db47427a7e21
-PKG_MIRROR_HASH:=3c1a9d91eb1d77df97084497c7e1ceac770dbefeac3d6544c3b4514d225e03f4
+PKG_SOURCE_DATE:=2026-05-27
+PKG_SOURCE_VERSION:=05d94be4554ce44a057bfce8d0dd37d951703dab
+PKG_MIRROR_HASH:=d9e9f6cf293cf0b7fb8d651b21fe48bd7553a56bba3796af27d8874423a0f47c
 
 PKG_MAINTAINER:=Álvaro Fernández Rojas <noltari@gmail.com>
 PKG_LICENSE:=BSD-3-Clause Custom
@@ -76,7 +76,7 @@ define Package/bcm2711-eeprom/install
 	$(INSTALL_DIR) $(1)/lib/firmware/raspberrypi/bootloader-2711/latest
 
 	$(CP) $(PKG_BUILD_DIR)/firmware-2711/release-notes.md $(1)/lib/firmware/raspberrypi/bootloader-2711
-	$(CP) $(PKG_BUILD_DIR)/firmware-2711/latest/pieeprom-2025-05-08.bin $(1)/lib/firmware/raspberrypi/bootloader-2711/latest
+	$(CP) $(PKG_BUILD_DIR)/firmware-2711/latest/pieeprom-2026-05-17.bin $(1)/lib/firmware/raspberrypi/bootloader-2711/latest
 	$(CP) $(PKG_BUILD_DIR)/firmware-2711/latest/recovery.bin $(1)/lib/firmware/raspberrypi/bootloader-2711/latest
 	$(CP) $(PKG_BUILD_DIR)/firmware-2711/latest/vl805-000138c0.bin $(1)/lib/firmware/raspberrypi/bootloader-2711/latest
 endef
@@ -86,7 +86,7 @@ define Package/bcm2712-eeprom/install
 	$(INSTALL_DIR) $(1)/lib/firmware/raspberrypi/bootloader-2712/latest
 
 	$(CP) $(PKG_BUILD_DIR)/firmware-2712/release-notes.md $(1)/lib/firmware/raspberrypi/bootloader-2712
-	$(CP) $(PKG_BUILD_DIR)/firmware-2712/latest/pieeprom-2025-05-08.bin $(1)/lib/firmware/raspberrypi/bootloader-2712/latest
+	$(CP) $(PKG_BUILD_DIR)/firmware-2712/latest/pieeprom-2026-05-26.bin $(1)/lib/firmware/raspberrypi/bootloader-2712/latest
 	$(CP) $(PKG_BUILD_DIR)/firmware-2712/latest/recovery.bin $(1)/lib/firmware/raspberrypi/bootloader-2712/latest
 endef
 

--- a/utils/bcm27xx-eeprom/patches/0002-rpi-eeprom-update-change-default-include-path.patch
+++ b/utils/bcm27xx-eeprom/patches/0002-rpi-eeprom-update-change-default-include-path.patch
@@ -24,16 +24,16 @@ Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
  fi
  
  LOCAL_MODE=0
-@@ -466,7 +466,7 @@ checkDependencies() {
+@@ -567,7 +567,7 @@ checkDependencies() {
        echo "Run with -h for more information."
        echo
-       echo "To enable flashrom programming of the EEPROM"
--      echo "Add these the following entries to /etc/default/rpi-eeprom-update"
-+      echo "Add these the following entries to /etc/bcm27xx-eeprom.conf"
-       echo "RPI_EEPROM_USE_FLASHROM=1"
+       echo "To enable immediate update programming of the EEPROM"
+-      echo "Add the following entries to /etc/default/rpi-eeprom-update"
++      echo "Add the following entries to /etc/bcm27xx-eeprom.conf"
+       echo "RPI_EEPROM_IMMEDIATE_UPDATE=1"
        echo "CM4_ENABLE_RPI_EEPROM_UPDATE=1"
-       echo 
-@@ -553,7 +553,7 @@ The system should then boot normally.
+       echo
+@@ -659,7 +659,7 @@ The system should then boot normally.
  
  If /boot does not correspond to the boot partition and this
  is not a NOOBS system, then the mount point for BOOTFS should be defined
@@ -42,7 +42,7 @@ Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
  
  A backup of the current EEPROM config file is written to ${FIRMWARE_BACKUP_DIR}
  before applying the update.
-@@ -585,7 +585,7 @@ Options:
+@@ -691,7 +691,7 @@ Options:
     -u Install the specified VL805 (USB EEPROM) image file.
  
  Environment:
@@ -51,7 +51,7 @@ Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
  
  EEPROM_CONFIG_HOOK
  
-@@ -657,7 +657,7 @@ must first be enabled by removing ENABLE
+@@ -763,7 +763,7 @@ must first be enabled by removing ENABLE
  via usbboot.
  
  After enabling self-update set the CM4_ENABLE_RPI_EEPROM_UPDATE=1 environment

--- a/utils/bcm27xx-eeprom/patches/0003-rpi-eeprom-update-chmod-silent-f-is-not-supported.patch
+++ b/utils/bcm27xx-eeprom/patches/0003-rpi-eeprom-update-chmod-silent-f-is-not-supported.patch
@@ -13,16 +13,16 @@ Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
 
 --- a/rpi-eeprom-update
 +++ b/rpi-eeprom-update
-@@ -248,7 +248,7 @@ applyRecoveryUpdate()
-                 || die "Failed to copy ${TMP_EEPROM_IMAGE} to ${BOOTFS}"
+@@ -307,7 +307,7 @@ applyRecoveryUpdate()
+                    || die "Failed to copy ${TMP_EEPROM_IMAGE} to ${BOOTFS}"
  
-         # For NFS mounts ensure that the files are readable to the TFTP user
--        chmod -f go+r "${BOOTFS}/pieeprom.upd" "${BOOTFS}/pieeprom.sig" \
-+        chmod go+r "${BOOTFS}/pieeprom.upd" "${BOOTFS}/pieeprom.sig" \
-                 || die "Failed to set permissions on eeprom update files"
+            # For NFS mounts ensure that the files are readable to the TFTP user
+-           chmod -f go+r "${BOOTFS}/pieeprom.upd" "${BOOTFS}/pieeprom.sig" \
++           chmod go+r "${BOOTFS}/pieeprom.upd" "${BOOTFS}/pieeprom.sig" \
+                    || die "Failed to set permissions on eeprom update files"
+         fi
     fi
- 
-@@ -259,7 +259,7 @@ applyRecoveryUpdate()
+@@ -319,7 +319,7 @@ applyRecoveryUpdate()
                  || die "Failed to copy ${VL805_UPDATE_IMAGE} to ${BOOTFS}/vl805.bin"
  
          # For NFS mounts ensure that the files are readable to the TFTP user

--- a/utils/bcm27xx-eeprom/patches/0004-rpi-eeprom-config-replace-nano-with-vi-as-default-ed.patch
+++ b/utils/bcm27xx-eeprom/patches/0004-rpi-eeprom-config-replace-nano-with-vi-as-default-ed.patch
@@ -13,7 +13,7 @@ Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
 
 --- a/rpi-eeprom-config
 +++ b/rpi-eeprom-config
-@@ -184,8 +184,8 @@ def edit_config(eeprom=None):
+@@ -191,8 +191,8 @@ def edit_config(eeprom=None):
      """
      Implements something like 'git commit' for editing EEPROM configs.
      """
@@ -24,7 +24,7 @@ Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
      if 'EDITOR' in os.environ:
          editor = os.environ['EDITOR']
  
-@@ -515,7 +515,7 @@ Operating modes:
+@@ -545,7 +545,7 @@ Operating modes:
  
     To cancel the pending update run 'sudo rpi-eeprom-update -r'
  


### PR DESCRIPTION
## 📦 Package Details

**Description:**
I've updated the eeprom-firmware package that is needed for kernel-6.18.y series. Please review and apply. Thank you

---

## 🧪 Run Testing Details

- **OpenWrt Version: master**
- **OpenWrt Target/Subtarget: bcm27xx_bcm2712/bcm2711**
- **OpenWrt Device: raspberry pi 4/5**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [x] It is structured in a way that it is potentially upstreamable

