### PR TITLE
xtables-addons: fix build with newer kernels

### DIFF
--- a/net/xtables-addons/patches/501-use-ccflags-y.patch
+++ b/net/xtables-addons/patches/501-use-ccflags-y.patch
@@ -1,0 +1,32 @@
+Index: xtables-addons-3.27/extensions/ACCOUNT/Kbuild
+===================================================================
+--- xtables-addons-3.27.orig/extensions/ACCOUNT/Kbuild
++++ xtables-addons-3.27/extensions/ACCOUNT/Kbuild
+@@ -1,5 +1,6 @@
+ # -*- Makefile -*-
+ 
+ EXTRA_CFLAGS = -I${src}/..
++ccflags-y += $(EXTRA_CFLAGS)
+ 
+ obj-m += xt_ACCOUNT.o
+Index: xtables-addons-3.27/extensions/LUA/Kbuild
+===================================================================
+--- xtables-addons-3.27.orig/extensions/LUA/Kbuild
++++ xtables-addons-3.27/extensions/LUA/Kbuild
+@@ -49,3 +49,5 @@ xt_LUA-y += lua/lapi.o \
+ 			lua/lvm.o \
+ 			lua/lzio.o \
+ 			lua/lauxlib.o \
++
++ccflags-y += $(EXTRA_CFLAGS)
+Index: xtables-addons-3.27/extensions/pknock/Kbuild
+===================================================================
+--- xtables-addons-3.27.orig/extensions/pknock/Kbuild
++++ xtables-addons-3.27/extensions/pknock/Kbuild
+@@ -1,5 +1,6 @@
+ # -*- Makefile -*-
+ 
+ EXTRA_CFLAGS = -I${src}/..
++ccflags-y += $(EXTRA_CFLAGS)
+ 
+ obj-m += xt_pknock.o

--- a/net/xtables-addons/patches/502-pknock-new-timer-api.patch
+++ b/net/xtables-addons/patches/502-pknock-new-timer-api.patch
@@ -1,0 +1,52 @@
+Index: xtables-addons-3.27/extensions/pknock/xt_pknock.c
+===================================================================
+--- xtables-addons-3.27.orig/extensions/pknock/xt_pknock.c
++++ xtables-addons-3.27/extensions/pknock/xt_pknock.c
+@@ -30,6 +30,20 @@
+ #include "xt_pknock.h"
+ #include "compat_xtables.h"
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++#define pknock_del_timer(t) timer_delete(t)
++#else
++#define pknock_del_timer(t) del_timer(t)
++#endif
++
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 16, 0)
++#define pknock_from_timer(var, timer, member) \
++	timer_container_of(var, timer, member)
++#else
++#define pknock_from_timer(var, timer, member) \
++	from_timer(var, timer, member)
++#endif
++
+ enum status {
+ 	ST_INIT = 1,
+ 	ST_MATCHING,
+@@ -296,7 +310,7 @@ static const struct proc_ops pknock_proc
+ static void update_rule_gc_timer(struct xt_pknock_rule *rule)
+ {
+ 	if (timer_pending(&rule->timer))
+-		del_timer(&rule->timer);
++		pknock_del_timer(&rule->timer);
+ 	rule->timer.expires = jiffies + msecs_to_jiffies(gc_expir_time);
+ 	add_timer(&rule->timer);
+ }
+@@ -355,7 +369,7 @@ has_logged_during_this_minute(const stru
+ static void peer_gc(struct timer_list *tl)
+ {
+ 	unsigned int i;
+-	struct xt_pknock_rule *rule = from_timer(rule, tl, timer);
++	struct xt_pknock_rule *rule = pknock_from_timer(rule, tl, timer);
+ 	struct peer *peer;
+ 	struct list_head *pos, *n;
+ 
+@@ -517,7 +531,7 @@ remove_rule(struct xt_pknock_mtinfo *inf
+ 		remove_proc_entry(info->rule_name, pde);
+ 	pr_debug("(D) rule deleted: %s.\n", rule->rule_name);
+ 	if (timer_pending(&rule->timer))
+-		del_timer(&rule->timer);
++		pknock_del_timer(&rule->timer);
+ 	list_del(&rule->head);
+ 	kfree(rule->peer_head);
+ 	kfree(rule);


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** Jo-Philipp Wich <jo@mein.io>

**Description:**

This PR fixes xtables-addons build failures with newer Linux kernels.

Changes included:

1. Replace deprecated `EXTRA_CFLAGS` usage with `ccflags-y` in extension
   Kbuild files so local include paths and compiler flags are correctly
   propagated by modern kbuild.

2. Update the `pknock` extension to support newer timer APIs by using
   the appropriate timer helpers on newer kernels while maintaining
   compatibility with older kernels.

These fixes resolve build failures observed when compiling xtables-addons
against Linux 6.18.

Affected build failures include:

```text
ACCOUNT/xt_ACCOUNT.c: fatal error: compat_xtables.h: No such file or directory

LUA/controller.h: fatal error: stdlib.h: No such file or directory

pknock/xt_pknock.c: error: implicit declaration of function 'del_timer'
pknock/xt_pknock.c: error: implicit declaration of function 'from_timer'
```

---

## 🧪 Run Testing Details

- **OpenWrt Version:** master
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** ZBT Z8803BE

Build-tested with:

- Linux 6.18.x
- aarch64 (MediaTek Filogic)

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using

  ```bash
  make package/xtables-addons/refresh V=s
  ```

- [x] It is structured in a way that it is potentially upstreamable

<sub>(e.g., subject line, commit description, etc.)</sub>

<sub>We must try to upstream patches to reduce maintenance burden.</sub>