### PR TITLE
net-snmp: enable blumenthal-aes

### DIFF
--- a/net/net-snmp/Makefile
+++ b/net/net-snmp/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=net-snmp
 PKG_VERSION:=5.9.4
-PKG_RELEASE:=10
+PKG_RELEASE:=11
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/net-snmp
@@ -284,6 +284,7 @@ endif
 
 ifeq ($(BUILD_VARIANT),ssl)
 CONFIGURE_ARGS+= --with-openssl="$(STAGING_DIR)/usr"
+CONFIGURE_ARGS+= --enable-blumenthal-aes
 else
 CONFIGURE_ARGS+= --without-openssl
 endif


### PR DESCRIPTION


## 📦 Package Details

**Maintainer:** @stintel 
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**

In order to use AES-192 and the like, it is necessary to enable blumenthal-aes.
<!-- Briefly describe what this package does or what changes are introduced -->

---

## 🧪 Run Testing Details

- **OpenWrt Version:** openwrt-25.12
- **OpenWrt Target/Subtarget:** x86/64

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
