### PR TITLE
xfrpc: fix init script to handle LuCI-generated proxy sections

### DIFF
--- a/net/xfrpc/files/xfrpc.init
+++ b/net/xfrpc/files/xfrpc.init
@@ -13,23 +13,60 @@ PROG=/usr/bin/$NAME
 
 
 handle_xfrpc() {
-    local section="$1"
-    local config="$2"
+	local section="$1"
+	local config="$2"
 
-    case "$section" in
-        common)
-            uci_validate_section xfrpc xfrpc common \
-                'server_addr:host' \
-                'server_port:uinteger' \
-                'token:string:'
-            ;;
-    esac
+	# Only process the "common" section
+	[ "$section" = "common" ] || return
 
-    # Write the validated settings to the config file
-    echo "[${section}]" >> "$config"
-    [ -z "$server_addr" ] || echo "server_addr = $server_addr" >> "$config"
-    [ -z "$server_port" ] || echo "server_port = $server_port" >> "$config"
-    [ -z "$token" ] || echo "token = $token" >> "$config"
+	uci_validate_section xfrpc xfrpc common \
+		'server_addr:host' \
+		'server_port:uinteger' \
+		'token:string:'
+
+	# Write the validated settings to the config file
+	echo "[${section}]" >> "$config"
+	[ -z "$server_addr" ] || echo "server_addr = $server_addr" >> "$config"
+	[ -z "$server_port" ] || echo "server_port = $server_port" >> "$config"
+	[ -z "$token" ] || echo "token = $token" >> "$config"
+}
+
+# Fallback handler for LuCI-generated proxy sections.
+# LuCI's GridSection creates sections with type "xfrpc" and an
+# option "type" (e.g. type="tcp"). This handler reads the option
+# and dispatches to the correct output format.
+handle_xfrpc_proxy() {
+	local section="$1"
+	local config="$2"
+
+	# Skip the "common" section
+	[ "$section" = "common" ] && return
+
+	uci_validate_section xfrpc xfrpc "$section" \
+		'enabled:bool:1' \
+		'local_ip:host' \
+		'local_port:uinteger' \
+		'remote_port:uinteger' \
+		'custom_domains:string' \
+		'subdomain:string'
+
+	[ "$enabled" = 0 ] && return
+
+	echo "[${section}]" >> "$config"
+	echo "type = $type" >> "$config"
+	[ -z "$local_ip" ] || echo "local_ip = $local_ip" >> "$config"
+	[ -z "$local_port" ] || echo "local_port = $local_port" >> "$config"
+
+	case "$type" in
+		tcp)
+			[ -z "$remote_port" ] || echo "remote_port = $remote_port" >> "$config"
+			;;
+		http|https)
+			[ -z "$remote_port" ] || echo "remote_port = $remote_port" >> "$config"
+			[ -z "$custom_domains" ] || echo "custom_domains = $custom_domains" >> "$config"
+			[ -z "$subdomain" ] || echo "subdomain = $subdomain" >> "$config"
+			;;
+	esac
 }
 
 handle_tcp() {
@@ -140,6 +177,8 @@ start_service() {
 	config_foreach handle_http http "$conf_file"
 	config_foreach handle_https https "$conf_file"
 	config_foreach handle_socks5 socks5 "$conf_file"
+	# Fallback: handle LuCI-generated sections (type=xfrpc with option type="tcp"/etc)
+	config_foreach handle_xfrpc_proxy xfrpc "$conf_file"
 
 	procd_open_instance
 	procd_set_param command "$PROG" -c "$conf_file" -f -d $loglevel


### PR DESCRIPTION
## Description

Fixes the `xfrpc.init` script to properly handle proxy sections created by `luci-app-xfrpc`.

## Root Cause

The LuCI web interface (`luci-app-xfrpc`) creates proxy sections with UCI type `xfrpc` via its GridSection configuration. However, the init script's `start_service()` only iterated sections of specific types (`tcp`, `http`, `https`, `socks5`) using `config_foreach`. Since no handler processed `xfrpc`-typed sections, proxy configurations added through the LuCI interface were silently dropped during xfrpc.ini generation, resulting in a malformed config file that prevented xfrpc from starting.

## Changes

1. **handle_xfrpc()**: Added a guard at the top of the function:
   ```sh
   [ "$section" = "common" ] || return
   ```
   Previously, non-common sections (like those created by LuCI with type `xfrpc`) would pass through this handler and inherit leftover `$server_addr`/`$server_port`/`$token` values from the common section processing, polluting the proxy config.

2. **handle_xfrpc_proxy()**: New fallback handler for `xfrpc`-typed proxy sections. It reads the `type` option (tcp/http/https) from the section and writes the correct proxy parameters.

3. **start_service()**: Added `config_foreach handle_xfrpc_proxy xfrpc "$conf_file"` after the existing type-specific handlers, ensuring LuCI-generated sections are processed.

## Compatibility

- Sections with proper types (`config tcp`, `config http`, etc.) continue to work exactly as before via their dedicated handlers.
- The new fallback only activates when no type-specific handler matched the section.
- Backward compatible with existing configurations.

## Testing

Verified on ImmortalWrt 24.10.4 (Xiaomi WR30U, aarch64):
- Manually configured TCP proxy (`config tcp`): xfrpc.ini generated correctly, service starts
- LuCI-added TCP proxy (`config xfrpc` with `option type 'tcp'`): xfrpc.ini generated correctly, service starts
- All proxy types (tcp, http, https) work through both configuration paths

## Related

Fixes https://github.com/openwrt/luci/issues/7972
Companion PR: https://github.com/openwrt/luci/pull/8704