### PR TITLE
perl: fix compilation with glibc

### DIFF
--- a/lang/perl/files/libc.config
+++ b/lang/perl/files/libc.config
@@ -1,7 +1,8 @@
 ($owrt:libc eq 'glibc') {
 	perllibs="$perllibs -lbsd"
 	ldflags="$ldflags -L$owrt:staging_dir/lib"
-	
+
+	d_gnulibc='define'
 	d_perl_lc_all_category_positions_init='undef'
 	d_perl_lc_all_separator='undef'
 	d_perl_lc_all_uses_name_value_pairs='define'


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** [@pprindeville](https://github.com/pprindeville)

**Description:**
Fix perl build faild with glibc.

---

## 🧪 Run Testing Details

- **OpenWrt Version: 25.12**
- **OpenWrt Target/Subtarget: x86_64 and aarch64**
