### PR TITLE
cgi-io: add generic version check override

### DIFF
--- a/net/cgi-io/test-version.sh
+++ b/net/cgi-io/test-version.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
+# shellcheck shell=busybox
+
+case "$PKG_NAME" in
+cgi-io)
+	exit 0
+	;;
+
+*)
+	echo "Untested package: $PKG_NAME" >&2
+	exit 1
+	;;
+esac


### PR DESCRIPTION
The binary included in this package does not output anything, causing the generic version check in CI to fail. Override the test.

I've removed all the noise from the PR template since it's not relevant. This works around an unrelated CI failure in #29784.