### PR TITLE
monit: update to 6.0.0

### DIFF
--- a/admin/monit/Makefile
+++ b/admin/monit/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=monit
-PKG_VERSION:=5.35.2
+PKG_VERSION:=6.0.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://bitbucket.org/tildeslash/monit/downloads/
-PKG_HASH:=4dfef54329e63d9772a9e1c36ac99bc41173b79963dc0d8235f2c32f4b9e078f
+PKG_SOURCE_URL:=https://mmonit.com/monit/dist/
+PKG_HASH:=ddacd2a8120aeb2351e4486ee04a17782b5004aee99f2041d829bc4dcf2a5b3b
 
 PKG_MAINTAINER:=Yaroslav Petrov <info@lank.me>
 PKG_LICENSE:=AGPL-3.0


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** Me (@Lankaster )

**Description:**

* New release, see the changelog [1] for what's new.

* Switch the download source from Bitbucket to the official release page (https://mmonit.com/monit/dist/). The source code archives on Bitbucket no longer use clear naming conventions like "monit-x.y.z". The Monit team has confirmed that downloading directly from their official distribution site is the recommended approach going forward.

[1] https://mmonit.com/monit/changes/

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12, master
- **OpenWrt Target/Subtarget:** x86_64
- **OpenWrt Device:**: Alix Apu4

---