### PR TITLE
utils/hplip: fix CPE ID

### DIFF
--- a/utils/hplip/Makefile
+++ b/utils/hplip/Makefile
@@ -16,7 +16,7 @@ PKG_HASH:=a6af314a7af0572f2ab6967b2fe68760e64d74628ef0e6237f8504d81047edbe
 PKG_MAINTAINER:=Luiz Angelo Daros de Luca <luizluca@gmail.com>
 PKG_LICENSE:=GPL-2.0 GPL-2.0-or-later
 PKG_LICENSE_FILES:=COPYING LICENSE
-PKG_CPE_ID:=cpe:/a:hp:linux_imaging_and_printing_project
+PKG_CPE_ID:=cpe:/a:hp:linux_imaging_and_printing
 
 PKG_BUILD_PARALLEL:=1
 PKG_BUILD_DEPENDS:=libcups


### PR DESCRIPTION
hp:linux_imaging_and_printing is a better CPE ID than hp:linux_imaging_and_printing_project as this CPE ID has the latest CVE (whereas hp:linux_imaging_and_printing_project only has CVEs up to 2013):
https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:hp:linux_imaging_and_printing

Fixes: 5afe5c9031190844f267357c68efe3c9c3cbe51d (treewide: assign PKG_CPE_ID)

Maintainer: @neheb
Compile tested: Not needed
Run tested: Not needed