### PR TITLE
rust: fix host build on x64 Darwin

### DIFF
--- a/lang/rust/rust-values.mk
+++ b/lang/rust/rust-values.mk
@@ -32,6 +32,8 @@ CARGO_RUSTFLAGS+=-Ctarget-feature=-crt-static $(RUSTC_LDFLAGS)
 ifeq ($(HOST_OS),Darwin)
   ifeq ($(HOST_ARCH),arm64)
     RUSTC_HOST_ARCH:=aarch64-apple-darwin
+  else ifeq ($(HOST_ARCH),x86_64)
+    RUSTC_HOST_ARCH:=x86_64-apple-darwin
   endif
 endif
 


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @lu-zero 

**Description:**
cherry-pick: aa32dd256eb04eff40748b8b1a8623461441ffbe original PR: https://github.com/openwrt/packages/pull/29685

`rust/host` fails to compile on macOS running on Intel x64 because the host target triple is autogenerated to be `arm64-unknown-linux-`. Rust doesn't have such a target triple, thus the build fails because there are no pre-built artefacts for bootstrapping.

Fix this by setting `RUSTC_HOST_ARCH` to `x86_64-apple-darwin` in case our host is `HOST_ARCH=x86_64` and `HOST_OS=Darwin`. This fix is based on the existing fix for Apple silicon [1].

Fixes:
``` bash
make package/feeds/packages/rust/host/compile -j 1 V=s
…
  File "/Volumes/pepe/_/openwrt/build_dir/target-x86_64_musl/host/rustc-1.90.0-src/x.py", line 53, in <module>
    bootstrap.main()
  File "/Volumes/pepe/_/openwrt/build_dir/target-x86_64_musl/host/rustc-1.90.0-src/src/bootstrap/bootstrap.py", line 1377, in main
    bootstrap(args)
  File "/Volumes/pepe/_/openwrt/build_dir/target-x86_64_musl/host/rustc-1.90.0-src/src/bootstrap/bootstrap.py", line 1342, in bootstrap
    build.download_toolchain()
  File "/Volumes/pepe/_/openwrt/build_dir/target-x86_64_musl/host/rustc-1.90.0-src/src/bootstrap/bootstrap.py", line 684, in download_toolchain
    download_component(download_info)
  File "/Volumes/pepe/_/openwrt/build_dir/target-x86_64_musl/host/rustc-1.90.0-src/src/bootstrap/bootstrap.py", line 517, in download_component
    get(
  File "/Volumes/pepe/_/openwrt/build_dir/target-x86_64_musl/host/rustc-1.90.0-src/src/bootstrap/bootstrap.py", line 58, in get
    raise RuntimeError(
RuntimeError: src/stage0 doesn't contain a checksum for dist/2025-08-07/rust-std-1.89.0-x86_64-unknown-linux-darwin24.6.0.tar.xz. Pre-built artifacts might not be available for this target at this time, see https://doc.rust-lang.org/nightly/rustc/platform-support.html for more information.
```

[1] https://github.com/openwrt/packages/commit/105fa3920e12f557bdf1fcbc566fc286fb53e319
[2] https://github.com/openwrt/packages/pull/21837

---

## 🧪 Run Testing Details

- **OpenWrt Version:** openwrt-24.10
- **OpenWrt Target/Subtarget:** x64
- **OpenWrt Device:** x64
- **Build tested:** macOS 15.7.7 Intel

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

@robimarko @PolynomialDivision @BKPepe 