### PR TITLE
uacme: make it explictly conflict with acme-acmesh

### DIFF
--- a/net/uacme/Makefile
+++ b/net/uacme/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=uacme
 PKG_VERSION:=1.8.1
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ndilieto/uacme/tar.gz/upstream/$(PKG_VERSION)?
@@ -48,6 +48,7 @@ define Package/uacme
   CATEGORY:=Network
   DEPENDS:=+libcurl +LIBCURL_WOLFSSL:libmbedtls +acme-common
   TITLE:=lightweight client for ACMEv2
+  CONFLICTS:=acme-acmesh
   Menu:=1
   PROVIDES:=@acme
 endef


### PR DESCRIPTION

Fixes: https://github.com/openwrt/packages/issues/29747

Signed-off-by: Seo Suchan <tjtncks@gmail.com>

## 📦 Package Details

**Maintainer:** @lucize 
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->
Because ACME clients share acme-common frontend provides /usr/lib/acme/hook so each clients cannot installed at same time. mark them as explictly conflict

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
 snapshot
- **OpenWrt Target/Subtarget:**
x86/x64
- **OpenWrt Device:**
kvm VM

---

## ✅ Formalities

- [ ] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
