### PR TITLE
ci: re-enable formality comments and labels

### DIFF
--- a/.github/workflows/multi-arch-test-build.yml
+++ b/.github/workflows/multi-arch-test-build.yml
@@ -22,11 +22,34 @@ jobs:
           max_body_line_len: 100
           max_subject_len_hard: 80
           max_subject_len_soft: 60
-          # This still needs a fine-grained token related to:
-          # https://github.com/openwrt/packages/pull/28011
-          # job_step: 2
-          # post_comment: true
-          # warn_on_no_modify: true
+          job_step: 2
+          post_comment: true
+          warn_on_no_modify: true
+
+  label_formality_status:
+    name: Add formality check labels
+    runs-on: ubuntu-slim
+    needs: formalities
+    if: always()
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Add 'not following guidelines' label
+        if: needs.formalities.result == 'failure'
+        uses: buildsville/add-remove-label@v2.0.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          labels: "not following guidelines"
+          type: add
+
+      - name: Remove 'not following guidelines' label
+        if: needs.formalities.result == 'success'
+        uses: buildsville/add-remove-label@v2.0.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          labels: "not following guidelines"
+          type: remove
 
   build:
     name: Feeds Package Test Build


### PR DESCRIPTION
This reverts commit 1f2d66502bd1d529d346515ca956f539b70c2b9d and reintroduce PR: https://github.com/openwrt/packages/pull/28054

Hopefully, token issue was solved and if not, let's see. 🤞 