### PR TITLE
python3: fix host python extension compilation on macOS

### DIFF
--- a/lang/python/python3-host.mk
+++ b/lang/python/python3-host.mk
@@ -74,10 +74,10 @@ HOST_PYTHON3_VARS = \
 	CCSHARED="$(HOSTCC) $(HOST_FPIC)" \
 	CXX="$(HOSTCXX)" \
 	LD="$(HOSTCC)" \
-	LDSHARED="$(HOSTCC) -shared" \
+	LDSHARED="$(HOSTCC) $(if $(findstring Darwin,$(HOST_OS)),-bundle -undefined dynamic_lookup,-shared)" \
 	CFLAGS="$(HOST_CFLAGS)" \
 	CPPFLAGS="$(HOST_CPPFLAGS) -I$(HOST_PYTHON3_INC_DIR)" \
-	LDFLAGS="$(HOST_LDFLAGS) -lpython$(PYTHON3_VERSION)" \
+	LDFLAGS="$(HOST_LDFLAGS)$(if $(findstring Darwin,$(HOST_OS)),, -lpython$(PYTHON3_VERSION))" \
 	$(CARGO_HOST_CONFIG_VARS) \
 	SETUPTOOLS_RUST_CARGO_PROFILE="$(CARGO_HOST_PROFILE)"
 


### PR DESCRIPTION
Maintainer: @commodo

⚠️  This was tested only on OpenWrt 24.10 branch
✅  MacBook Air, Apple M3, macOS Tahoe 26.5.1
cc: @httpstorm (not sure, who else should I ping to test and verify it)
_____
On macOS (Darwin) hosts, building host Python C extensions (such as Cython) using the '-shared' flag and linking against '-lpython3.x' causes the host Python interpreter to load a duplicate copy of the Python runtime. This leads to type checking mismatches and segmentation faults (SIGSEGV) when importing the compiled extension.

For example, running:
    ./staging_dir/hostpkg/bin/python3 -c "import Cython.Utils"
crashes with:
    Segmentation fault: 11

To build shared modules correctly on macOS, they must be compiled as bundles using the '-bundle -undefined dynamic_lookup' flags instead of '-shared', and they should not link against the Python library (no '-lpython3.x' in LDFLAGS).

Fix this by dynamically adjusting LDSHARED and LDFLAGS in python3-host.mk when the host OS is Darwin.
