### PR TITLE
acme-acmesh: Remove duplicated notification on certificate renewal

### DIFF
--- a/net/acme-acmesh/Makefile
+++ b/net/acme-acmesh/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=acme-acmesh
 PKG_VERSION:=3.1.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/acmesh-official/acme.sh/tar.gz/$(PKG_VERSION)?

--- a/net/acme-acmesh/files/hook.sh
+++ b/net/acme-acmesh/files/hook.sh
@@ -123,7 +123,6 @@ get)
 			case $status in
 			0)
 				link_certs "$domain_dir" "$main_domain"
-				$NOTIFY renewed
 				exit
 				;;
 			2)


### PR DESCRIPTION
fix #29703

## 📦 Package Details

**Maintainer:** @tohojo

**Description:**
Remove duplicated notification on certificate renewal. fix #29703 

---

## 🧪 Run Testing Details

- **OpenWrt Version: 25.12.4**
- **OpenWrt Target/Subtarget: x86/64**
- **OpenWrt Device: Generic x86/64**

---

## ✅ Formalities

- ✅ I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
