### PR TITLE
[24.10] xfrpc: update to 5.06.909

### DIFF
--- a/net/xfrpc/Makefile
+++ b/net/xfrpc/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=xfrpc
-PKG_VERSION:=3.05.661
+PKG_VERSION:=5.06.909
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/liudf0716/xfrpc/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=202b5eb6d4ecee5444ac5a55fea462ad106ebfb88f51ca8499553db4f701f28f
+PKG_HASH:=7742bedbe929f5bfb386af2025de744aa38bc6f531e1f86a1fbb7318e3ec8f72
 PKG_BUILD_DIR:=$(BUILD_DIR)/xfrpc-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Dengfeng Liu <liudf0716@gmail.com>

--- a/net/xfrpc/files/xfrpc.init
+++ b/net/xfrpc/files/xfrpc.init
@@ -38,19 +38,38 @@ handle_tcp() {
 
 	uci_validate_section xfrpc tcp $section \
 		'enabled:bool:1' \
+		'service_type:string' \
 		'local_ip:host' \
 		'local_port:uinteger' \
-		'remote_port:uinteger' 
+		'remote_port:uinteger' \
+		'start_time:string' \
+		'end_time:string'
 	
 	# if enabled is 0, then return
 	[ $enabled = 0 ] && return
 
+	# Validate service_type if provided
+	if [ -n "$service_type" ]; then
+		case "$service_type" in
+			ssh|mstsc|rdp|vnc|telnet)
+				# Valid service type
+				;;
+			*)
+				echo "Error: Invalid service_type '$service_type'. Must be one of: ssh, mstsc, rdp, vnc, telnet"
+				return 1
+				;;
+		esac
+	fi
+
 	# Write the validated settings to the config file
 	echo "[${section}]" >> "$config"
 	echo "type = tcp" >> "$config"
+	[ -z "$service_type" ] || echo "service_type = $service_type" >> "$config"
 	[ -z "$local_ip" ] || echo "local_ip = $local_ip" >> "$config"
 	[ -z "$local_port" ] || echo "local_port = $local_port" >> "$config"
 	[ -z "$remote_port" ] || echo "remote_port = $remote_port" >> "$config"
+	[ -z "$start_time" ] || echo "start_time = $start_time" >> "$config"
+	[ -z "$end_time" ] || echo "end_time = $end_time" >> "$config"
 }
 
 handle_http() {
@@ -63,6 +82,8 @@ handle_http() {
 		'local_port:uinteger' \
 		'custom_domains:string' \
 		'subdomain:string' \
+		'start_time:string' \
+		'end_time:string'
 
 	# if enabled is 0, then return
 	[ $enabled = 0 ] && return
@@ -70,10 +91,13 @@ handle_http() {
 	# Write the validated settings to the config file
 	echo "[${section}]" >> "$config"
 	echo "type = http" >> "$config"
+	echo "service_type = http" >> "$config"
 	[ -z "$local_ip" ] || echo "local_ip = $local_ip" >> "$config"
 	[ -z "$local_port" ] || echo "local_port = $local_port" >> "$config"
 	[ -z "$custom_domains" ] || echo "custom_domains = $custom_domains" >> "$config"
 	[ -z "$subdomain" ] || echo "subdomain = $subdomain" >> "$config"
+	[ -z "$start_time" ] || echo "start_time = $start_time" >> "$config"
+	[ -z "$end_time" ] || echo "end_time = $end_time" >> "$config"
 }
 
 handle_https() {
@@ -85,7 +109,9 @@ handle_https() {
 		'local_ip:host' \
 		'local_port:uinteger' \
 		'custom_domains:string' \
-		'subdomain:string' 
+		'subdomain:string' \
+		'start_time:string' \
+		'end_time:string'
 	
 	# if enabled is 0, then return
 	[ $enabled = 0 ] && return
@@ -93,10 +119,13 @@ handle_https() {
 	# Write the validated settings to the config file
 	echo "[${section}]" >> "$config"
 	echo "type = https" >> "$config"
+	echo "service_type = https" >> "$config"
 	[ -z "$local_ip" ] || echo "local_ip = $local_ip" >> "$config"
 	[ -z "$local_port" ] || echo "local_port = $local_port" >> "$config"
 	[ -z "$custom_domains" ] || echo "custom_domains = $custom_domains" >> "$config"
 	[ -z "$subdomain" ] || echo "subdomain = $subdomain" >> "$config"
+	[ -z "$start_time" ] || echo "start_time = $start_time" >> "$config"
+	[ -z "$end_time" ] || echo "end_time = $end_time" >> "$config"
 }
 
 handle_socks5() {
@@ -105,7 +134,9 @@ handle_socks5() {
 
 	uci_validate_section xfrpc socks5 $section \
 		'enabled:bool:1' \
-		'remote_port:uinteger' 
+		'remote_port:uinteger' \
+		'start_time:string' \
+		'end_time:string'
 
 	# if enabled is 0, then return
 	[ $enabled = 0 ] && return
@@ -114,10 +145,32 @@ handle_socks5() {
 	echo "[${section}]" >> "$config"
 	echo "type = socks5" >> "$config"
 	[ -z "$remote_port" ] || echo "remote_port = $remote_port" >> "$config"
+	[ -z "$start_time" ] || echo "start_time = $start_time" >> "$config"
+	[ -z "$end_time" ] || echo "end_time = $end_time" >> "$config"
+}
+
+handle_iod() {
+	local section="$1"
+	local config="$2"
+
+	uci_validate_section xfrpc iod $section \
+		'enabled:bool:1' \
+		'local_port:uinteger' \
+		'remote_port:uinteger' 
+
+	# if enabled is 0, then return
+	[ $enabled = 0 ] && return
+
+	# Write the validated settings to the config file
+	echo "[${section}]" >> "$config"
+	echo "type = iod" >> "$config"
+	[ -z "$local_port" ] || echo "local_port = $local_port" >> "$config"
+	[ -z "$remote_port" ] || echo "remote_port = $remote_port" >> "$config"
 }
 
 service_triggers() {
 	procd_add_reload_trigger "$NAME"
+	procd_add_interface_trigger "interface.*.up" wan /etc/init.d/xfrpc restart
 }
 
 start_service() {
@@ -140,9 +193,10 @@ start_service() {
 	config_foreach handle_http http "$conf_file"
 	config_foreach handle_https https "$conf_file"
 	config_foreach handle_socks5 socks5 "$conf_file"
+	config_foreach handle_iod iod "$conf_file"
 
 	procd_open_instance
-	procd_set_param command "$PROG" -c "$conf_file" -f -d $loglevel
+	procd_set_param command "$PROG" -c "$conf_file" -s -f -d $loglevel
 	procd_set_param file "$conf_file"
 	procd_set_param respawn
 	procd_close_instance


### PR DESCRIPTION
## Summary
- Updated xfrpc from 3.05.661 to 5.06.909
- Switch from git clone to tarball download
- Add start_time/end_time scheduling support for tcp/http/https/socks5
- Add service_type validation for tcp (ssh/mstsc/rdp/vnc/telnet)
- Add iod proxy type support
- Add WAN up auto-restart trigger
- Add -s startup parameter

## Changes
| Item | Before | After |
|------|--------|-------|
| PKG_VERSION | 3.05.661 | 5.06.909 |
| Source | git clone | tarball download |
| Scheduling | not supported | start_time/end_time |
| iod proxy | not supported | supported |
| WAN restart | not supported | supported |

## Test
Built and tested on OpenWrt 24.10.