### PR TITLE
yggdrasil-ng: add package

### DIFF
--- a/net/yggdrasil-ng/Makefile
+++ b/net/yggdrasil-ng/Makefile
@@ -1,0 +1,57 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=yggdrasil-ng
+PKG_VERSION:=0.1.6
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/Revertron/Yggdrasil-ng/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=a8ec3727c17873747f3cf91c5fd6dad403747d245f964141b8e465f469412522
+PKG_BUILD_DIR:=$(BUILD_DIR)/Yggdrasil-ng-$(PKG_VERSION)
+
+PKG_MAINTAINER:=OverLessArtem <artemover@duck.com>
+PKG_LICENSE:=MPL-2.0
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_DEPENDS:=rust/host
+PKG_BUILD_PARALLEL:=1
+PKG_BUILD_FLAGS:=no-mips16
+
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/rust/rust-package.mk
+
+# Workspace crate that contains the yggdrasil binary
+MAKE_PATH:=crates/yggdrasil
+
+define Package/yggdrasil-ng
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=Routing and Redirection
+  TITLE:=Yggdrasil mesh network (Rust rewrite)
+  URL:=https://github.com/Revertron/Yggdrasil-ng
+  DEPENDS:=$(RUST_ARCH_DEPENDS) @!i386_pentium-mmx @IPV6 +kmod-tun
+endef
+
+define Package/yggdrasil-ng/description
+  Yggdrasil-ng is a Rust rewrite of the Yggdrasil Network — a fully
+  end-to-end encrypted IPv6 mesh networking protocol. Wire-compatible
+  with the original Go implementation.
+
+  Features a smaller memory footprint, faster throughput, and a
+  single binary (daemon + control tool combined). Supports TCP and
+  TLS transports, Crypto-Key Routing (CKR) for VPN tunneling,
+  multicast peer discovery, and a built-in stateful firewall.
+endef
+
+define Package/yggdrasil-ng/install
+	$(INSTALL_DIR) \
+		$(1)/etc/yggdrasil-ng \
+		$(1)/etc/init.d \
+		$(1)/usr/sbin
+
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/bin/yggdrasil $(1)/usr/sbin/
+	$(INSTALL_BIN) ./files/yggdrasil-ng.init $(1)/etc/init.d/yggdrasil-ng
+endef
+
+$(eval $(call RustBinPackage,yggdrasil-ng))
+$(eval $(call BuildPackage,yggdrasil-ng))

--- a/net/yggdrasil-ng/files/yggdrasil-ng.init
+++ b/net/yggdrasil-ng/files/yggdrasil-ng.init
@@ -1,0 +1,22 @@
+#!/bin/sh /etc/rc.common
+
+START=85
+STOP=15
+
+USE_PROCD=1
+PROG=/usr/sbin/yggdrasil
+CONFIG_DIR=/etc/yggdrasil-ng
+CONFIG_FILE=$CONFIG_DIR/yggdrasil.toml
+
+start_service() {
+	# On first boot generate a config with a fresh Ed25519 keypair.
+	# The key is persisted in /etc/yggdrasil-ng/ and survives reboots.
+	[ -f "$CONFIG_FILE" ] || $PROG --genconf "$CONFIG_FILE"
+
+	procd_open_instance
+	procd_set_param command $PROG --config "$CONFIG_FILE"
+	procd_set_param respawn
+	procd_set_param stdout 1
+	procd_set_param stderr 1
+	procd_close_instance
+}

--- a/net/yggdrasil-ng/test.sh
+++ b/net/yggdrasil-ng/test.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+case "$1" in
+	"yggdrasil-ng")
+		yggdrasil --version 2>&1 | grep "$2"
+		;;
+esac


### PR DESCRIPTION
## 📦 Package Details

  **Maintainer:** @TotallyNotOver
  <sub>(You can find this by checking the history of the package `Makefile`.)</sub>

  **Description:**
  Add yggdrasil-ng a Rust rewrite of the Yggdrasil Network, a fully
  end-to-end encrypted IPv6 mesh networking protocol.

  Compared to the existing Go yggdrasil package:
  - **Significantly smaller binary** (4.1 MB vs ~10+ MB for Go)
  - **Lower memory footprint** ideal for RAM-constrained routers
  - **Faster throughput** iperf3 tests show measurable improvements
  - **Single binary** daemon and control tool combined, no separate
    `yggdrasilctl` needed

  Features: wire-compatible with yggdrasil-go v0.5.x, TCP/TLS transports,
  Crypto-Key Routing (CKR) for VPN tunneling, multicast peer discovery,
  built-in stateful firewall.

  License: MPL-2.0 | 99 stars on GitHub | actively maintained

  ---

  ## 🧪 Run Testing Details

  - **OpenWrt Version:** 25.12.4
  - **OpenWrt Target/Subtarget:** x86/64
  - **OpenWrt Device:** SDK (build test only)

  Package compiles successfully. Binary: ELF 64-bit, dynamically linked
  against musl, stripped. Package size: 1.9 MB (compressed), 4.1 MB
  (uncompressed).

  ---

  ## ✅ Formalities

  - [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.