### PR TITLE
smartdns: bump to 48.1

### DIFF
--- a/net/smartdns/Makefile
+++ b/net/smartdns/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=smartdns
-PKG_VERSION:=46.1
+PKG_VERSION:=48.1
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-Release$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://codeload.github.com/pymumu/smartdns/tar.gz/refs/tags/Release$(PKG_VERSION)?
-PKG_HASH:=6307503fa409b9c6b87556d1b1f8eaf99c7be5b06a9d479ec3589c875391a6b3
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/pymumu/smartdns/tar.gz/Release$(PKG_VERSION)?
+PKG_HASH:=fbc9e8de5e3bd6cd2d7e3823321d5caed22b7c704ae66ed7274f8012246cb285
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-Release$(PKG_VERSION)
 
 PKG_MAINTAINER:=Nick Peng <pymumu@gmail.com>
@@ -19,26 +19,47 @@ PKG_LICENSE:=GPL-3.0-or-later
 PKG_LICENSE_FILES:=LICENSE
 PKG_CPE_ID:=cpe:/a:pymumu:smartdns
 
+PKG_CONFIG_DEPENDS:=CONFIG_PACKAGE_smartdns-ui
+PKG_BUILD_DEPENDS:=PACKAGE_smartdns-ui:node/host PACKAGE_smartdns-ui:rust-bindgen/host
 PKG_BUILD_PARALLEL:=1
 
+RUST_PKG_FEATURES:=build-release
+RUST_PKG_LOCKED:=0
+
 include $(INCLUDE_DIR)/package.mk
+include ../../lang/rust/rust-package.mk
 
-MAKE_VARS += VER=$(PKG_VERSION) 
 MAKE_PATH:=src
+MAKE_VARS+= VER=$(PKG_VERSION)
 
-define Package/smartdns
+define Package/smartdns/Default
   SECTION:=net
   CATEGORY:=Network
-  TITLE:=smartdns server
   SUBMENU:=IP Addresses and Names
-  DEPENDS:=+libpthread +libopenssl
+  TITLE:=smartdns
   URL:=https://www.github.com/pymumu/smartdns/
+endef
+
+define Package/smartdns
+  $(call Package/smartdns/Default)
+  TITLE+= server
+  DEPENDS:=+i386:libatomic +libopenssl
 endef
 
 define Package/smartdns/description
 SmartDNS is a local DNS server which accepts DNS query requests from local network clients,
 gets DNS query results from multiple upstream DNS servers concurrently, and returns the fastest IP to clients.
-Unlike dnsmasq's all-servers, smartdns returns the fastest IP, and encrypt DNS queries with DoT or DoH. 
+Unlike dnsmasq's all-servers, smartdns returns the fastest IP, and encrypt DNS queries with DoT or DoH.
+endef
+
+define Package/smartdns-ui
+  $(call Package/smartdns/Default)
+  TITLE+= dashboard
+  DEPENDS:=+smartdns $(RUST_ARCH_DEPENDS) @!i386
+endef
+
+define Package/smartdns-ui/description
+A dashboard ui for smartdns server.
 endef
 
 define Package/smartdns/conffiles
@@ -50,8 +71,54 @@ define Package/smartdns/conffiles
 /etc/smartdns/domain-forwarding.list
 endef
 
+define Download/smartdns-webui
+  PROTO:=git
+  URL:=https://github.com/pymumu/smartdns-webui.git
+  SOURCE_DATE:=2026-03-31
+  SOURCE_VERSION:=c0d2411d20bf8b172a045adbe07166df6691e58b
+  MIRROR_HASH:=fa9463e912169e8907f9454c186c7bcb0b3a36c86a522e065c98a7ea38fcecd8
+  SUBDIR:=smartdns-webui-$$$$(subst -,.,$$$$(SOURCE_DATE))~$$$$(call version_abbrev,$$$$(SOURCE_VERSION))
+  FILE:=$$(SUBDIR).tar.zst
+endef
+
+define Build/Prepare
+	$(call Build/Prepare/Default)
+
+ifneq ($(CONFIG_PACKAGE_smartdns-ui),)
+	$(eval $(call Download,smartdns-webui))
+	$(eval $(Download/smartdns-webui))
+	mkdir -p $(PKG_BUILD_DIR)/smartdns-webui
+	zstdcat $(DL_DIR)/$(FILE) | tar -C $(PKG_BUILD_DIR)/smartdns-webui $(TAR_OPTIONS) --strip-components=1
+endif
+endef
+
+define Build/Compile
+	$(call Build/Compile/Default)
+
+ifneq ($(CONFIG_PACKAGE_smartdns-ui),)
+	( \
+		pushd $(PKG_BUILD_DIR) ; \
+		pushd smartdns-webui ; \
+		npm install ; \
+		npm run build ; \
+		popd ; \
+		pushd plugin/smartdns-ui ; \
+		$(CARGO_PKG_CONFIG_VARS) \
+		MAKEFLAGS="$(PKG_JOBS)" \
+		TARGET_CFLAGS="$(filter-out -O%,$(TARGET_CFLAGS)) $(RUSTC_CFLAGS)" \
+		BINDGEN_EXTRA_CLANG_ARGS="--sysroot=$(TOOLCHAIN_ROOT_DIR)" \
+		cargo build -v --profile $(CARGO_PKG_PROFILE) \
+		$(if $(strip $(RUST_PKG_FEATURES)),--features "$(strip $(RUST_PKG_FEATURES))") \
+		$(if $(filter --jobserver%,$(PKG_JOBS)),,-j1) \
+		$(CARGO_PKG_ARGS) ; \
+		popd ; \
+		popd ; \
+	)
+endif
+endef
+
 define Package/smartdns/install
-	$(INSTALL_DIR) $(1)/usr/sbin $(1)/etc/config $(1)/etc/init.d 
+	$(INSTALL_DIR) $(1)/usr/sbin $(1)/etc/config $(1)/etc/init.d
 	$(INSTALL_DIR) $(1)/etc/smartdns $(1)/etc/smartdns/domain-set $(1)/etc/smartdns/conf.d/
 	$(INSTALL_DIR) $(1)/etc/smartdns/ip-set $(1)/etc/smartdns/download
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/smartdns $(1)/usr/sbin/smartdns
@@ -64,4 +131,12 @@ define Package/smartdns/install
 	$(INSTALL_CONF) $(PKG_BUILD_DIR)/package/openwrt/files/etc/config/smartdns $(1)/etc/config/smartdns
 endef
 
+define Package/smartdns-ui/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(INSTALL_DIR) $(1)/usr/share/smartdns
+	$(CP) $(PKG_BUILD_DIR)/plugin/smartdns-ui/target/$(RUSTC_TARGET_ARCH)/$(CARGO_PKG_PROFILE)/libsmartdns_ui.so $(1)/usr/lib/smartdns_ui.so
+	$(CP) $(PKG_BUILD_DIR)/smartdns-webui/out $(1)/usr/share/smartdns/wwwroot
+endef
+
 $(eval $(call BuildPackage,smartdns))
+$(eval $(call BuildPackage,smartdns-ui))

--- a/net/smartdns/Makefile
+++ b/net/smartdns/Makefile
@@ -9,8 +9,8 @@ PKG_NAME:=smartdns
 PKG_VERSION:=48.1
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://codeload.github.com/pymumu/smartdns/tar.gz/Release$(PKG_VERSION)?
+PKG_SOURCE:=$(PKG_NAME)-Release$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/pymumu/smartdns/tar.gz/refs/tags/Release$(PKG_VERSION)?
 PKG_HASH:=fbc9e8de5e3bd6cd2d7e3823321d5caed22b7c704ae66ed7274f8012246cb285
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-Release$(PKG_VERSION)
 
@@ -19,47 +19,26 @@ PKG_LICENSE:=GPL-3.0-or-later
 PKG_LICENSE_FILES:=LICENSE
 PKG_CPE_ID:=cpe:/a:pymumu:smartdns
 
-PKG_CONFIG_DEPENDS:=CONFIG_PACKAGE_smartdns-ui
-PKG_BUILD_DEPENDS:=PACKAGE_smartdns-ui:node/host PACKAGE_smartdns-ui:rust-bindgen/host
 PKG_BUILD_PARALLEL:=1
 
-RUST_PKG_FEATURES:=build-release
-RUST_PKG_LOCKED:=0
-
 include $(INCLUDE_DIR)/package.mk
-include ../../lang/rust/rust-package.mk
 
+MAKE_VARS += VER=$(PKG_VERSION)
 MAKE_PATH:=src
-MAKE_VARS+= VER=$(PKG_VERSION)
-
-define Package/smartdns/Default
-  SECTION:=net
-  CATEGORY:=Network
-  SUBMENU:=IP Addresses and Names
-  TITLE:=smartdns
-  URL:=https://www.github.com/pymumu/smartdns/
-endef
 
 define Package/smartdns
-  $(call Package/smartdns/Default)
-  TITLE+= server
-  DEPENDS:=+i386:libatomic +libopenssl
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=smartdns server
+  SUBMENU:=IP Addresses and Names
+  DEPENDS:=+i386:libatomic +libpthread +libopenssl
+  URL:=https://www.github.com/pymumu/smartdns/
 endef
 
 define Package/smartdns/description
 SmartDNS is a local DNS server which accepts DNS query requests from local network clients,
 gets DNS query results from multiple upstream DNS servers concurrently, and returns the fastest IP to clients.
 Unlike dnsmasq's all-servers, smartdns returns the fastest IP, and encrypt DNS queries with DoT or DoH.
-endef
-
-define Package/smartdns-ui
-  $(call Package/smartdns/Default)
-  TITLE+= dashboard
-  DEPENDS:=+smartdns $(RUST_ARCH_DEPENDS) @!i386
-endef
-
-define Package/smartdns-ui/description
-A dashboard ui for smartdns server.
 endef
 
 define Package/smartdns/conffiles
@@ -69,52 +48,6 @@ define Package/smartdns/conffiles
 /etc/smartdns/custom.conf
 /etc/smartdns/domain-block.list
 /etc/smartdns/domain-forwarding.list
-endef
-
-define Download/smartdns-webui
-  PROTO:=git
-  URL:=https://github.com/pymumu/smartdns-webui.git
-  SOURCE_DATE:=2026-03-31
-  SOURCE_VERSION:=c0d2411d20bf8b172a045adbe07166df6691e58b
-  MIRROR_HASH:=fa9463e912169e8907f9454c186c7bcb0b3a36c86a522e065c98a7ea38fcecd8
-  SUBDIR:=smartdns-webui-$$$$(subst -,.,$$$$(SOURCE_DATE))~$$$$(call version_abbrev,$$$$(SOURCE_VERSION))
-  FILE:=$$(SUBDIR).tar.zst
-endef
-
-define Build/Prepare
-	$(call Build/Prepare/Default)
-
-ifneq ($(CONFIG_PACKAGE_smartdns-ui),)
-	$(eval $(call Download,smartdns-webui))
-	$(eval $(Download/smartdns-webui))
-	mkdir -p $(PKG_BUILD_DIR)/smartdns-webui
-	zstdcat $(DL_DIR)/$(FILE) | tar -C $(PKG_BUILD_DIR)/smartdns-webui $(TAR_OPTIONS) --strip-components=1
-endif
-endef
-
-define Build/Compile
-	$(call Build/Compile/Default)
-
-ifneq ($(CONFIG_PACKAGE_smartdns-ui),)
-	( \
-		pushd $(PKG_BUILD_DIR) ; \
-		pushd smartdns-webui ; \
-		npm install ; \
-		npm run build ; \
-		popd ; \
-		pushd plugin/smartdns-ui ; \
-		$(CARGO_PKG_CONFIG_VARS) \
-		MAKEFLAGS="$(PKG_JOBS)" \
-		TARGET_CFLAGS="$(filter-out -O%,$(TARGET_CFLAGS)) $(RUSTC_CFLAGS)" \
-		BINDGEN_EXTRA_CLANG_ARGS="--sysroot=$(TOOLCHAIN_ROOT_DIR)" \
-		cargo build -v --profile $(CARGO_PKG_PROFILE) \
-		$(if $(strip $(RUST_PKG_FEATURES)),--features "$(strip $(RUST_PKG_FEATURES))") \
-		$(if $(filter --jobserver%,$(PKG_JOBS)),,-j1) \
-		$(CARGO_PKG_ARGS) ; \
-		popd ; \
-		popd ; \
-	)
-endif
 endef
 
 define Package/smartdns/install
@@ -131,12 +64,4 @@ define Package/smartdns/install
 	$(INSTALL_CONF) $(PKG_BUILD_DIR)/package/openwrt/files/etc/config/smartdns $(1)/etc/config/smartdns
 endef
 
-define Package/smartdns-ui/install
-	$(INSTALL_DIR) $(1)/usr/lib
-	$(INSTALL_DIR) $(1)/usr/share/smartdns
-	$(CP) $(PKG_BUILD_DIR)/plugin/smartdns-ui/target/$(RUSTC_TARGET_ARCH)/$(CARGO_PKG_PROFILE)/libsmartdns_ui.so $(1)/usr/lib/smartdns_ui.so
-	$(CP) $(PKG_BUILD_DIR)/smartdns-webui/out $(1)/usr/share/smartdns/wwwroot
-endef
-
 $(eval $(call BuildPackage,smartdns))
-$(eval $(call BuildPackage,smartdns-ui))


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @pymumu
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->
Changes: https://github.com/pymumu/smartdns/releases/tag/Release48.1


---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12
- **OpenWrt Target/Subtarget:** X86/64
- **OpenWrt Device:** R2

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
