### PR TITLE
netcat: fix build with GCC 15

### DIFF
--- a/net/netcat/Makefile
+++ b/net/netcat/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netcat
 PKG_VERSION:=0.7.1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=@SF/$(PKG_NAME)
@@ -32,6 +32,8 @@ define Package/netcat/description
 		Netcat is a featured networking utility which reads and writes data across network connections, using the TCP/IP protocol.
 	It is designed to be a reliable "back-end" tool that can be used directly or easily driven by other programs and scripts. At the same time, it is a feature-rich network debugging and exploration tool, since it can create almost any kind of connection you would need and has several interesting built-in capabilities.
 endef
+
+TARGET_CFLAGS += -std=gnu17
 
 define Build/Configure
 	$(call Build/Configure/Default, \


### PR DESCRIPTION
GCC 15 defaults to gnu23, which breaks the old bundled getopt K&R-style declarations used by netcat 0.7.1. Force gnu17 for this package to preserve the previous compiler semantics.

## 📦 Package Details

**Maintainer:** @adam2104 Adam Gensler <openwrt@a.gnslr.us>

**Description:**
Netcat is a featured networking utility which reads and writes data across network connections, using the TCP/IP protocol.
It is designed to be a reliable "back-end" tool that can be used directly or easily driven by other programs and scripts. At the same time, it is a feature-rich network debugging and exploration tool, since it can create almost any kind of connection you would need and has several interesting built-in capabilities.


---

## 🧪 Run Testing Details

- **OpenWrt Version:** Snapshot 7edb29d
- **OpenWrt Target/Subtarget:** mvebu/cortexa9
- **OpenWrt Device:** WRT1200AC

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.