### PR TITLE
net/eternalterminal: add new package

### DIFF
--- a/net/eternalterminal/Makefile
+++ b/net/eternalterminal/Makefile
@@ -1,0 +1,53 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=eternalterminal
+PKG_VERSION:=6.2.11
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/MisterTea/EternalTerminal.git
+PKG_SOURCE_VERSION:=et-v$(PKG_VERSION)
+PKG_MIRROR_HASH:=0bc27188bfc0ae5d4df3fe6961a12943addaa2b09e239a1103053fa8814f39b2
+
+PKG_LICENSE:=Apache-2.0
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_DEPENDS:=protobuf/host
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+define Package/eternalterminal
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=Eternal Terminal (Remote shell)
+  URL:=https://mistertea.github.io/EternalTerminal/
+  DEPENDS:=+libsodium +protobuf +libopenssl +zlib +libstdcpp
+endef
+
+define Package/eternalterminal/description
+  Eternal Terminal is a remote shell that automatically reconnects without interrupting the session.
+endef
+
+CMAKE_OPTIONS += \
+	-DDISABLE_VCPKG=ON \
+	-DDISABLE_TELEMETRY=ON \
+	-DDISABLE_SENTRY=ON \
+	-DDISABLE_CRASH_LOG=ON \
+	-DCODE_COVERAGE=OFF \
+	-DBUILD_TESTING=OFF \
+	-DINSTALL_BASH_COMPLETION=OFF \
+	-DINSTALL_ZSH_COMPLETION=OFF \
+	-DProtobuf_PROTOC_EXECUTABLE=$(STAGING_DIR_HOSTPKG)/bin/protoc
+
+define Package/eternalterminal/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/et $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/etserver $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/etterminal $(1)/usr/bin/
+
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/etserver.init $(1)/etc/init.d/etserver
+endef
+
+$(eval $(call BuildPackage,eternalterminal))

--- a/net/eternalterminal/files/etserver.init
+++ b/net/eternalterminal/files/etserver.init
@@ -1,0 +1,33 @@
+#!/bin/sh /etc/rc.common
+# Skrypt startowy Eternal Terminal (etserver) dla OpenWrt
+
+START=90
+STOP=10
+
+USE_PROCD=1
+PROG=/usr/bin/etserver
+
+start_service() {
+    # Wymuszamy, by etserver uważał /var/run za swój katalog XDG, 
+    # aby lokalny fifo nie uszkadzał pamięci flash.
+    export XDG_RUNTIME_DIR=/var/run
+    mkdir -p /var/run/etserver
+    chmod 0700 /var/run/etserver
+
+    procd_open_instance
+    procd_set_param command $PROG
+    
+    # Przekierowujemy standardowe wyjście (np. logi połączeń) do systemowego syslogd
+    procd_set_param stdout 1
+    procd_set_param stderr 1
+    
+    # Automatyczny restart demona, jeśli z jakiegoś powodu zginie
+    procd_set_param respawn "3600" "5" "5"
+    
+    procd_close_instance
+}
+
+reload_service() {
+    stop_service
+    start_service
+}

--- a/net/eternalterminal/patches/010-fix-protobuf-host-protoc.patch
+++ b/net/eternalterminal/patches/010-fix-protobuf-host-protoc.patch
@@ -1,0 +1,14 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -219,6 +219,11 @@ endif()
+ 
+ set(PROTOBUF_LIBS protobuf::libprotobuf)
+ 
++if(NOT TARGET protobuf::protoc)
++  add_executable(protobuf::protoc IMPORTED)
++  set_target_properties(protobuf::protoc PROPERTIES IMPORTED_LOCATION "${Protobuf_PROTOC_EXECUTABLE}")
++endif()
++
+ if(Protobuf_VERSION VERSION_GREATER_EQUAL 4)
+   find_package(absl REQUIRED)
+ 

--- a/net/eternalterminal/patches/020-disable-execinfo-for-musl.patch
+++ b/net/eternalterminal/patches/020-disable-execinfo-for-musl.patch
@@ -1,0 +1,31 @@
+--- a/src/base/Headers.hpp
++++ b/src/base/Headers.hpp
+@@ -124,9 +124,7 @@ namespace fs = boost::filesystem
+ #include "sago/platform_folders.h"
+ #include "sole.hpp"
+ 
+-#if !defined(__ANDROID__)
+-#include "ust.hpp"
+-#endif
++//#include "ust.hpp" // Disabled for OpenWrt/musl
+ 
+ #ifdef WITH_UTEMPTER
+ #include <utempter.h>
+@@ -172,15 +170,8 @@ const int MAX_CLIENT_KEEP_ALIVE_DURATION
+ // allow enough time.
+ const int SERVER_KEEP_ALIVE_DURATION = 11;
+ 
+-#if defined(__ANDROID__)
+-#define STFATAL LOG(FATAL) << "No Stack Trace on Android" << endl
+-
+-#define STERROR LOG(ERROR) << "No Stack Trace on Android" << endl
+-#else
+-#define STFATAL LOG(FATAL) << "Stack Trace: " << endl << ust::generate()
+-
+-#define STERROR LOG(ERROR) << "Stack Trace: " << endl << ust::generate()
+-#endif
++#define STFATAL LOG(FATAL) << "No Stack Trace on OpenWrt" << endl
++#define STERROR LOG(ERROR) << "No Stack Trace on OpenWrt" << endl
+ 
+ inline int GetErrno() {
+ #ifdef WIN32


### PR DESCRIPTION
Eternal Terminal is a remote shell that automatically reconnects without interrupting the session.

Notes:
- Set DISABLE_VCPKG to force usage of OpenWrt libraries (libsodium, protobuf)
- Added PKG_BUILD_DEPENDS:=protobuf/host to ensure protoc version matches libprotobuf
- Strip execution of backtrace() inside embedded UniversalStacktrace sub-module, as it relies on execinfo.h which is unsupported by musl libc.
- XDG_RUNTIME_DIR set to /var/run in init script to keep pipes in RAM disk.

## 📦 Package Details

**Maintainer:** @DienoX
<sub>(This is a new package, I am submitting myself as the maintainer in the Makefile)</sub>

**Description:**
Adding Eternal Terminal (et) to OpenWrt. It is a highly requested alternative to SSH and Mosh that maintains persistent connections even through IP roaming or network drops. It uses OpenWrt's native libsodium and protobuf.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12.4
- **OpenWrt Target/Subtarget:** mediatek/filogic (AArch64 / Cortex-A53)
- **OpenWrt Device:** Cudy WR3000P / GL.iNet Flint 2

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:
*(N/A - This PR introduces a new package without traditional .patch files, logic is handled natively in the Makefile)*
- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
- [ ] It is structured in a way that it is potentially upstreamable