### PR TITLE
gpgme: update to version 2.1.0

### DIFF
--- a/libs/gpgme/Makefile
+++ b/libs/gpgme/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gpgme
-PKG_VERSION:=2.0.1
+PKG_VERSION:=2.1.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://gnupg.org/ftp/gcrypt/$(PKG_NAME)
-PKG_HASH:=821ab0695c842eab51752a81980c92b0410c7eadd04103f791d5d2a526784966
+PKG_HASH:=841c5ea53fc26259f4fbf0e8bde982dea1b8a1ca0cb77e681c82b050566bf92b
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=LGPL-2.1-or-later


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @dangowrt

**Description:**
Update gpgme to 2.1.0 (new encryption-result and decryption flags, CMS signature attributes, export-filter context flag, a gpgsm lockup fix and a passphrase-cancel fix).

---

## 🧪 Run Testing Details

Compile-tested only on `mediatek/filogic` (`aarch64_cortex-a53`); not run-tested on hardware.

- **OpenWrt Version:** snapshot
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** —

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using `make package/<your-package>/refresh V=s`
- [x] It is structured in a way that it is potentially upstreamable
