### PR TITLE
fish: fix postrm script interpreter

### DIFF
--- a/utils/fish/Makefile
+++ b/utils/fish/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fish
 PKG_VERSION:=4.7.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/fish-shell/fish-shell/releases/download/$(PKG_VERSION)
@@ -84,7 +84,8 @@ fi
 endef
 
 define Package/fish/postrm
-	rm -rf "$${IPKG_INSTROOT}/$(CONFIGURE_PREFIX)/share/fish/$(PKG_VERSION)"
+#!/bin/sh
+rm -rf "$${IPKG_INSTROOT}/$(CONFIGURE_PREFIX)/share/fish/$(PKG_VERSION)"
 endef
 
 $(eval $(call BuildPackage,fish))


### PR DESCRIPTION
Add the missing shell interpreter line to the fish `postrm` script so apk can
run the generated post-deinstall hook when fish is removed.

Without the shebang, apk:

```text
fish-4.1.2-r2.post-deinstall: execve: Exec format error
```

Fixes: #29348

## 📦 Package Details

**Maintainer:** Curtis Jiang @jqqqqqqqqqq

**Description:**
Fix the fish package removal hook by adding the missing `#!/bin/sh` line to
the generated `postrm` script.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12.4
- **OpenWrt Target/Subtarget:** bcm53xx/generic
- **OpenWrt Device:** asus rt ac68u

Tested with:

```sh
apk add fish
apk del fish
```

Before this change, `apk del fish` reported `execve: Exec format error` while
running the fish post-deinstall hook.

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] Not applicable, this PR does not add or modify an upstream source patch.