### PR TITLE
strongswan: update to 6.0.7

### DIFF
--- a/net/strongswan/Makefile
+++ b/net/strongswan/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=strongswan
-PKG_VERSION:=6.0.6
-PKG_RELEASE:=2
+PKG_VERSION:=6.0.7
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://download.strongswan.org/ https://download2.strongswan.org/
-PKG_HASH:=07df7cedae56a7f3bb07e66d21a1f9f87e961db70e99184e11d3819413e4f87c
+PKG_HASH:=e518e34e159514f4c6ba80d1f926cb151e0dd4e3a1d94213171234b8b9ae6f55
 
 PKG_MAINTAINER:=Philip Prindeville <philipp@redfish-solutions.com>, Noel Kuntze <noel.kuntze@thermi.consulting>
 PKG_LICENSE:=GPL-2.0-or-later

--- a/net/strongswan/files/swanctl.init
+++ b/net/strongswan/files/swanctl.init
@@ -314,7 +314,7 @@ config_child() {
 	hold)
 		dpdaction="trap" ;;
 	restart)
-		dpdaction="start" ;;
+		dpdaction="restart" ;;
 	trap|start)
 		# already using new syntax
 		;;


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me, @Thermi 

**Description:**
Security fix for a double-free in libstrongswan.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** HEAD
- **OpenWrt Target/Subtarget:** x86_64/generic
- **OpenWrt Device:** pc-engines-apu6

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md]

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [X] It has been refreshed to avoid offsets, fuzzes, etc., using
- [ ] It is structured in a way that it is potentially upstreamable
