### PR TITLE
shadow: reintroduce newgidmap and newuidmap

### DIFF
--- a/utils/shadow/Makefile
+++ b/utils/shadow/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=shadow
 PKG_VERSION:=4.19.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/shadow-maint/shadow/releases/download/$(PKG_VERSION)
@@ -30,7 +30,7 @@ include $(INCLUDE_DIR)/nls.mk
 SHADOW_APPLETS := \
 	chage chfn chgpasswd chpasswd chsh expiry faillog gpasswd \
 	groupadd groupdel groupmems groupmod grpck grpconv grpunconv \
-	login logoutd newgrp newusers nologin \
+	login logoutd newgrp newgidmap newuidmap newusers nologin \
 	passwd pwck pwconv pwunconv su \
 	useradd userdel usermod vipw
 
@@ -45,7 +45,9 @@ CONFIGURE_ARGS += \
 	--without-sssd \
 	--without-libbsd \
 	--disable-logind \
-	--disable-subordinate-ids \
+	--enable-subordinate-ids \
+	--disable-shared \
+	--enable-static \
 	--with-bcrypt
 
 CONFIGURE_VARS += \


### PR DESCRIPTION

## 📦 Package Details

**Maintainer:** @commodo 
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

@BKPepe - Based on your comment https://github.com/openwrt/packages/pull/29505#issuecomment-4654072892

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

The `lxc-unprivileged` package depends on both `newgidmap` and `newuidmap` if users are installing and setting it up for the first time. dc52894 dropped both of the applets.

This change builds `libusbid` as a shared lib which builds a versioned symbol which OpenWrt does not stage so build with `--disable-shared` and `--enable-static` to avoid a failure.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** x86/64-gblic
- **OpenWrt Device:** N150

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
