### PR TITLE
netavark: update to 1.17.2

### DIFF
--- a/net/netavark/Makefile
+++ b/net/netavark/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netavark
-PKG_VERSION:=1.12.2
+PKG_VERSION:=1.17.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/containers/netavark/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=d1e5a7e65b825724fd084b0162084d9b61db8cda1dad26de8a07be1bd6891dbc
+PKG_HASH:=284faa7cc525b869cbac4053e0a4127ac743ca7da1457c49fffb35558ea9c78d
 
 PKG_MAINTAINER:=Oskari Rauta <oskari.rauta@gmail.com>
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
This is a regular update with no disruptive changes.
changelog:https://github.com/containers/netavark/releases/tag/v1.17.2

## 📦 Package Details

**Maintainer:** Oskari Rauta <oskari.rauta@gmail.com>

**Description:** Update netavark to v1.17.2
note: the latest v2.0.0 is required for podman 6.0, so we don't need to update it now.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** OpenWrt 25.12-SNAPSHOT
- **OpenWrt Target/Subtarget:** X86-64
- **OpenWrt Device:** CncTion Tiger Lake-6L

---

## ✅ Formalities

- [ √ ] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
