### PR TITLE
watchcat: clarify recovery timer baseline

### DIFF
--- a/utils/watchcat/Makefile
+++ b/utils/watchcat/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=watchcat
 PKG_VERSION:=1
-PKG_RELEASE:=23
+PKG_RELEASE:=24
 
 PKG_MAINTAINER:=Roger D <rogerdammit@gmail.com>
 PKG_LICENSE:=GPL-2.0

--- a/utils/watchcat/files/watchcat.sh
+++ b/utils/watchcat/files/watchcat.sh
@@ -169,6 +169,8 @@ watchcat_monitor_network() {
 		done
 
 		[ "$((time_now - time_lastcheck_withinternet))" -ge "$failure_period" ] && {
+			recovery_started="$time_now"
+
 			if [ "$script" != "" ]; then
 				watchcat_run_script "$script" "$iface"
 			else
@@ -188,8 +190,10 @@ watchcat_monitor_network() {
 				time_now="$(cat /proc/uptime)"
 				time_now="${time_now%%.*}"
 				time_lastcheck="$time_now"
+				time_lastcheck_withinternet="$time_now"
+			else
+				time_lastcheck_withinternet="$recovery_started"
 			fi
-			time_lastcheck_withinternet="$time_now"
 		}
 
 	done


### PR DESCRIPTION
Keep the default restart timing based on the moment the recovery action is
triggered.

The optional `reset_failure_timer` path still starts a fresh failure window
after the recovery action finishes. This makes the two timing modes explicit.

## 📦 Package Details

**Maintainer:** Daniel F. Dickinson <dfdpublic@wildtechgarden.ca> (@danielfdickinson)

**Description:**
Adjust watchcat's restart timing state so the default path continues from the
recovery trigger time, while `reset_failure_timer=1` continues to use the
post-recovery timestamp.

This also bumps `PKG_RELEASE` .

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12.2 r32802-f505120278
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** VM
---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] Not applicable, this PR does not add or modify an upstream source patch.
