### PR TITLE
ddns-scripts: add curl source IP bind fallback

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -7,8 +7,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
-PKG_VERSION:=2.8.3
-PKG_RELEASE:=8
+PKG_VERSION:=2.8.4
+PKG_RELEASE:=1
 
 PKG_LICENSE:=GPL-2.0
 

--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -933,7 +933,7 @@ endef
 
 define Package/ddns-scripts-one/prerm
 #!/bin/sh
-if [-z "${IPKG_INSTROOT}" ]; then
+if [ -z "$${IPKG_INSTROOT}" ]; then
 	/etc/init.d/ddns stop
 fi
 exit 0

--- a/net/ddns-scripts/files/usr/bin/ddns.sh
+++ b/net/ddns-scripts/files/usr/bin/ddns.sh
@@ -33,6 +33,13 @@ usage() {
 	exit "$code"
 }
 
+version() {
+	local version="unknown"
+
+	[ -f "${DDNS_PACKAGE_DIR}/version" ] && version="$(cat "${DDNS_PACKAGE_DIR}/version")"
+	printf '%s\n' "ddns-scripts ${version}"
+}
+
 action_update() {
 	local cacert
 
@@ -160,6 +167,9 @@ main() {
 	[ "$#" -eq 0 ] && usage "1"
 
 	case "${cmd}" in
+		-V|--version)
+			version
+			;;
 		service)
 			sub_service "${action}" "${service}"
 			;;

--- a/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_functions.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_functions.sh
@@ -617,6 +617,7 @@ do_transfer() {
 	local __ERR=0
 	local __CNT=0	# error counter
 	local __PROG  __RUNPROG
+	local __FALLBACK_RUNPROG __FALLBACK_DESC
 
 	[ $# -ne 1 ] && write_log 12 "Error in 'do_transfer()' - wrong number of parameters"
 
@@ -674,11 +675,17 @@ do_transfer() {
 			write_log 13 "cURL: libcurl compiled without https support"
 		# force network/interface-device to use for communication
 		if [ -n "$bind_network" ]; then
-			local __DEVICE
+			local __DEVICE __BINDIP __BIND_OPT __FALLBACK_BIND_OPT
 			network_get_device __DEVICE $bind_network || \
 				write_log 13 "Can not detect local device using 'network_get_device $bind_network' - Error: '$?'"
+			# set correct program to detect IP
+			[ $use_ipv6 -eq 0 ] && __RUNPROG="network_get_ipaddr" || __RUNPROG="network_get_ipaddr6"
+			eval "$__RUNPROG __BINDIP $bind_network" || \
+				write_log 13 "Can not detect current IP using '$__RUNPROG $bind_network' - Error: '$?'"
 			write_log 7 "Force communication via device '$__DEVICE'"
-			__PROG="$__PROG --interface $__DEVICE"
+			__BIND_OPT=" --interface $__DEVICE"
+			__FALLBACK_BIND_OPT=" --interface $__BINDIP"
+			__FALLBACK_DESC="IP '$__BINDIP'"
 		fi
 		# force ip version to use
 		if [ $force_ipversion -eq 1 ]; then
@@ -705,7 +712,9 @@ do_transfer() {
 			write_log 13 "cURL: libcurl compiled without Proxy support"
 		fi
 
-		__RUNPROG="$__PROG '$__URL'"	# build final command
+		__RUNPROG="$__PROG$__BIND_OPT '$__URL'"	# build final command
+		[ -n "$__FALLBACK_BIND_OPT" ] && \
+			__FALLBACK_RUNPROG="$__PROG$__FALLBACK_BIND_OPT '$__URL'"
 		__PROG="cURL"			# reuse for error logging
 
 	# uclient-fetch possibly with ssl support if /lib/libustream-ssl.so installed
@@ -765,6 +774,14 @@ do_transfer() {
 		eval $__RUNPROG			# DO transfer
 		__ERR=$?			# save error code
 		[ $__ERR -eq 0 ] && return 0	# no error leave
+		if [ -n "$__FALLBACK_RUNPROG" ]; then
+			write_log 3 "$__PROG Error: '$__ERR'"
+			write_log 7 "$(cat $ERRFILE)"		# report error
+			write_log 4 "Transfer failed - retry using $__FALLBACK_DESC"
+			__RUNPROG="$__FALLBACK_RUNPROG"
+			__FALLBACK_RUNPROG=""
+			continue
+		fi
 		[ -n "$LUCI_HELPER" ] && return 1	# no retry if called by LuCI helper script
 
 		write_log 3 "$__PROG Error: '$__ERR'"

--- a/net/ddns-scripts/samples/ddns.config_sample
+++ b/net/ddns-scripts/samples/ddns.config_sample
@@ -269,10 +269,13 @@ config service "myddns"
 	# In some very special configurations i.e. Multi WAN environment
 	# in a NAT cascade it might be necessary to define
 	# a network to use for communication.
+	# If bind_network is not set and ip_source is "network",
+	# ip_network is used as the default bind network.
 	# should use option ip_source "web" (see above)
 	# Needs GNU Wget (with SSL support) or cURL to be installed.
-	# GNU Wget will use IP address and cURL the physical device
-	# of the given network
+	# GNU Wget will use IP address and cURL the logical device
+	# of the given network. cURL retries once with the IP address
+	# when the device-bound transfer fails.
 	# default: none
 #	option bind_network "wan7"
 


### PR DESCRIPTION
This fixes a long-standing failure mode in the cURL transfer path when `bind_network` is active.

`ddns-scripts` has defaulted `bind_network` from `ip_source=network` since 2020, and cURL has bound that network by logical device since the PPPoE fix in 2021. That device binding is still the right first choice because it preserves the existing PPPoE and multi-WAN behavior.

However, on some PPPoE setups libcurl can fail when bound to the logical PPP device while the same request succeeds when bound to the source address of that same network. In the observed case, `curl --interface pppoe-wan` to the HE.net update endpoint timed out with the TCP connection stuck in `SYN_SENT`, while `curl --interface <wan-ip>` succeeded immediately.

This PR keeps the current behavior as the primary path and only retries once with the network source IP when the device-bound cURL transfer fails. That keeps existing users on the original code path unless it fails, preserves the selected network for multi-WAN setups, and makes cURL consistent with the existing GNU Wget path, which already binds to the network IP address.

The sample configuration is also updated to document the implicit `bind_network` default and the cURL fallback behavior.

Tested:
- `bash -n net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_functions.sh`
- `git diff --check HEAD~1..HEAD`
- Runtime checked on a PPPoE WAN setup where device-bound cURL failed and source-IP-bound cURL succeeded against `dyn.dns.he.net`.