### PR TITLE
python3: fix host PGO build failure on deep build paths

### DIFF
--- a/lang/python/python3/Makefile
+++ b/lang/python/python3/Makefile
@@ -287,6 +287,9 @@ Package/python3/install:=:
 ifeq ($(HOST_OS),Linux)
 HOST_LDFLAGS += \
 	-Wl,--no-as-needed -lrt
+
+HOST_MAKE_VARS += \
+	TMPDIR=/tmp
 endif
 
 # Would be nice to be able to do this, but hosts are very fiddly


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me

**Description:**

Python 3.14 made "forkserver" the default multiprocessing start method on Linux, which binds an AF_UNIX socket under $TMPDIR during the PGO profile-run. OpenWrt points TMPDIR at the deeply nested build tree, so the socket path can exceed the 108-byte AF_UNIX limit and abort the host build with "AF_UNIX path too long" in test_re (cpython#149527). Pin TMPDIR=/tmp for the host build.

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [ ] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
