### PR TITLE
arp-scan: fix maintainer script interpreters

### DIFF
--- a/net/arp-scan/Makefile
+++ b/net/arp-scan/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=arp-scan
 PKG_VERSION:=1.10.0
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/royhills/arp-scan/tar.gz/$(PKG_VERSION)?
@@ -52,6 +52,7 @@ define Package/arp-scan/install
 endef
 
 define Package/arp-scan/postinst
+#!/bin/sh
 cat <<EOF
 
 Please install the arp-scan-database package in order to let arp-scan
@@ -80,8 +81,9 @@ define Package/arp-scan-database/install
 endef
 
 define Package/arp-scan-database/postrm
-	$(RM) -rf $(1)/usr/share/arp-scan
-	$(RM) -rf $(1)/etc/arp-scan
+#!/bin/sh
+rm -rf "$${IPKG_INSTROOT}/usr/share/arp-scan" \
+	"$${IPKG_INSTROOT}/etc/arp-scan"
 endef
 
 $(eval $(call BuildPackage,arp-scan-database))


### PR DESCRIPTION
Add missing shell interpreter lines to the `arp-scan` maintainer scripts so apk
can execute the generated install and removal hooks directly.

This fixes an apk removal error from `arp-scan-database`:

```text
arp-scan-database-1.10.0-r4.post-deinstall
* execve: Exec format error
ERROR: lib/apk/exec/arp-scan-database-1.10.0-r4.post-deinstall: exited with error 127
```

The database `postrm` cleanup now also uses `IPKG_INSTROOT`, and `PKG_RELEASE`
is bumped.

## 📦 Package Details

**Maintainer:** Sergey Urushkin <urusha.v1.0@gmail.com>

**Description:**
Fix apk maintainer-script execution for `arp-scan` and `arp-scan-database`.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12.2
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** libvirt VM

Tested with:

```sh
apk update
apk add arp-scan arp-scan-database
apk del arp-scan arp-scan-database
```

Before this change, removing `arp-scan-database` reported `execve: Exec format
error` while running the generated post-deinstall hook.

Also checked locally:

```sh
make package/feeds/packages/arp-scan/download V=s
make package/feeds/packages/arp-scan/check V=s
git diff --check
```

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] Not applicable, this PR does not add or modify an upstream source patch.
