### PR TITLE
treewide: musl-fts is only needed when using MUSL

### DIFF
--- a/admin/fluent-bit/Makefile
+++ b/admin/fluent-bit/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fluent-bit
 PKG_VERSION:=4.2.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/fluent/fluent-bit.git
@@ -21,7 +21,7 @@ define Package/fluent-bit
   CATEGORY:=Administration
   TITLE:=Fast and Lightweight Logs and Metrics processor
   URL:=https://fluentbit.io/
-  DEPENDS:= +libyaml +libopenssl +libcurl +libstdcpp +libatomic +musl-fts +flex +bison \
+  DEPENDS:= +libyaml +libopenssl +libcurl +libstdcpp +libatomic +USE_MUSL:musl-fts +flex +bison \
 	    +libsasl2
 endef
 

--- a/utils/nnn/Makefile
+++ b/utils/nnn/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nnn
 PKG_VERSION:=5.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/jarun/nnn/tar.gz/v$(PKG_VERSION)?
@@ -21,7 +21,7 @@ define Package/nnn
   CATEGORY:=Utilities
   TITLE:=Full-featured terminal file manager
   URL:=https://github.com/jarun/nnn
-  DEPENDS:=+libncurses +libreadline +musl-fts
+  DEPENDS:=+libncurses +libreadline +USE_MUSL:musl-fts
 endef
 
 define Package/nnn/description


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @BKPepe 

**Description:**
Two packages (`fluent-bit` and `nnn`) don't properly gate `musl-fts` as only required when using MUSL.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** HEAD
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** bananapi_bpi-r4-pro-8x

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md]
