### PR TITLE
flashrom: update to version 1.7.0

### DIFF
--- a/utils/flashrom/Makefile
+++ b/utils/flashrom/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=flashrom
-PKG_VERSION:=1.3.0
-PKG_RELEASE:=2
+PKG_VERSION:=1.7.0
+PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-v$(PKG_VERSION).tar.bz2
+PKG_SOURCE:=$(PKG_NAME)-v$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://download.flashrom.org/releases
-PKG_HASH:=a053234453ccd012e79f3443bdcc61625cf97b7fd7cb4cdd8bfbffbe8b149623
+PKG_HASH:=4328ace9833f7efe7c334bdd73482cde8286819826cc00149e83fba96bf3ab4f
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-v$(PKG_VERSION)
 
 PKG_MAINTAINER:=Álvaro Fernández Rojas <noltari@gmail.com>

--- a/utils/flashrom/flashrom.mk
+++ b/utils/flashrom/flashrom.mk
@@ -98,6 +98,12 @@ endif
 
 MESON_ARGS += \
 	-Ddefault_programmer_name=$(DEFAULT_PROGRAMMER_NAME) \
+	-Dich_descriptors_tool=enabled \
+	-Dbash_completion=disabled \
+	-Dtests=disabled \
 	-Dprogrammer=$(subst $(space),$(comma),$(strip $(PROGRAMMER_ARGS))) \
-	-Dwerror=false \
-	-Dtests=disabled
+	-Drpmc=disabled \
+	-Duse_git_version=disabled \
+	-Dman-pages=disabled \
+	-Ddocumentation=disabled \
+	-Dgenerate_authors_list=disabled

--- a/utils/flashrom/patches/0001-libflashrom-fix-build-on-big-endian-targets.patch
+++ b/utils/flashrom/patches/0001-libflashrom-fix-build-on-big-endian-targets.patch
@@ -1,0 +1,51 @@
+From 3e016738aadf6b02abb3357d6be2fde9560dbd07 Mon Sep 17 00:00:00 2001
+From: Florian Larysch <fl@n621.de>
+Date: Mon, 13 Apr 2026 01:40:52 +0200
+Subject: [PATCH] libflashrom: fix build on big-endian targets
+
+Commit f74f02e2 ("Add guard for compare_region_with_dump()") added
+little-endian-only compile guards to that function because it was only
+used on little-endian systems and caused -Wunused-function to trip on
+other targets.
+
+When b0b975d0 ("libflashrom: Add new layout_compare() function with
+test") introduced flashrom_layout_compare(), it included the new
+function within those guards too, but this isn't necessary:
+compare_region_with_dump() is not sensitive to endianess and adding that
+new dependent actually made the original reason for adding the guard
+obsolete.
+
+However, now building on big-endian architectures fails because
+cli_classic.c unconditionally refers to flashrom_layout_compare().
+
+Resolve this by simply removing the guard.
+
+Fixes: https://ticket.coreboot.org/issues/635
+
+Change-Id: If3e6828e6445e0708e1174728f91053e48a097ba
+Signed-off-by: Florian Larysch <fl@n621.de>
+Reviewed-on: https://review.coreboot.org/c/flashrom/+/92156
+Tested-by: build bot (Jenkins) <no-reply@coreboot.org>
+Reviewed-by: Anastasia Klimchuk <aklm@chromium.org>
+---
+ libflashrom.c | 2 --
+ 1 file changed, 2 deletions(-)
+
+--- a/libflashrom.c
++++ b/libflashrom.c
+@@ -462,7 +462,6 @@ bool flashrom_flag_get(const struct flas
+ 	}
+ }
+ 
+-#ifdef __FLASHROM_LITTLE_ENDIAN__
+ static int compare_region_with_dump(const struct romentry *const a, const struct romentry *const b)
+ {
+ 	if (a->region.start != b->region.start
+@@ -508,7 +507,6 @@ int flashrom_layout_compare(const struct
+ 
+ 	return 0;
+ }
+-#endif /* __FLASHROM_LITTLE_ENDIAN__ */
+ 
+ int flashrom_layout_read_from_ifd(struct flashrom_layout **const layout, struct flashctx *const flashctx,
+ 				  const void *const dump, const size_t len)


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @Noltari

**Description:**
* Update flashrom version from `1.3.0` to `1.7.0`
* Add patch to fix  link error for __FLASHROM_LITTLE_ENDIAN__

Fixes: #29590

---

## 🧪 Run Testing Details

- **OpenWrt Version: master**
- **OpenWrt Target/Subtarget: x86/64**
- **OpenWrt Device: APU3**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
- [x] It is structured in a way that it is potentially upstreamable

