### PR TITLE
yt-dlp: bump to 2026.06.09

### DIFF
--- a/multimedia/yt-dlp/Makefile
+++ b/multimedia/yt-dlp/Makefile
@@ -3,11 +3,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=yt-dlp
-PKG_VERSION:=2026.3.17
-PKG_RELEASE:=2
+PKG_VERSION:=2026.6.9
+PKG_RELEASE:=1
 
 PYPI_NAME:=yt-dlp
-PKG_HASH:=ba7aa31d533f1ffccfe70e421596d7ca8ff0bf1398dc6bb658b7d9dec057d2c9
+PKG_HASH:=d50fcb95f48d61bedde33e408c1881d4c279e51c31354a599ce09e96ba0f4b86
 PYPI_SOURCE_NAME:=yt_dlp
 
 PKG_MAINTAINER:=George Sapkin <george@sapk.in>

--- a/multimedia/yt-dlp/test-version.sh
+++ b/multimedia/yt-dlp/test-version.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
+# shellcheck shell=busybox
+
+case "$PKG_NAME" in
+yt-dlp)
+	yt-dlp --version | sed 's/\.0\+/./g' | grep -F "$PKG_VERSION"
+	;;
+
+yt-dlp-src)
+	exit 0
+	;;
+
+*)
+	echo "Untested package: $PKG_NAME" >&2
+	exit 1
+	;;
+esac

--- a/multimedia/yt-dlp/test.sh
+++ b/multimedia/yt-dlp/test.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-if [ "$1" = 'yt-dlp' ]; then
-	yt-dlp --version | sed 's/\.0\+/./g' | grep -F "$PKG_VERSION"
-fi


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me

**Description:**

Bump yt-dlp to 2026.06.09.

Fixes: CVE-2026-50019
Fixes: CVE-2026-50023
Fixes: CVE-2026-50574
Changes: https://github.com/yt-dlp/yt-dlp/releases/tag/2026.06.09

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT, r34878-b25d90b7e4
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** QEMU

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.