### PR TITLE
knot: update to version 3.5.5

### DIFF
--- a/net/knot/Makefile
+++ b/net/knot/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=knot
-PKG_VERSION:=3.5.4
-PKG_RELEASE:=2
+PKG_VERSION:=3.5.5
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://secure.nic.cz/files/knot-dns/
-PKG_HASH:=4a0bc892dfaa5a150ff2855f0a88f2267124bc271818eae9a2b1f6da487c34e4
+PKG_HASH:=38502c1472247c955aa3329bb5722e61ca765b833e3497d71f891ebf8e77fa04
 
 PKG_MAINTAINER:=Daniel Salzman <daniel.salzman@nic.cz>
 PKG_LICENSE:=GPL-2.0-or-later LGPL-2.0-or-later MIT ISC BSD-3-Clause


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @salzmdan

**Description:**
- Release notes: https://www.knot-dns.cz/2026-06-12-version-355.html

---

## 🧪 Run Testing Details

- **OpenWrt Version:** TurrisOS 9.1.0
- **OpenWrt Target/Subtarget:** mvebu/cortexa9
- **OpenWrt Device:** Turris Omnia
---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [x] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
