### PR TITLE
Etherwake: simplify the init script and better document its configuration

### DIFF
--- a/net/etherwake/Makefile
+++ b/net/etherwake/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=etherwake
 PKG_VERSION:=1.09
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE:=$(PKG_NAME)_$(PKG_VERSION).orig.tar.gz
 PKG_SOURCE_URL:=https://ftp.debian.org/debian/pool/main/e/etherwake

--- a/net/etherwake/files/etherwake.config
+++ b/net/etherwake/files/etherwake.config
@@ -1,6 +1,4 @@
 config 'etherwake' 'setup'
-	# possible program paths
-	option 'pathes' '/usr/bin/etherwake /usr/bin/ether-wake'
 	# interface, defaults to 'eth0'
 	# -i <ifname>
 	option 'interface' ''

--- a/net/etherwake/files/etherwake.config
+++ b/net/etherwake/files/etherwake.config
@@ -1,8 +1,6 @@
 config 'etherwake' 'setup'
 	# possible program paths
 	option 'pathes' '/usr/bin/etherwake /usr/bin/ether-wake'
-	# use sudo, defaults to off
-	option 'sudo' 'off'
 	# interface, defaults to 'eth0'
 	# -i <ifname>
 	option 'interface' ''

--- a/net/etherwake/files/etherwake.config
+++ b/net/etherwake/files/etherwake.config
@@ -1,24 +1,17 @@
 config 'etherwake' 'setup'
-	# interface, defaults to 'eth0'
-	# -i <ifname>
-	option 'interface' ''
+	# interface to use, defaults to 'eth0'
+	#option 'interface' 'eth0'
 	# send wake-up packet to the broadcast address, defaults to off
-	# -b
-	option 'broadcast' 'off'
+	#option 'broadcast' 'off'
 
 config 'target'
 	# name for the target
-	option 'name' 'example'
-	# mac address to wake up
-	option 'mac' '11:22:33:44:55:66'
-	# secureOn password in ethernet hex format
-	option 'secureon' 'AA:BB:CC:DD:EE:FF'
+	#option 'name' 'example'
+	# mac address of the machine to wake up
+	#option 'mac' '00:11:22:33:44:55'
+	# (optional) 6-byte secureOn password in ethernet hex format
+	#option 'secureon' 'aa:bb:cc:dd:ee:ff'
+	# (optional) 4-byte secureOn password in dotted decimal format
+	#option 'secureon' '170.187.204.221'
 	# wake up on system start, defaults to off
-	option 'wakeonboot' 'off'
-
-# To add a new target use:
-#  uci add etherwake target
-#  uci set etherwake.@target[-1].name=example
-#  uci set etherwake.@target[-1].mac=11:22:33:44:55:66
-#  uci set etherwake.@target[-1].password=AABBCCDDEEFF
-#  uci set etherwake.@target[-1].wakeonboot=off
+	#option 'wakeonboot' 'off'

--- a/net/etherwake/files/etherwake.config
+++ b/net/etherwake/files/etherwake.config
@@ -11,8 +11,8 @@ config 'target'
 	option 'name' 'example'
 	# mac address to wake up
 	option 'mac' '11:22:33:44:55:66'
-	# password in hex without any delimiters
-	option 'password' 'AABBCCDDEEFF'
+	# secureOn password in ethernet hex format
+	option 'secureon' 'AA:BB:CC:DD:EE:FF'
 	# wake up on system start, defaults to off
 	option 'wakeonboot' 'off'
 

--- a/net/etherwake/files/etherwake.init
+++ b/net/etherwake/files/etherwake.init
@@ -12,8 +12,8 @@ start()
 	config_load "${NAME}"
 
 	# interface
-	config_get value 'setup' 'interface'
-	[ -n "${value}" ] && append PROGRAM "-i ${value}"
+	config_get value 'setup' 'interface' 'eth0'
+	append PROGRAM "-i ${value}"
 
 	# broadcast
 	config_get_bool value 'setup' 'broadcast' '0'

--- a/net/etherwake/files/etherwake.init
+++ b/net/etherwake/files/etherwake.init
@@ -21,10 +21,6 @@ start()
 		exit 1
 	}
 
-	# sudo
-	config_get_bool value 'setup' 'sudo' '0'
-	[ "${value}" -ne 0 ] && PROGRAM="sudo ${PROGRAM}"
-
 	# interface
 	config_get value 'setup' 'interface'
 	[ -n "${value}" ] && append PROGRAM "-i ${value}"

--- a/net/etherwake/files/etherwake.init
+++ b/net/etherwake/files/etherwake.init
@@ -3,23 +3,13 @@
 
 NAME='etherwake'
 START=60
-PROGRAM=''
+PROGRAM='/usr/bin/etherwake'
 
 start()
 {
-	local searchlist=''
-	local section=''
 	local value=''
 
 	config_load "${NAME}"
-
-	# check for available program
-	config_get searchlist 'setup' 'pathes'
-	PROGRAM=$(search_program "${searchlist}")
-	[ -z "${PROGRAM}" ] && {
-		echo "${initscript}: No ${NAME} program installed. Check: opkg list | grep ${NAME}"
-		exit 1
-	}
 
 	# interface
 	config_get value 'setup' 'interface'
@@ -98,25 +88,6 @@ do_etherwake()
 	return $?
 }
 
-
-# find first available program from searchlist
-search_program()
-{
-	local searchlist="$1"
-	local test=''
-	local program=''
-
-	for test in ${searchlist} ; do
-		[ -x "${test}" ] && {
-			program="${test}"
-			break;
-		}
-	done
-
-	[ -n "${program}" ] && echo "${program}"
-
-	return
-}
 
 # prepare hex password
 etherwake_password()

--- a/net/etherwake/files/etherwake.init
+++ b/net/etherwake/files/etherwake.init
@@ -65,6 +65,7 @@ do_etherwake()
 	local value=''
 	local password=''
 	local args=''
+	local section_name=''
 
 	# password (legacy option)
 	config_get value "${section}" 'password'
@@ -80,17 +81,18 @@ do_etherwake()
 		append args "-p ${password}"
 	fi
 
+	# name
+	config_get section_name "${section}" 'name'
+	[ -z "${section_name}" ] && section_name="${section}"
+
 	# mac address
 	config_get value "${section}" 'mac'
-	[ -z "${value}" ] && { echo "${initscript}: Target ${section} has no MAC address"; return 1; }
+	[ -z "${value}" ] && {
+		echo "Target '${section_name}' has no 'mac' address"; return 1; }
 	append args "${value}"
 
-	# name
-	config_get value "${section}" 'name'
-	[ -z "${value}" ] && value="{section}"
-
 	# execute command
-	echo "${initscript}: Waking up ${value} via ${PROGRAM}${args:+ ${args}}"
+	echo "Waking up '${section_name}' via ${PROGRAM}${args:+ ${args}}"
 	${PROGRAM} ${args}
 	return $?
 }

--- a/net/etherwake/files/etherwake.init
+++ b/net/etherwake/files/etherwake.init
@@ -66,12 +66,19 @@ do_etherwake()
 	local password=''
 	local args=''
 
-	# password
+	# password (legacy option)
 	config_get value "${section}" 'password'
 	[ -n "${value}" ] && {
 		password=$(etherwake_password "${value}")
-		append args "-p ${password}"
 	}
+
+	# secureOn password
+	config_get value "${section}" 'secureon'
+	if [ -n "${value}" ]; then
+		append args "-p ${value}"
+	elif [ -n "${password}" ]; then
+		append args "-p ${password}"
+	fi
 
 	# mac address
 	config_get value "${section}" 'mac'
@@ -89,7 +96,7 @@ do_etherwake()
 }
 
 
-# prepare hex password
+# prepare hex password (support legacy option)
 etherwake_password()
 {
 	local delimiter=':'


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** Peter Wagner (@tripolar)

**Description:**
The Etherwake package offers Wake-on-LAN functionality. This change simplifies the init script logic and improves documentation in the example configuration file.

Specifically:
1. Removes the use of `sudo` by the init script and the relevant configuration option. OpenWrt defaults to using root to run init scripts so there is no need to elevate privileges. A non-privileged user that wants to invoke the init script can do `sudo /etc/init.d/etherwake` instead. _This change could be breaking but unlikely given the lack of sudo in releases by default._

2. Removes the use of the `pathes` option by the init script to locate the `etherwake` binary at runtime. The Makefile installs the binary at `/usr/bin/etherwake` so the location is fixed and known ahead of time. If the user wants to use a different location they can edit the `PROGRAM` variable inside the init script. _This change is unlikely to be breaking._

3. Simplifies how the init script handles WOL SecureOn passwords. Currently the script expects the `password` option to be in hex format but without colon delimiters and then adds the colon delimiters itself before passing the value to the binary. This seems unnecessary. Also, the script's logic doesn't support 4-byte passwords that must be in a different format that's using dots not colons. This change introduces a new `secureon` option which the script simply passes to the underlying binary. This way we eliminate the handling logic from the script and support both 6-byte and 4-byte passwords. The `password` option is still honored by the script but removed from the example configuration. If both options are configured then the new option takes effect. _This change is unlikely to be breaking._

4. Adds clarity and detail to the example configuration.
    1. Makes sure the default `interface` value promised in the configuration is enforced by the init script, not the underlying binary.
    2. Removes unnecessary content from the documentation. E.g., how each option translates to a specific command-line argument for the underlying binary.
    3. Rephrases comments to improve clarity.

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

Tested multiple combinations of new and old options locally. Did not notice any regressions in functionality.

Read through the code of [luci-app-wol](https://github.com/openwrt/luci/tree/master/applications/luci-app-wol) and confirmed this change is compatible with that package.

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] Not applicable, this PR does not add or modify an upstream source patch.

---

P.S.: After this change gets merged the relevant [Wiki page](https://openwrt.org/docs/guide-user/services/w_o_l/etherwake) should be updated.