### PR TITLE
exfatprogs: update to version 1.4.1

### DIFF
--- a/utils/exfatprogs/Makefile
+++ b/utils/exfatprogs/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=exfatprogs
-PKG_VERSION:=1.3.2
+PKG_VERSION:=1.4.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/exfatprogs/exfatprogs/releases/download/$(PKG_VERSION)
-PKG_HASH:=67ddb50543636292df8fde58117eefd54210d6cd7bf1eea5e91d2c4dccbc425e
+PKG_HASH:=85c133e8802cbc1191bff2477a67b376192dfb9f94bb254c05dbae79fd958f2e
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=GPL-2.0-only
@@ -23,6 +23,7 @@ define Package/exfatprogs/Default
   CATEGORY:=Utilities
   SUBMENU:=Filesystem
   URL:=https://github.com/exfatprogs/exfatprogs
+  DEPENDS:=+libblkid +USE_MUSL:musl-fts
 endef
 
 define Package/exfat-mkfs


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @dangowrt

**Description:**
Update exfatprogs to 1.4.1 (1.4.0 added exFAT partition-table support, chdosattr/lsdosattr and the --upcase option). The new MBR/foreign-filesystem detection links libblkid and fts, so add +libblkid and +USE_MUSL:musl-fts.

---

## 🧪 Run Testing Details

Compile-tested only on `mediatek/filogic` (`aarch64_cortex-a53`); not run-tested on hardware.

- **OpenWrt Version:** snapshot
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** —

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using `make package/<your-package>/refresh V=s`
- [x] It is structured in a way that it is potentially upstreamable
