### PR TITLE
radicale3: bump version to 3.7.5

### DIFF
--- a/net/radicale3/Makefile
+++ b/net/radicale3/Makefile
@@ -4,7 +4,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=radicale3
-PKG_VERSION:=3.7.2
+PKG_VERSION:=3.7.5
 PKG_RELEASE:=1
 
 PKG_LICENSE:=GPL-3.0-or-later
@@ -13,7 +13,7 @@ PKG_CPE_ID:=cpe:/a:radicale:radicale
 
 PYPI_NAME:=Radicale
 PYPI_SOURCE_NAME:=radicale
-PKG_HASH:=2c61de17ee4105a998dd250a79732b83313f74aa396bd40b71e7438b695e0edc
+PKG_HASH:=a6b45128ac6d84e397e78e9340abc2906c9037cd5b65641f02578eda238fa0b7
 
 PKG_MAINTAINER:=Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>
 

--- a/net/radicale3/Makefile
+++ b/net/radicale3/Makefile
@@ -40,7 +40,7 @@ define Package/radicale3/description
   pre-configured to work out-of-the-box.
   The Radicale Project runs on most of the UNIX-like platforms
   (Linux, BSD, MacOS X) and Windows. It is known to work with Evolution,
-  Lightning, iPhone and Android clients. It is free and open-source software,
+  Thunderbird, iOS, and Android clients. It is free and open-source software,
   released under GPL version 3.
 
   This package contains the python files.


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @danielfdickinson 
Also notify: @BKPepe 

**Description:**
Bump to latest upstream version (3.7.5)

---

## 🧪 Run Testing Details

- **OpenWrt Version:** OpenWrt SNAPSHOT r35043-11865bffc8
- **OpenWrt Target/Subtarget:** bcm27xx/bcm2712
- **OpenWrt Device:** Raspberry Pi 5 Model B Rev 1.0

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
