### PR TITLE
mollysocket: add new package

### DIFF
--- a/net/mollysocket/Makefile
+++ b/net/mollysocket/Makefile
@@ -1,0 +1,58 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=mollysocket
+PKG_VERSION:=1.7.1
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/mollyim/mollysocket/tar.gz/$(PKG_VERSION)?
+PKG_HASH:=b380faf8ca526e92bcbc121d8ac35b88945a6f62b4602dea0df6f7c1f6bfaac7
+
+PKG_MAINTAINER:=Rosa Hase <github@smnx.addy.io>
+PKG_LICENSE:=AGPL-3.0-only
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_DEPENDS:=rust/host
+PKG_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/rust/rust-package.mk
+
+define Package/mollysocket
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=MollySocket UnifiedPush bridge
+  URL:=https://github.com/mollyim/mollysocket
+  # These targets lack native 64-bit atomics (AtomicU64), required by a dependency
+  # https://github.com/tikv/rust-prometheus/issues/565
+  DEPENDS:=$(RUST_ARCH_DEPENDS) @!(mips||mipsel||powerpc) +libopenssl +libsqlite3
+endef
+
+define Package/mollysocket/description
+  MollySocket allows getting Signal notifications via UnifiedPush
+endef
+
+define Package/mollysocket/conffiles
+/etc/mollysocket/config.toml
+endef
+
+# fix for aws-lc: requires SSE2
+export OPENSSL_NO_ASM=1
+TARGET_CFLAGS += -DOPENSSL_NO_ASM
+
+define Package/mollysocket/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/bin/mollysocket $(1)/usr/bin/mollysocket
+
+	$(INSTALL_DIR) $(1)/etc/mollysocket
+	$(INSTALL_CONF) ./files/mollysocket.config $(1)/etc/mollysocket/config.toml
+
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/mollysocket.init $(1)/etc/init.d/mollysocket
+
+	$(INSTALL_DIR) $(1)/lib/upgrade/keep.d
+	$(INSTALL_DATA) ./files/mollysocket.upgrade $(1)/lib/upgrade/keep.d/mollysocket
+endef
+
+$(eval $(call RustBinPackage,mollysocket))
+$(eval $(call BuildPackage,mollysocket))

--- a/net/mollysocket/files/mollysocket.config
+++ b/net/mollysocket/files/mollysocket.config
@@ -1,0 +1,8 @@
+host = "127.0.0.1"
+port = 8020
+webserver = true
+allowed_endpoints = ["*"]
+allowed_uuids = ["*"]
+db = "/etc/mollysocket/db.sqlite"
+# vapid_privkey = ""
+# vapid_key_file = "/etc/mollysocket/vapid.key"

--- a/net/mollysocket/files/mollysocket.init
+++ b/net/mollysocket/files/mollysocket.init
@@ -1,0 +1,16 @@
+#!/bin/sh /etc/rc.common
+
+USE_PROCD=1
+START=95
+STOP=10
+
+PROG=/usr/bin/mollysocket
+CONF=/etc/mollysocket/config.toml
+
+start_service() {
+	procd_open_instance
+	procd_set_param command "$PROG" server
+	procd_set_param env MOLLY_CONF="$CONF"
+	procd_set_param respawn
+	procd_close_instance
+}

--- a/net/mollysocket/files/mollysocket.upgrade
+++ b/net/mollysocket/files/mollysocket.upgrade
@@ -1,0 +1,1 @@
+/etc/mollysocket/


### PR DESCRIPTION
MollySocket allows getting Signal notifications via UnifiedPush.

## 📦 Package Details

**Maintainer:** Rosa Hase
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->
MollySocket allows getting signal notifications via [UnifiedPush](https://unifiedpush.org/). 

It works like a linked device, which doesn't have an encryption key, connected to the Signal server. Everytime it receives an encrypted event, it notifies your mobile via UnifiedPush.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12.4
- **OpenWrt Target/Subtarget:** mediatek-filogic
- **OpenWrt Device:** Flint2
- Tested: https://github.com/daxcore/mollysocket-openwrt

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
