### PR TITLE
haproxy: update to v3.4.1

### DIFF
--- a/net/haproxy/Makefile
+++ b/net/haproxy/Makefile
@@ -10,12 +10,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=haproxy
-PKG_VERSION:=3.2.15
+PKG_VERSION:=3.4.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://www.haproxy.org/download/3.2/src
-PKG_HASH:=117e408aff544c9ad758c2fb3fd8cf791a72609d3ae319b2cf9f2a0b035393c2
+PKG_SOURCE_URL:=https://www.haproxy.org/download/3.4/src
+PKG_HASH:=2e62c4ce4fd77d3bc7cf17e586431663454456a078b7c8465b8f0125b5bc22f8
 
 PKG_MAINTAINER:=Thomas Heil <heil@terminal-consulting.de>, \
 		Christian Lachner <gladiac@gmail.com>
@@ -91,7 +91,7 @@ define Build/Compile
 		VERSION="$(PKG_VERSION)" SUBVERS="-$(PKG_RELEASE)" \
 		VERDATE="$(shell date -d @$(SOURCE_DATE_EPOCH) '+%Y/%m/%d')" IGNOREGIT=1 \
 		$(ADDON) \
-		CFLAGS="$(TARGET_CFLAGS) -fno-strict-aliasing -Wdeclaration-after-statement -Wno-unused-label -Wno-sign-compare -Wno-unused-parameter -Wno-clobbered -Wno-missing-field-initializers -Wno-cast-function-type -Wno-address-of-packed-member -Wtype-limits -Wshift-negative-value -Wshift-overflow=2 -Wduplicated-cond -Wnull-dereference -fwrapv -fasynchronous-unwind-tables -Wno-null-dereference" \
+		CFLAGS="$(filter-out -ffile-prefix-map=% -fmacro-prefix-map=%,$(TARGET_CFLAGS)) -fno-strict-aliasing -Wdeclaration-after-statement -Wno-unused-label -Wno-sign-compare -Wno-unused-parameter -Wno-clobbered -Wno-missing-field-initializers -Wno-cast-function-type -Wno-address-of-packed-member -Wtype-limits -Wshift-negative-value -Wshift-overflow=2 -Wduplicated-cond -Wnull-dereference -fwrapv -fasynchronous-unwind-tables -Wno-null-dereference" \
 		LD="$(TARGET_CC)" \
 		LDFLAGS="$(TARGET_LDFLAGS)"
 
@@ -105,7 +105,7 @@ define Build/Compile
 	$(MAKE_VARS) $(MAKE) -C $(PKG_BUILD_DIR) \
 		DESTDIR="$(PKG_INSTALL_DIR)" \
 		CC="$(TARGET_CC)" \
-		CFLAGS="$(TARGET_CFLAGS) -Wno-address-of-packed-member" \
+		CFLAGS="$(TARGET_CFLAGS) -Wno-address-of-packed-member -DHALOG_VERSION='$(PKG_VERSION)-$(PKG_RELEASE)'" \
 		LDFLAGS="$(TARGET_LDFLAGS)" \
 		admin/halog/halog
 endef

--- a/net/haproxy/patches/0001-add-halog-version.patch
+++ b/net/haproxy/patches/0001-add-halog-version.patch
@@ -1,0 +1,36 @@
+--- a/admin/halog/halog.c
++++ b/admin/halog/halog.c
+@@ -44,6 +44,15 @@
+ #define SEP(c) ((unsigned char)(c) <= ' ')
+ #define SKIP_CHAR(p,c) do { while (1) { int __c = (unsigned char)*p++; if (__c == c) break; if (__c <= ' ') { p--; break; } } } while (0)
+ 
++#define STR2(x) #x
++#define STR(x) STR2(x)
++
++#ifdef HALOG_VERSION
++#define HALOG_BUILD_INFO "halog - HAProxy log statistics reporter (" STR(HALOG_VERSION) ")\n"
++#else
++#define HALOG_BUILD_INFO "halog - HAProxy log statistics reporter\n"
++#endif
++
+ /* [0] = err/date, [1] = req, [2] = conn, [3] = resp, [4] = data */
+ static struct eb_root timers[5] = {
+ 	EB_ROOT_UNIQUE, EB_ROOT_UNIQUE, EB_ROOT_UNIQUE,
+@@ -165,6 +174,7 @@ void usage(FILE *output, const char *msg
+ {
+ 	fprintf(output,
+ 		"%s"
++		"%s"
+ 		"Usage:\n"
+ 		"  halog [-h|--help] for long help\n"
+ 		"  halog [input_filters]* [modifiers]* [output_format] < log\n"
+@@ -174,7 +184,8 @@ void usage(FILE *output, const char *msg
+ 		"    out = {-c|-u|-uc|-ue|-ua|-ut|-uao|-uto|-uba|-ubt|-hdr <block>:<field>|\n"
+ 		"           -cc|-gt|-pct|-st|-tc|-srv|-ic}\n"
+ 		"\n",
+-		msg ? msg : ""
++		msg ? msg : "",
++		HALOG_BUILD_INFO
+ 		);
+ }
+ 


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @gladiac

**Description:**
- New major LTS version. See https://www.haproxy.com/blog/announcing-haproxy-3-4
- Updated haproxy PKG_VERSION and PKG_HASH
- Added patch to insert version information into halog. This is to make the ci/cd happy.
- See changes: http://git.haproxy.org/?p=haproxy-3.4.git;a=shortlog

---

## 🧪 Run Testing Details

- **OpenWrt Version:** Master
- **OpenWrt Target/Subtarget:** Mediatek MT798x
- **OpenWrt Device:** GL.iNet GL-MT6000

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.