### PR TITLE
exim: update to version 4.99.4

### DIFF
--- a/mail/exim/Makefile
+++ b/mail/exim/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=exim
-PKG_VERSION:=4.99.3
+PKG_VERSION:=4.99.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://downloads.exim.org/exim4/
-PKG_HASH:=663e76d2a0d9b8fc5b373d0008e44ae044f10feb22bc9dbae8c7f21345ebfb3b
+PKG_HASH:=87ff38815700dfb1ee4eb7e8dba7916df7a755905354d2d0faa1ae1790c4fd9d
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 
 PKG_LICENSE:=GPL-2.0-or-later


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @dangowrt

**Description:**
Update Exim to 4.99.4 (maintenance release on the 4.99 stable series).

---

## 🧪 Run Testing Details

Compile-tested only on `mediatek/filogic` (`aarch64_cortex-a53`); not run-tested on hardware.

- **OpenWrt Version:** snapshot
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** —

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using `make package/<your-package>/refresh V=s`
- [x] It is structured in a way that it is potentially upstreamable
