### PR TITLE
bsbf-bonding: fix final wan interface check and delete wan quietly

### DIFF
--- a/net/bsbf-resources/Makefile
+++ b/net/bsbf-resources/Makefile
@@ -4,7 +4,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bsbf-resources
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_LICENSE:=AGPL-3.0-or-later
 PKG_MAINTAINER:=Chester A. Unal <chester.a.unal@arinc9.com>

--- a/net/bsbf-resources/files/etc/uci-defaults/99-bsbf-bonding
+++ b/net/bsbf-resources/files/etc/uci-defaults/99-bsbf-bonding
@@ -45,10 +45,10 @@ fi
 final_wan_interfaces="$wan_network_interface $(echo $lan_interfaces | tr ' ' '\n' | grep -v "^$lan_network_interface$")"
 
 # Exit if there are no suitable wan interfaces.
-[ -z "$(echo "$final_wan_interfaces" | tr ' ' '\n')" ] && uci revert network ; exit 0
+[ -z "$(echo $final_wan_interfaces)" ] && { uci revert network ; exit 0; }
 
 # Delete existing wan and wan6 networks.
-uci delete network.wan
+uci -q delete network.wan
 uci -q delete network.wan6
 uci -q del_list firewall.$fw_section.network='wan'
 uci -q del_list firewall.$fw_section.network='wan6'


### PR DESCRIPTION
## 🧪 Run Testing Details

- **OpenWrt Version: 7b8ce1e095**
- **OpenWrt Target/Subtarget: mvebu/cortexa9**
- **OpenWrt Device: linksys_wrt32x**