### PR TITLE
dockerd: fix cgroup v2 swap limit detection via init jail

### DIFF
--- a/utils/dockerd/files/dockerd.init
+++ b/utils/dockerd/files/dockerd.init
@@ -232,11 +232,21 @@ start_service() {
 
 	procd_open_instance
 	procd_set_param stderr 1
+
 	if [ -z "${DOCKERD_CONF}" ]; then
-		procd_set_param command /usr/bin/dockerd
+		procd_set_param command /bin/sh -c " \
+			echo '+memory' > /sys/fs/cgroup/cgroup.subtree_control 2>/dev/null; \
+			mkdir -p /sys/fs/cgroup/dockerd-init; \
+			echo \$\$ > /sys/fs/cgroup/dockerd-init/cgroup.procs; \
+			exec /usr/bin/dockerd"
 	else
-		procd_set_param command /usr/bin/dockerd --config-file="${DOCKERD_CONF}"
+		procd_set_param command /bin/sh -c " \
+			echo '+memory' > /sys/fs/cgroup/cgroup.subtree_control 2>/dev/null; \
+			mkdir -p /sys/fs/cgroup/dockerd-init; \
+			echo \$\$ > /sys/fs/cgroup/dockerd-init/cgroup.procs; \
+			exec /usr/bin/dockerd --config-file='${DOCKERD_CONF}'"
 	fi
+
 	procd_set_param limits nofile="${nofile} ${nofile}"
 	procd_close_instance
 }


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @G-M0N3Y-2503

**Description:**
On systems using cgroup v2, Docker incorrectly logs `WARNING: No swap limit support` at startup and actively strips `memswap_limit` arguments from containers, even when the kernel has swap accounting fully enabled.

This occurs because Docker's `sysinfo` package verifies swap limit capabilities by looking for the `memory.swap.max` file inside the exact cgroup where the `dockerd` process is currently running. Because `procd` spawns daemons directly in the root cgroup (`/sys/fs/cgroup/`), and the cgroup v2 design dictates that control files cannot exist in the root directory, Docker's check fails and it artificially disables the feature internally.

This commit resolves the issue by wrapping the daemon execution in a lightweight cgroup jail:
1. Delegates the memory controller to child cgroups (`+memory`).
2. Creates a dedicated child cgroup (`/sys/fs/cgroup/dockerd-init`).
3. Moves the boot PID into the child cgroup before `exec`ing the daemon.

This safely mimics the isolation provided by `systemd`, allowing Docker to correctly detect `memory.swap.max`, clear the warning, and natively enforce hardware swap limits on containers. The shell commands are idempotent and fully safe for daemon restarts.

This has bugged me for a long while, Gemini helped me finally find the root of the issue.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** master
- **OpenWrt Target/Subtarget:** x86_64

---
