### PR TITLE
nebula-proto: fix interface state after tunnel startup

### DIFF
--- a/net/nebula/Makefile
+++ b/net/nebula/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nebula
 PKG_VERSION:=1.10.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/slackhq/nebula/tar.gz/v$(PKG_VERSION)?

--- a/net/nebula/files/nebula.proto
+++ b/net/nebula/files/nebula.proto
@@ -40,12 +40,11 @@ proto_nebula_init_config() {
 }
 
 proto_nebula_setup() {
-	local interface="$1" config_file address addresses
+	local interface="$1" config_file address addresses ifaddr_timeout
 	local yaml_listen_host yaml_listen_port yaml_tun_dev
 
 	config_load network
 	config_get config_file "${interface}" "config_file"
-	proto_init_update "${interface}" 1
 
 	[ -s "$config_file" ] || { log "Config file not found or empty!"; return 1; }
 	eval "$(yaml_parse "$config_file" "yaml_")"
@@ -54,6 +53,26 @@ proto_nebula_setup() {
 
 	log "Setting up ${interface} from $(basename "$config_file")."
 	proto_run_command "$interface" "$PROG" -config "$config_file"
+
+	ifaddr_timeout=10
+	while [ "$ifaddr_timeout" -gt 0 ]; do
+		addresses="$(ip -o -4 addr show dev "$interface" scope global 2>/dev/null | awk '{print $4}')"
+		[ -n "$addresses" ] && break
+		ifaddr_timeout=$((ifaddr_timeout - 1))
+		sleep 1
+	done
+
+	[ -n "$addresses" ] || {
+		log "Timed out waiting for ${interface} to receive an IPv4 address."
+		proto_notify_error "$interface" IFADDR_TIMEOUT
+		proto_block_restart "$interface"
+		proto_setup_failed "$interface"
+		return 1
+	}
+
+	proto_init_update "$interface" 1
+	proto_set_keep 1
+
 	# TODO: if lighthouse, open local port 4242
 	# TODO: else get local subnet from local_range variable, if not,
 	# TODO: iterate over each lighthouse/hosts and append /24
@@ -71,7 +90,6 @@ proto_nebula_setup() {
 		json_close_object
 	json_close_array
 	proto_close_data
-	addresses="$(ip -4 a list dev "$interface" 2>/dev/null | grep inet | awk '{print $2}' | awk -F "/" '{print $1}')"
 	log "Running ${interface} from $(basename "$config_file")${addresses+:  with addresses: $addresses}."
 	for address in ${addresses}; do
 		case "${address}" in


### PR DESCRIPTION
## Description

When Nebula is started by the proto handler, the tunnel device can be created and assigned an address while the OpenWrt logical interface remains in pending state.

This leaves netifd without the final runtime state for the interface. As a result, ifstatus and LuCI do not show the assigned address, uptime or traffic counters.

Firewall zones referencing the nebula network may also not be associated with the tunnel device, so traffic on the tunnel can be handled incorrectly by the normal OpenWrt firewall configuration.

The setup code initialized the interface update before starting Nebula. However, `proto_run_command` prepares and sends its own command notification to netifd, which reinitializes the notification data. As a result, the update prepared by `proto_init_update` is lost before `proto_send_update` is called.

Start Nebula first, then wait until the tunnel interface has a global IPv4 address before initializing and sending the interface update. On fast systems the address may already be available by the time it is checked, but without an explicit wait there is still a startup race where Nebula has been launched and the TUN device is not fully addressed yet.

Keep the CIDR prefix when collecting addresses, so netifd receives the correct prefix length instead of reporting the address as /32.

If no address appears before the timeout, report `IFADDR_TIMEOUT`, block automatic restart and mark setup as failed instead of sending an incomplete link-up update.

## 📦 Package Details

**Package:** `nebula-proto`
**Maintainer:** @yingziwu

---

## 🧪 Run Testing Details

- **OpenWrt Version:** `25.12.4`
- **OpenWrt Target/Subtarget:** `bmips/bcm6368`
- **OpenWrt Device:** `Observa VH4032N`

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

- [X] This PR changes the OpenWrt package script directly. It does not add or
refresh a patch under a package patches/ directory.