### PR TITLE
travelmate: fix uplink teardown when a station has a bssid but no macaddr

### DIFF
--- a/net/travelmate/Makefile
+++ b/net/travelmate/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=travelmate
 PKG_VERSION:=2.4.5
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
 

--- a/net/travelmate/files/travelmate-functions.sh
+++ b/net/travelmate/files/travelmate-functions.sh
@@ -1067,21 +1067,11 @@ f_genstatus() {
 	if [ "${status}" = "true" ]; then
 		status="connected, ${trm_connection:-"-"}"
 		dev_status="$("${trm_ubuscmd}" -S call network.wireless status 2>/dev/null)"
-		parse="$(printf "%s" "${dev_status}" | "${trm_jsoncmd}" \
-			-e '@.*.interfaces[@.config.mode="sta"].section' \
-			-e '@.*.interfaces[@.config.mode="sta"].config.ssid' \
-			-e '@.*.interfaces[@.config.mode="sta"].config.macaddr' \
-			-e '@.*.interfaces[@.config.mode="sta"].config.network[0]' \
-			-e '@.*.interfaces[@.config.mode="sta"].config.bssid')"
-		{
-			IFS= read -r section
-			IFS= read -r sta_essid
-			IFS= read -r sta_mac
-			IFS= read -r sta_iface
-			IFS= read -r sta_bssid
-		} <<-EOF
-			${parse}
-		EOF
+		section="$(printf "%s" "${dev_status}" | "${trm_jsoncmd}" -ql1 -e '@.*.interfaces[@.config.mode="sta"].section')"
+		sta_essid="$(printf "%s" "${dev_status}" | "${trm_jsoncmd}" -ql1 -e '@.*.interfaces[@.config.mode="sta"].config.ssid')"
+		sta_mac="$(printf "%s" "${dev_status}" | "${trm_jsoncmd}" -ql1 -e '@.*.interfaces[@.config.mode="sta"].config.macaddr')"
+		sta_iface="$(printf "%s" "${dev_status}" | "${trm_jsoncmd}" -ql1 -e '@.*.interfaces[@.config.mode="sta"].config.network[0]')"
+		sta_bssid="$(printf "%s" "${dev_status}" | "${trm_jsoncmd}" -ql1 -e '@.*.interfaces[@.config.mode="sta"].config.bssid')"
 		if [ -n "${section}" ]; then
 			sta_radio="$(uci_get "wireless" "${section}" "device")"
 			f_getcfg "${sta_radio}" "${sta_essid}" "${sta_bssid}"


### PR DESCRIPTION
f_genstatus() parsed five station fields with a single multi-expression jsonfilter call and read them positionally. jsonfilter emits no line for an absent field, so an uplink configured with a 'bssid' but no 'macaddr' (a BSSID-pinned uplink) loses the macaddr line, shifting every following field up by one and leaving sta_bssid empty. f_getcfg() then cannot match the uplink's config, 'enabled' defaults to 0, and f_check() logs "uplink connection lost (interface gone)", tearing the working uplink down every trm_timeout seconds. Uplinks without a bssid are unaffected, which is why this only hit some setups.

Read each field with its own 'jsonfilter -ql1' call (matching how ifname is already read in f_check) so a missing field yields an empty value in its own slot instead of shifting the others.

Tested on GL-MT3000 / OpenWrt 25.12.4: a BSSID-pinned 2.4 GHz uplink now holds across reboots with zero teardowns; f_check reports enabled:1 and the correct sta_bssid.

## 📦 Package Details

Maintainer: @dibdot
(Dirk Brenken — that's the PKG_MAINTAINER in the Makefile.)

Description:

▎ Travelmate is a wireless uplink/hotspot connection manager. This fixes a station-status parsing bug in f_genstatus(): the five station fields are read positionally from one multi-expression jsonfilter call, but jsonfilter omits a line for any absent field — so a BSSID-pinned uplink (has bssid, no macaddr) shifts the reads, leaves sta_bssid empty, and Travelmate tears the working uplink down every trm_timeout ("interface gone"). Each field is now read independently.

🧪 Run Testing Details
- OpenWrt Version: 25.12.4
- OpenWrt Target/Subtarget: mediatek/filogic
- OpenWrt Device: GL.iNet GL-MT3000
---

## ✅ Formalities

- [✅] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [N/A] It can be applied using `git am`
- [N/A] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [N/A] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
