### PR TITLE
bcp38: clean up nft rule handling

### DIFF
--- a/net/bcp38/Makefile
+++ b/net/bcp38/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bcp38
 PKG_VERSION:=5
-PKG_RELEASE:=12
+PKG_RELEASE:=13
 PKG_LICENSE:=GPL-3.0-or-later
 
 include $(INCLUDE_DIR)/package.mk

--- a/net/bcp38/files/run.sh
+++ b/net/bcp38/files/run.sh
@@ -86,8 +86,8 @@ setup_chains()
 	nft flush chain "$FAMILY" "$TABLE" "$CHAIN" 2>/dev/null
 
 	nft add rule "$FAMILY" "$TABLE" "$CHAIN" udp sport . udp dport { 68 . 67, 67 . 68 } counter return comment \"always accept DHCP traffic\"
-	nft add rule "$FAMILY" "$TABLE" "$CHAIN" oifname $interface ip daddr @"$MATCHSET" ip daddr != @"$NOMATCHSET" counter reject with icmp type host-unreachable
-	nft add rule "$FAMILY" "$TABLE" "$CHAIN" iifname $interface ip saddr @"$MATCHSET" ip saddr != @"$NOMATCHSET" counter drop
+	nft add rule "$FAMILY" "$TABLE" "$CHAIN" oifname "$interface" ip daddr @"$MATCHSET" ip daddr != @"$NOMATCHSET" counter reject with icmp type host-unreachable
+	nft add rule "$FAMILY" "$TABLE" "$CHAIN" iifname "$interface" ip saddr @"$MATCHSET" ip saddr != @"$NOMATCHSET" counter drop
 
 	nft add chain "$FAMILY" "$TABLE" input "{ type filter hook input priority $priority; policy accept; comment \"bcp38 filter\"; }"
 	nft add chain "$FAMILY" "$TABLE" forward "{ type filter hook forward priority $priority; policy accept; comment \"bcp38 filter\"; }"
@@ -101,8 +101,8 @@ setup_chains()
 destroy_table()
 {
 	if [ "$TABLE" != "fw4" ]; then
-		#as of kernel 3.18 we can delete a table without need to flush it
-		nft delete table "$FAMILY" "$TABLE" 2>/dev/null
+		# Delete the table if it exists.
+		nft destroy table "$FAMILY" "$TABLE" 2>/dev/null
 	fi
 }
 


### PR DESCRIPTION
Quote interface names when creating nft rules and use destroy table for idempotent cleanup.

Interface name is now quoted when creating `iifname` / `oifname` rules, so
it is passed to `nft` as a single value.

## 📦 Package Details

**Maintainer:** Toke Høiland-Jørgensen <toke@toke.dk>

**Description:**
Small nftables cleanup for the bcp38 package.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12.2 r32802-f505120278
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** VM

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] Not applicable, this PR does not add or modify an upstream source patch.
