### PR TITLE
mwan3: prefer default route source address

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
-PKG_VERSION:=2.12.1
+PKG_VERSION:=2.12.2
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>

--- a/net/mwan3/files/lib/mwan3/common.sh
+++ b/net/mwan3/files/lib/mwan3/common.sh
@@ -54,7 +54,7 @@ mwan3_get_true_iface()
 
 mwan3_get_src_ip()
 {
-	local family _src_ip interface true_iface device addr_cmd default_ip IP sed_str
+	local family _src_ip interface true_iface device addr_cmd default_ip IP sed_str route_target
 	interface=$2
 	mwan3_get_true_iface true_iface $interface
 
@@ -64,15 +64,19 @@ mwan3_get_src_ip()
 		addr_cmd='network_get_ipaddr'
 		default_ip="0.0.0.0"
 		sed_str='s/ *inet \([^ \/]*\).*/\1/;T;p;q'
+		route_target="0.0.0.0"
 		IP="$IP4"
 	elif [ "$family" = "ipv6" ]; then
 		addr_cmd='network_get_ipaddr6'
 		default_ip="::"
 		sed_str='s/ *inet6 \([^ \/]*\).* scope.*/\1/;T;p;q'
+		route_target="::"
 		IP="$IP6"
 	fi
 
-	$addr_cmd _src_ip "$true_iface"
+	__network_ifstatus _src_ip "$true_iface" ".route[@.target='$route_target' && !@.table].source" "" 1
+	[ -n "$_src_ip" ] && _src_ip="${_src_ip%%/*}"
+	[ -z "$_src_ip" ] && $addr_cmd _src_ip "$true_iface"
 	if [ -z "$_src_ip" ]; then
 		if [ "$family" = "ipv6" ]; then
 			# on IPv6-PD interfaces (like PPPoE interfaces) we don't


### PR DESCRIPTION
Prefer the `src` address from the interface default route before falling back
to the interface address from netifd.

This fixes the diagnostics/tracking case where an interface has one address,
but the default route explicitly selects a different source address.

Fixes: #29055

## Package Details

**Maintainer:** @feckert

**Description:**
Fix `mwan3_get_src_ip()` so it uses the default route's preferred source
address when one is present.

---

## Run Testing Details

- **OpenWrt Version:** 25.12.2
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** libvirt OpenWrt VM

Tested the source address selection on an OpenWrt VM with mocked route and
netifd values.

With a default route containing `src 203.0.113.50`, `mwan3_get_src_ip()` now
returns:

```text
route_src_case=203.0.113.50
```

When the default route does not contain `src`, it still falls back to the
interface address:

```text
fallback_case=100.64.1.2
```

Local checks:

```sh
busybox ash -n feeds/packages/net/mwan3/files/lib/mwan3/common.sh
git -C feeds/packages diff --check
make package/feeds/packages/mwan3/check V=s
```

---

## Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] Not applicable, this PR does not add or modify an upstream source patch.
