### PR TITLE
slirp4netns: update to 1.3.4

### DIFF
--- a/net/slirp4netns/Makefile
+++ b/net/slirp4netns/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=slirp4netns
-PKG_VERSION:=1.3.1
+PKG_VERSION:=1.3.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/rootless-containers/slirp4netns/archive/v$(PKG_VERSION)
-PKG_HASH:=a3b7c7b593b279c46d25a48b583371ab762968e98b6a46457d8d52a755852eb9
+PKG_HASH:=c8e445deded09c5e777af3c599f808b3d0cbfeab482d9e76746df0926234200d
 
 PKG_MAINTAINER:=Oskari Rauta <oskari.rauta@gmail.com>
 PKG_LICENSE:=GPL-2.0-or-later


### PR DESCRIPTION
This is a regular update with no disruptive changes.
changelog:https://github.com/rootless-containers/slirp4netns/releases/tag/v1.3.4

## 📦 Package Details

**Maintainer:** Oskari Rauta <oskari.rauta@gmail.com>

**Description:** Update slirp4netns to the latest v1.3.4

---

## 🧪 Run Testing Details

- **OpenWrt Version:** OpenWrt 25.12-SNAPSHOT
- **OpenWrt Target/Subtarget:** X86-64
- **OpenWrt Device:** CncTion Tiger Lake-6L

---

## ✅ Formalities

- [ √ ] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
