### PR TITLE
Add missing configuration options to collectd df plugin config

### DIFF
--- a/utils/collectd/Makefile
+++ b/utils/collectd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=collectd
 PKG_VERSION:=5.12.0
-PKG_RELEASE:=56
+PKG_RELEASE:=57
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://collectd.org/files/ \

--- a/utils/collectd/files/usr/share/collectd/plugin/df.json
+++ b/utils/collectd/files/usr/share/collectd/plugin/df.json
@@ -1,6 +1,10 @@
 {
 	"bool": [
-		"IgnoreSelected"
+		"IgnoreSelected",
+		"ReportByDevice",
+		"ReportInodes",
+		"ValuesAbsolute",
+		"ValuesPercentage"
 	],
 	"list": [
 		"Device",


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @hnyman

**Description:**

`collectd` `df` plugin configuration file misses several options supported by `collectd` `df`. This change adds them.

Fixes #29849

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12.4
- **OpenWrt Target/Subtarget:** N/A
- **OpenWrt Device:** N/A

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [X] It can be applied using `git am`
- [X] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [X] It is structured in a way that it is potentially upstreamable
