### PR TITLE
lm-sensors: fix build failure in iconv test

### DIFF
--- a/utils/lm-sensors/patches/100-Fix-iconv-linking-detection-for-glibc-based-builds.patch
+++ b/utils/lm-sensors/patches/100-Fix-iconv-linking-detection-for-glibc-based-builds.patch
@@ -22,15 +22,16 @@ Fixes build on glibc-based systems including OpenWrt glibc targets.
 
 --- a/Makefile
 +++ b/Makefile
-@@ -171,6 +171,23 @@ LIBCFLAGS := -fpic -D_REENTRANT $(ALL_CF
+@@ -171,6 +171,24 @@ LIBCFLAGS := -fpic -D_REENTRANT $(ALL_CF
  
  ALL_LDFLAGS := $(LDFLAGS)
  
++pound := \#
 +# Determine iconv linking requirements
 +# glibc has built-in iconv, other libc implementations may need -liconv
 +ifndef LIBICONV
 +  ICONV_TEST := $(shell printf '%s\n' \
-+    '#include <iconv.h>' \
++    '$(pound)include <iconv.h>' \
 +    'int main() { iconv_t cd = iconv_open("UTF-8", "ASCII"); return 0; }' \
 +    | $(CC) $(ALL_CPPFLAGS) -x c - -o /tmp/lm_sensors_iconv_test 2>/dev/null && echo "builtin" || echo "external")
 +
@@ -48,15 +49,18 @@ Fixes build on glibc-based systems including OpenWrt glibc targets.
  .PHONY: all user clean install user_install uninstall user_uninstall
 --- a/prog/sensors/Module.mk
 +++ b/prog/sensors/Module.mk
-@@ -39,7 +39,10 @@ REMOVESENSORSBIN := $(patsubst $(MODULE_
+@@ -39,7 +39,13 @@ REMOVESENSORSBIN := $(patsubst $(MODULE_
  REMOVESENSORSMAN := $(patsubst $(MODULE_DIR)/%,$(DESTDIR)$(PROGSENSORSMAN1DIR)/%,$(PROGSENSORSMAN1FILES))
  REMOVESENSORSZSH := $(patsubst $(MODULE_DIR)/%,$(DESTDIR)$(ZSHCOMPDIR)/%,$(PROGSENSORSZSHCOMPFILES))
  
 -LIBICONV := $(shell if /sbin/ldconfig -p | grep -q '/libiconv\.so$$' ; then echo \-liconv; else echo; fi)
-+LIBICONV := $(shell printf '%s\n' \
-+  '#include <iconv.h>' \
++ifndef LIBICONV
++pound := \#
++LIBICONV ?= $(shell printf '%s\n' \
++  '$(pound)include <iconv.h>' \
 +  'int main() { iconv_t cd = iconv_open("UTF-8", "ASCII"); return 0; }' \
 +  | $(CC) $(ALL_CPPFLAGS) -x c - 2>/dev/null && echo || echo \-liconv)
++endif
  
  $(PROGSENSORSTARGETS): $(PROGSENSORSSOURCES:.c=.ro) lib/$(LIBDEP_FOR_PROGS)
  	$(CC) $(EXLDFLAGS) -o $@ $(PROGSENSORSSOURCES:.c=.ro) $(LIBICONV) -Llib -lsensors -lm


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** Jo-Philipp Wich <jo@mein.io>

**Description:**

Building lm-sensors under OpenWrt with GNU make 4.2.1 fails while parsing the multi-line `$(shell ...)` expression used for iconv detection:

```text
Makefile:177: *** unterminated call to function 'shell': missing ')'.  Stop.
```

Escaping the `#` in the generated `#include <iconv.h>` line avoids the parse failure and allows the iconv detection test to execute normally.

The generated C source remains unchanged after Makefile parsing.

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12
- **OpenWrt Target/Subtarget:** Mediatek/Filogic
- **OpenWrt Device:** Z8103AX

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using

  ```bash
  make package/lm-sensors/refresh V=s
  ```

- [x] It is structured in a way that it is potentially upstreamable
