### PR TITLE
rust: fix llvm build failure on macOS due to uuid_string_t conflict

### DIFF
--- a/lang/rust/patches/0002-llvm-uuid-string-t-macos-fix.patch
+++ b/lang/rust/patches/0002-llvm-uuid-string-t-macos-fix.patch
@@ -1,0 +1,36 @@
+From 6e9e4299b9a671ce54f3b5f4bc8073a9eb9a6071 Mon Sep 17 00:00:00 2001
+From: Josef Schlehofer <pepe.schlehofer@gmail.com>
+Date: Mon, 8 Jun 2026 09:12:00 +0200
+Subject: [PATCH] llvm: fix build failure on macOS due to uuid_string_t conflict
+
+When building LLVM on macOS, if the `libuuid` package from Homebrew or
+MacPorts is installed, its `<uuid/uuid.h>` header shadows the macOS SDK's
+`<uuid/uuid.h>`. The `libuuid` version does not define the `uuid_string_t`
+typedef, leading to a compilation failure in `LockFileManager.cpp`:
+
+    error: unknown type name 'uuid_string_t'
+
+Since `uuid_string_t` is defined as `char[37]` in the macOS system header,
+using `char UUIDStr[37];` directly is fully compatible and avoids the build
+failure caused by header shadowing.
+
+Signed-off-by: Josef Schlehofer <pepe.schlehofer@gmail.com>
+---
+ src/llvm-project/llvm/lib/Support/LockFileManager.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/llvm-project/llvm/lib/Support/LockFileManager.cpp b/src/llvm-project/llvm/lib/Support/LockFileManager.cpp
+index d6527ba..84c0f2a 100644
+--- a/src/llvm-project/llvm/lib/Support/LockFileManager.cpp
++++ b/src/llvm-project/llvm/lib/Support/LockFileManager.cpp
+@@ -89,7 +89,7 @@ static std::error_code getHostID(SmallVectorImpl<char> &HostID) {
+   if (gethostuuid(uuid, &wait) != 0)
+     return errnoAsErrorCode();
+ 
+-  uuid_string_t UUIDStr;
++  char UUIDStr[37];
+   uuid_unparse(uuid, UUIDStr);
+   StringRef UUIDRef(UUIDStr);
+   HostID.append(UUIDRef.begin(), UUIDRef.end());
+-- 
+2.50.1 (Apple Git-155)


### PR DESCRIPTION
Maintainer: @lu-zero

⚠️ Compile tested on macOS 26.5.1 for OpenWrt 24.10
Ping @httpstorm , It should also happen on the OpenWrt master branch. Could you please check it there, if it is not my local issue? Based on your findings, I will try to upstream the patch.

_____

When building host-rustc (which builds LLVM) on macOS, if the libuuid package from Homebrew or MacPorts is installed, its <uuid/uuid.h> header shadows the macOS SDK's <uuid/uuid.h>.

The libuuid header does not define the uuid_string_t typedef (which is normally typedef char uuid_string_t[37]), leading to a compilation failure in LLVM's LockFileManager.cpp:
```bash
  FAILED: lib/Support/CMakeFiles/LLVMSupport.dir/LockFileManager.cpp.o
  /usr/bin/c++ ... -isystem .../staging_dir/host/include ... -c .../LockFileManager.cpp
  .../LockFileManager.cpp:92:3: error: unknown type name 'uuid_string_t'
     92 |   uuid_string_t UUIDStr;
        |   ^
  1 error generated.
```

The root cause is the -isystem .../staging_dir/host/include flag, which adds the Homebrew libuuid header path before the macOS SDK, shadowing the system uuid/uuid.h that defines uuid_string_t.

Avoid this conflict by explicitly declaring char UUIDStr[37] instead of uuid_string_t UUIDStr, which is portable and fully compatible with both the system SDK and libuuid headers.

Tested by building lang/rust from clean on macOS (Apple Silicon):
  ```make
  make package/feeds/packages/rust/host/compile
  ```