### PR TITLE
quickjs: bump to 2026.06.04

### DIFF
--- a/lang/quickjs/Makefile
+++ b/lang/quickjs/Makefile
@@ -1,16 +1,16 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=quickjs
-PKG_VERSION:=2025.09.13
+PKG_VERSION:=2026.06.04
 # The source versioning structure is somewhat bizarre as the file name
 # might differ from the directory name and the version.
-PKG_SRC_VERSION:=2025-09-13
-PKG_SRC_VERSION_REV:=2
+PKG_SRC_VERSION:=2026-06-04
+PKG_SRC_VERSION_REV:=
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_SRC_VERSION)$(if $(PKG_SRC_VERSION_REV),-$(PKG_SRC_VERSION_REV)).tar.xz
 PKG_SOURCE_URL:=https://bellard.org/quickjs/
-PKG_HASH:=996c6b5018fc955ad4d06426d0e9cb713685a00c825aa5c0418bd53f7df8b0b4
+PKG_HASH:=b376e839b322978313d929fd20663b11ba58b75df5a46c126dd19ea2fa70ad2a
 
 PKG_MAINTAINER:=George Sapkin <george@sapk.in>
 PKG_LICENSE:=MIT

--- a/lang/quickjs/test-version.sh
+++ b/lang/quickjs/test-version.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# shellcheck shell=busybox
+
+case "$PKG_NAME" in
+quickjs)
+	qjs --help | grep -F "${PKG_VERSION//./-}"
+	;;
+
+*)
+	echo "Untested package: $PKG_NAME" >&2
+	exit 1
+	;;
+esac

--- a/lang/quickjs/test.sh
+++ b/lang/quickjs/test.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 
-if [ "$1" = 'quickjs' ]; then
-	qjs --help | grep -F "${PKG_VERSION//./-}"
-fi
+# shellcheck shell=busybox
+
+case "$PKG_NAME" in
+quickjs)
+	qjs --eval 'console.log(2 ** 8)' | grep 256
+	;;
+esac


### PR DESCRIPTION
**Maintainer:** me

**Description:**

Bump QuickJS to 2026.06.04.

Add basic JS evaluation test and move version check to override.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12.4
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** QEMU/Vadas

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.