### PR TITLE
expat: update to 2.8.1

### DIFF
--- a/libs/expat/Makefile
+++ b/libs/expat/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=expat
-PKG_VERSION:=2.7.4
+PKG_VERSION:=2.8.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/libexpat/libexpat/releases/download/R_$(subst .,_,$(PKG_VERSION))
-PKG_HASH:=461ecc8aa98ab1a68c2db788175665d1a4db640dc05bf0e289b6ea17122144ec
+PKG_HASH:=a52eb72108be160e190b5cafa5bba8663f1313f2013e26060d1c18e26e31067b
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=COPYING

--- a/libs/expat/test-version.sh
+++ b/libs/expat/test-version.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# shellcheck shell=busybox
+
+case "$PKG_NAME" in
+libexpat)
+	# Shared libraries
+	exit 0
+	;;
+
+*)
+	echo "Untested package: $PKG_NAME" >&2
+	exit 1
+	;;
+esac


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** None

**Description:**
Update libexpat to 2.8.1

---

## 🧪 Run Testing Details

- **OpenWrt Version:** master
- **OpenWrt Target/Subtarget:** x86 / x86_64
- **OpenWrt Device:** QEMU

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.