### PR TITLE
net-snmp: fix 'bad number' warning when engineidtype is unset

### DIFF
--- a/net/net-snmp/files/snmpd.init
+++ b/net/net-snmp/files/snmpd.init
@@ -240,7 +240,7 @@ snmpd_engineid_add() {
 	config_get engineid "$cfg" engineid
 	[ -n "$engineid" ] && echo "engineID $engineid" >> $CONFIGFILE
 	config_get engineidtype "$cfg" engineidtype
-	[ "$engineidtype" -ge 1 -a "$engineidtype" -le 3 ] && \
+	[ -n "$engineidtype" ] && [ "$engineidtype" -ge 1 -a "$engineidtype" -le 3 ] && \
 		echo "engineIDType $engineidtype" >> $CONFIGFILE
 	config_get engineidnic "$cfg" engineidnic
 	[ -n "$engineidnic" ] && echo "engineIDNic $engineidnic" >> $CONFIGFILE


### PR DESCRIPTION
Add a `-n` guard before the arithmetic comparison of `engineidtype` in
`snmpd_engineid_add()`. When the `engineid` UCI section exists but
`engineidtype` is not configured, the empty string is passed to
`[ -ge ]`/`[ -le ]` which causes `sh: bad number` on every boot.

Tested on busybox ash (OpenWrt 25.x).