### PR TITLE
ddns-scripts: update_gandi_net: Use new PAT token for auth

### DIFF
--- a/net/ddns-scripts/files/usr/lib/ddns/update_gandi_net.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/update_gandi_net.sh
@@ -22,13 +22,13 @@ json_close_array
 
 # Log the curl command
 write_log 7 "curl -s -X PUT \"$__ENDPOINT/domains/$domain/records/$username/$__RRTYPE\" \
-	-H \"Authorization: Apikey $password\" \
+	-H \"Authorization: Bearer $password\" \
 	-H \"Content-Type: application/json\" \
 	-d \"$(json_dump)\" \
 	--connect-timeout 30"
 
 __STATUS=$(curl -s -X PUT "$__ENDPOINT/domains/$domain/records/$username/$__RRTYPE" \
-	-H "Authorization: Apikey $password" \
+	-H "Authorization: Bearer $password" \
 	-H "Content-Type: application/json" \
 	-d "$(json_dump)" \
 	--connect-timeout 30 \


### PR DESCRIPTION
API keys are no longer supported. Change the auth header to support the new PAT token auth.

## 📦 Package Details

**Maintainer:** @feckert 


**Description:**
Upgrade the script to use scoped Gandi.net PAT tokens. The API keys are deprecated and new ones cannot be created
---

## 🧪 Run Testing Details

- **OpenWrt Version: OpenWrt 24.10.2 r28739-d9340319c6 **
- **OpenWrt Target/Subtarget: mediatek/filogic**
- **OpenWrt Device: GL.iNet GL-MT6000**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [x] It is structured in a way that it is potentially upstreamable
