### PR TITLE
ddns-scripts: DNSimple provider and nslookup enhancements

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -7,8 +7,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
-PKG_VERSION:=2.8.3
-PKG_RELEASE:=7
+PKG_VERSION:=2.8.4
+PKG_RELEASE:=1
 
 PKG_LICENSE:=GPL-2.0
 
@@ -394,6 +394,24 @@ define Package/ddns-scripts-porkbun/description
 	'option domain' to be the FQDN for which to configure DDNS
 endef
 
+define Package/ddns-scripts-dnsimple
+	$(call Package/ddns-scripts/Default)
+	TITLE:=Extension for dnsimple.com API v2
+	DEPENDS:=ddns-scripts +curl
+	PROVIDES:=ddns-scripts_dnsimple.com-v2
+endef
+
+define Package/ddns-scripts-dnsimple/description
+	Dynamic DNS Client scripts extension for dnsimple.com API v2 (requires curl)
+	Required:
+	'option lookup_host' to be your hostname to update e.g. my.host.example.com
+	'option username' to be your DNSimple numerical account ID
+	'option password' to be a DNSimple API token
+	'option domain' to be the DNSimple DNS Zone ID e.g. example.com
+	Optional Parameters:
+	'option param_opt' must be an existing DNS record ID, saves 1 API call
+endef
+
 define Package/ddns-scripts-huaweicloud
   $(call Package/ddns-scripts/Default)
   TITLE:=Extension for huaweicloud.com API
@@ -495,6 +513,7 @@ define Package/ddns-scripts-services/install
 	rm $(1)/usr/share/ddns/default/ns1.com.json
 	rm $(1)/usr/share/ddns/default/one.com.json
 	rm $(1)/usr/share/ddns/default/porkbun.com-v3.json
+	rm $(1)/usr/share/ddns/default/dnsimple.com-v2.json
 	rm $(1)/usr/share/ddns/default/huaweicloud.com.json
 	rm $(1)/usr/share/ddns/default/aliyun.com.json
 	rm $(1)/usr/share/ddns/default/servercow.de.json
@@ -959,6 +978,25 @@ exit 0
 endef
 
 
+define Package/ddns-scripts-dnsimple/install
+	$(INSTALL_DIR) $(1)/usr/lib/ddns
+	$(INSTALL_BIN) ./files/usr/lib/ddns/update_dnsimple_v2.sh \
+		$(1)/usr/lib/ddns
+
+	$(INSTALL_DIR) $(1)/usr/share/ddns/default
+	$(INSTALL_DATA) ./files/usr/share/ddns/default/dnsimple.com-v2.json \
+		$(1)/usr/share/ddns/default/
+endef
+
+define Package/ddns-scripts-dnsimple/prerm
+#!/bin/sh
+if [ -z "$${IPKG_INSTROOT}" ]; then
+	/etc/init.d/ddns stop
+fi
+exit 0
+endef
+
+
 define Package/ddns-scripts-huaweicloud/install
 	$(INSTALL_DIR) $(1)/usr/lib/ddns
 	$(INSTALL_BIN) ./files/usr/lib/ddns/update_huaweicloud_com.sh \
@@ -1040,6 +1078,7 @@ $(eval $(call BuildPackage,ddns-scripts-transip))
 $(eval $(call BuildPackage,ddns-scripts-ns1))
 $(eval $(call BuildPackage,ddns-scripts-one))
 $(eval $(call BuildPackage,ddns-scripts-porkbun))
+$(eval $(call BuildPackage,ddns-scripts-dnsimple))
 $(eval $(call BuildPackage,ddns-scripts-huaweicloud))
 $(eval $(call BuildPackage,ddns-scripts-aliyun))
 $(eval $(call BuildPackage,ddns-scripts-servercow))

--- a/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_functions.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_functions.sh
@@ -1017,13 +1017,14 @@ get_registered_ip() {
 		__RUNPROG="$__PROG $lookup_host >$DATFILE 2>$ERRFILE"
 		__PROG="hostip"
 	elif [ -n "$NSLOOKUP" ]; then	# last use BusyBox nslookup
+		[ $use_ipv6 -eq 1 ] && lookup_type="-type=aaaa" || lookup_type="-type=a"
 		NSLOOKUP_MUSL=$($(command -v nslookup) localhost 2>&1 | grep -F "(null)")	# not empty busybox compiled with musl
 		[ $force_dnstcp -ne 0 ] && \
 			write_log 14 "Busybox nslookup - no support for 'DNS over TCP'"
 		[ -n "$NSLOOKUP_MUSL" -a -n "$dns_server" ] && \
 			write_log 14 "Busybox compiled with musl - nslookup don't support the use of DNS Server"
 
-		__RUNPROG="$NSLOOKUP $lookup_host $dns_server >$DATFILE 2>$ERRFILE"
+		__RUNPROG="$NSLOOKUP $lookup_type $lookup_host $dns_server >$DATFILE 2>$ERRFILE"
 		__PROG="BusyBox nslookup"
 	else	# there must be an error
 		write_log 12 "Error in 'get_registered_ip()' - no supported Name Server lookup software accessible"

--- a/net/ddns-scripts/files/usr/lib/ddns/update_dnsimple_v2.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/update_dnsimple_v2.sh
@@ -1,0 +1,204 @@
+#!/bin/sh
+#
+# Distributed under the terms of the GNU General Public License (GPL) version 2.0
+# 2026 Jorge Gallegos <kad@blegh.net>
+#
+# Script for DDNS support via DNSimple's v2 API for the OpenWRT ddns-scripts package.
+#
+# Will attempt to create a new or edit an existing A or AAAA record for the
+# given lookup host and domain. "password" configuration should be set to
+# DNSimple API token. "username" should be set to the DNSimple account ID.
+# "domain" should be set to the DNSimple zone. Optionally, "param_opt" can
+# be set to an existing DNSimple record
+#
+# DNSimple API documentation:
+# https://developer.dnsimple.com/v2/zones/records/
+
+# Source JSON parser
+. /usr/share/libubox/jshn.sh
+
+# Set API base URL
+__API="https://api.dnsimple.com/v2"
+__CONNECT_TIMEOUT=5  # cURL connect timeout in seconds
+
+# Check availability of cURL with SSL
+[ -z "$CURL" ] && [ -z "$CURL_SSL" ] && write_log 14 "cURL with SSL support required! Please install"
+
+# Validate configuration
+[ -z "$lookup_host" ] && write_log 14 "Service section not configured correctly! Missing 'lookup_host' (Hostname)"
+[ -z "$username" ] && write_log 14 "Service section not configured correctly! Missing 'username' (Account ID)"
+[ -z "$password" ] && write_log 14 "Service section not configured correctly! Missing 'password' (API token)"
+[ -z "$domain" ] && write_log 14 "Service section not configured correctly! Missing 'domain' (DNS Zone)"
+
+__ACCOUNT_ID="$username"
+__RECORD_ID="$param_opt"  # if provided, saves 1 API call to retrieve the record ID
+
+# Get record name by substracting zone from lookup host
+# if they are equal (i.e. root record) blank it
+if [ "$lookup_host" = "$domain" ]; then
+	__SUBDOMAIN=""
+else
+	__SUBDOMAIN="$(echo "$lookup_host" | sed -e "s/\.$domain\$//")"
+fi
+__DOMAIN="$domain"
+
+# Determine IPv4 or IPv6 address and record type
+if [ "$use_ipv6" -eq 1 ]; then
+	expand_ipv6 "$__IP" __ADDR
+	__RECORD_TYPE="AAAA"
+else
+	__ADDR="$__IP"
+	__RECORD_TYPE="A"
+fi
+
+
+# Make DNSimple API call
+# $1 - HTTP method (GET, POST, PATCH, DELETE)
+# $2 - DNSimple API endpoint path
+# $3 - request JSON payload (optional)
+api_call() {
+	local response url method payload
+	method="$1"
+	url="$__API/$2"
+	payload="$3"
+
+	write_log 7 "API endpoint URL: $url"
+	write_log 7 "API request method: $method"
+	[ -n "$payload" ] && write_log 7 "API request JSON payload: $payload"
+
+	if [ -n "$payload" ]; then
+		"$CURL" -s -X "$method" "$url" \
+			-H "Authorization: Bearer $password" \
+			-H "Accept: application/json" \
+			-H "Content-Type: application/json" \
+			--fail-with-body \
+			--connect-timeout "$__CONNECT_TIMEOUT" \
+			--data "$payload" \
+			-o "$DATFILE" 2>"$ERRFILE"
+	else
+		"$CURL" -s -X "$method" "$url" \
+			-H "Authorization: Bearer $password" \
+			-H "Accept: application/json" \
+			--fail-with-body \
+			--connect-timeout "$__CONNECT_TIMEOUT" \
+			-o "$DATFILE" 2>"$ERRFILE"
+	fi
+
+	if [ -s "$ERRFILE" ]; then
+		write_log 14 "API response error: $(cat "$ERRFILE")"
+	fi
+
+	write_log 7 "API response JSON payload: $(cat "$DATFILE")"
+	cat "$DATFILE"
+}
+
+# Check DNSimple API response for errors
+# DNSimple returns HTTP error codes, but we also check for error messages in response
+json_check_response() {
+	local message
+	json_get_var message "message" 2>/dev/null
+	[ -n "$message" ] && write_log 14 "API request failed: $message"
+}
+
+# Review DNS record and, if it is the record we're looking for, get its id
+callback_review_record() {
+	local id name type
+	json_select "$1"
+	json_get_var id "id"
+	json_get_var name "name"
+	json_get_var type "type"
+
+	[ "$name" = "$__SUBDOMAIN" ] && [ "$type" = "$__RECORD_TYPE" ] && echo "$id"
+	json_select ..
+}
+
+# Retrieve all DNS records, find the first appropriate A/AAAA record, and get its id
+find_existing_record_id() {
+	local response
+
+	# Call API with filters
+	response=$(api_call "GET" "$__ACCOUNT_ID/zones/$__DOMAIN/records?name=$__SUBDOMAIN&type=$__RECORD_TYPE")
+	json_load "$response"
+	json_check_response
+
+	# Check if data array exists and iterate through it
+	json_select "data" 2>/dev/null || return
+	json_get_keys keys
+	for key in $keys; do
+		local found_id
+		found_id=$(callback_review_record "$key")
+		if [ -n "$found_id" ]; then
+			echo "$found_id"
+			return
+		fi
+	done
+}
+
+# Create a new record
+create_record() {
+	local request response
+	json_init
+	json_add_string "name" "$__SUBDOMAIN"
+	json_add_string "type" "$__RECORD_TYPE"
+	json_add_string "content" "$__ADDR"
+	request=$(json_dump)
+	response=$(api_call "POST" "$__ACCOUNT_ID/zones/$__DOMAIN/records" "$request")
+	json_load "$response"
+	json_check_response
+}
+
+# Retrieve an existing record and get its content
+# $1 - record id to retrieve
+retrieve_record_content() {
+	local content response
+	response=$(api_call "GET" "$__ACCOUNT_ID/zones/$__DOMAIN/records/$1")
+	json_load "$response"
+	json_check_response
+	json_select "data"
+	json_get_var content "content"
+	echo "$content"
+}
+
+# Edit an existing A/AAAA record
+# $1 - record id to edit
+edit_record() {
+	local request response
+	json_init
+	json_add_string "content" "$__ADDR"
+	request=$(json_dump)
+	response=$(api_call "PATCH" "$__ACCOUNT_ID/zones/$__DOMAIN/records/$1" "$request")
+	json_load "$response"
+	json_check_response
+}
+
+
+# Try to identify an appropriate existing DNS record to update
+if [ -z "$__RECORD_ID" ]; then
+	write_log 7 "Retrieving DNS $__RECORD_TYPE record"
+	__ID=$(find_existing_record_id)
+else
+	write_log 7 "Using user-supplied DNS record id: $__RECORD_ID"
+	__ID="$__RECORD_ID"
+fi
+
+# Create or update DNS record with current IP address
+if [ -z "$__ID" ]; then
+	write_log 7 "Creating new DNS $__RECORD_TYPE record"
+	create_record
+else
+	write_log 7 "Updating existing DNS $__RECORD_TYPE record"
+	if [ "$use_ipv6" -eq 1 ]; then
+		__IPV6=$(retrieve_record_content "$__ID")
+		expand_ipv6 "$__IPV6" __CURRENT_ADDR
+		write_log 7 "Expanded ipv6 from $__IPV6 to $__CURRENT_ADDR"
+	else
+		__CURRENT_ADDR=$(retrieve_record_content "$__ID")
+	fi
+	write_log 7 "$__CURRENT_ADDR == $__ADDR ?"
+	if [ "$__CURRENT_ADDR" = "$__ADDR" ]; then
+		write_log 7 "DNS record already has the correct IP address, skipping update"
+	else
+		edit_record "$__ID"
+	fi
+fi
+

--- a/net/ddns-scripts/files/usr/share/ddns/default/dnsimple.com-v2.json
+++ b/net/ddns-scripts/files/usr/share/ddns/default/dnsimple.com-v2.json
@@ -1,0 +1,10 @@
+{
+	"name": "dnsimple.com-v2",
+	"ipv4": {
+		"url": "update_dnsimple_v2.sh"
+	},
+	"ipv6": {
+		"url": "update_dnsimple_v2.sh"
+	}
+}
+


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @feckert 
**Description:**

    Add DDNS update support for DNSimple DNS via their REST API.
    Authentication is performed via API Token.
    
    Will attempt to create a new or edit an existing A or AAAA record for the
    given lookup host and domain. "password" configuration should be set to
    DNSimple API token. "username" should be set to the DNSimple account ID.
    "domain" should be set to the DNSimple zone. Optionally, "param_opt" can
    be set to an existing DNSimple record.
    
    Based it off the porkbun script, as it behaves very similar.

    Also adding query type to default busybox nslookup, supports the -type option since 2018
---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12.4
- **OpenWrt Target/Subtarget:** ramips/mt7621
- **OpenWrt Device:** Netgear R6220

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
