### PR TITLE
rust: fix host build on x64 Darwin

### DIFF
--- a/lang/rust/rust-values.mk
+++ b/lang/rust/rust-values.mk
@@ -32,6 +32,8 @@ CARGO_RUSTFLAGS+=-Ctarget-feature=-crt-static $(RUSTC_LDFLAGS)
 ifeq ($(HOST_OS),Darwin)
   ifeq ($(HOST_ARCH),arm64)
     RUSTC_HOST_ARCH:=aarch64-apple-darwin
+  else ifeq ($(HOST_ARCH),x86_64)
+    RUSTC_HOST_ARCH:=x86_64-apple-darwin
   endif
 endif
 


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @lu-zero 

**Description:**
`rust/host` fails to compile on macOS running on Intel x64 because the host target triple is autogenerated to be `arm64-unknown-linux-`. Rust doesn't have such a target triple, thus the build fails because there are no pre-built artefacts for bootstrapping.

Fix this by setting `RUSTC_HOST_ARCH` to `x86_64-apple-darwin` in case our host is `HOST_ARCH=x86_64` and `HOST_OS=Darwin`. This fix is based on the existing fix for Apple silicon [1].

Fixes:
``` bash
make package/feeds/packages/rust/host/compile -j 1 V=s
…
  File "/Volumes/pepe/py/openwrt/build_dir/target-x86_64_musl/host/rustc-1.96.0-src/x.py", line 53, in <module>
    bootstrap.main()
    ~~~~~~~~~~~~~~^^
  File "/Volumes/pepe/py/openwrt/build_dir/target-x86_64_musl/host/rustc-1.96.0-src/src/bootstrap/bootstrap.py", line 1418, in main
    bootstrap(args)
    ~~~~~~~~~^^^^^^
  File "/Volumes/pepe/py/openwrt/build_dir/target-x86_64_musl/host/rustc-1.96.0-src/src/bootstrap/bootstrap.py", line 1366, in bootstrap
    build.download_toolchain()
    ~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/Volumes/pepe/py/openwrt/build_dir/target-x86_64_musl/host/rustc-1.96.0-src/src/bootstrap/bootstrap.py", line 697, in download_toolchain
    download_component(download_info)
    ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "/Volumes/pepe/py/openwrt/build_dir/target-x86_64_musl/host/rustc-1.96.0-src/src/bootstrap/bootstrap.py", line 529, in download_component
    get(
    ~~~^
        download_info.base_download_url,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<3 lines>...
        verbose=download_info.verbose,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/Volumes/pepe/py/openwrt/build_dir/target-x86_64_musl/host/rustc-1.96.0-src/src/bootstrap/bootstrap.py", line 58, in get
    raise RuntimeError(
    ...<6 lines>...
    )
RuntimeError: src/stage0 doesn't contain a checksum for dist/2026-04-16/rust-std-1.95.0-x86_64-unknown-linux-darwin24.6.0.tar.xz. Pre-built artifacts might not be available for this target at this time, see https://doc.rust-lang.org/nightly/rustc/platform-support.html for more information.
```

[1] https://github.com/openwrt/packages/commit/105fa3920e12f557bdf1fcbc566fc286fb53e319
[2] https://github.com/openwrt/packages/pull/21837

---

## 🧪 Run Testing Details

- **OpenWrt Version:** main
- **OpenWrt Target/Subtarget:** x64
- **OpenWrt Device:** x64
- **Build tested:** macOS 15.7.7 Intel

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

@robimarko @PolynomialDivision @BKPepe 