### PR TITLE
libreswan: fix default subnet matching

### DIFF
--- a/net/libreswan/Makefile
+++ b/net/libreswan/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libreswan
 PKG_VERSION:=4.12
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://download.libreswan.org/

--- a/net/libreswan/files/etc/init.d/ipsec
+++ b/net/libreswan/files/etc/init.d/ipsec
@@ -78,6 +78,14 @@ expand_phase2alg() {
 	phase2alg_proposal="${encryption_algorithm:+${encryption_algorithm// /+}${hash_algorithm:+-${hash_algorithm// /+}${dh_group:+-${dh_group// /+}}}}"
 }
 
+append_subnet() {
+	local subnet="$1"
+	local var="$2"
+
+	[ "$subnet" = "0.0.0.0" ] && subnet="0.0.0.0/0"
+	append "$var" "$subnet" ","
+}
+
 generate_tunnel_config() {
 	local id=$1
 	local config_file="$IPSEC_CONF_DIR/$id.conf"
@@ -95,8 +103,6 @@ generate_tunnel_config() {
 	config_get rightid "$id" rightid "$right"
 	config_get leftsourceip "$id" leftsourceip
 	config_get rightsourceip "$id" rightsourceip
-	config_get leftsubnets "$id" leftsubnets
-	config_get rightsubnets "$id" rightsubnets
 	config_get_bool ikev2 "$id" ikev2
 	[ "$ikev2" = "1" ] && ikev2=yes || ikev2=no
 	config_get_bool rekey "$id" rekey
@@ -111,20 +117,22 @@ generate_tunnel_config() {
 	config_get nflog "$id" nflog 0
 	[ "$nflog" = "0" ] && unset nflog
 
+	leftsubnets=""
+	rightsubnets=""
 	config_list_foreach "$id" ike expand_ike
 	config_list_foreach "$id" phase2alg expand_phase2alg
+	config_list_foreach "$id" leftsubnets append_subnet leftsubnets
+	config_list_foreach "$id" rightsubnets append_subnet rightsubnets
 
 	config_get authby "$id" authby
 	config_get psk "$id" psk
 
 	if [ -n "$leftsubnets" ]; then
-		[[ "$leftsubnets" =~ 0.0.0.0* ]] && leftsubnets="0.0.0.0/0"
-		leftsubnets="{${leftsubnets// /,}}"
+		leftsubnets="{${leftsubnets}}"
 	fi
 
 	if [ -n "$rightsubnets" ]; then
-		[[ "$rightsubnets" =~ 0.0.0.0* ]] && rightsubnets="0.0.0.0/0"
-		rightsubnets="{${rightsubnets// /,}}"
+		rightsubnets="{${rightsubnets}}"
 	fi
 
 	config_get interface "$id" interface


### PR DESCRIPTION
Match only explicit default-route subnet tokens when normalizing `leftsubnets`
and `rightsubnets`.

The previous regex treated dots as wildcards, so values such as
`10.250.0.0/16` and `10.0.0.0/8` could be rewritten to `0.0.0.0/0`.

Fixes: https://github.com/openwrt/openwrt/issues/23795

## 📦 Package Details

**Maintainer:** Lucian Cristian <lucian.cristian@gmail.com> (@lucize)

**Description:**
Fix the libreswan UCI init script so it only normalizes an explicit default
route subnet token, `0.0.0.0` or `0.0.0.0/0`, instead of matching unrelated
private subnets that happen to contain `0.0.0.0` in the string.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12.2
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** libvirt OpenWrt VM

Reproduced the issue on the VM with a temporary `/etc/config/libreswan` tunnel
containing:

```uci
list leftsubnets '10.250.0.0/16'
list rightsubnets '10.0.0.0/8'
```

Before this change, `/etc/init.d/ipsec start` generated:

```text
leftsubnets={0.0.0.0/0}
rightsubnets={0.0.0.0/0}
```

Also tested the new subnet matching helper in the VM shell:

```text
FIX_NO:10.250.0.0/16
FIX_NO:10.0.0.0/8
FIX_NO:192.168.0.0/16
FIX_MATCH:0.0.0.0/0
FIX_MATCH:0.0.0.0
FIX_MATCH:10.0.0.0/8 0.0.0.0/0
```

Local checks:

```sh
git diff --check
sh -n feeds/packages/net/libreswan/files/etc/init.d/ipsec
make package/feeds/packages/libreswan/download V=s
make package/feeds/packages/libreswan/check V=s
```

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] Not applicable, this PR does not add or modify an upstream source patch.
