### PR TITLE
vscode: update commit message validation line length

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,6 +5,6 @@
     "files.trimFinalNewlines": true,
     "files.eol": "\n",
     "git.inputValidation": true,
-    "git.inputValidationSubjectLength": 60,
-    "git.inputValidationLineLength": 75
+    "git.inputValidationSubjectLength": 80,
+    "git.inputValidationLineLength": 100
 }


### PR DESCRIPTION
Adjusted per 8dbf9b876eef092c46dd129ba6d3cf932f1e074a ("check_formalities.sh: increase line length limits") from actions-shared-workflows repository [1]

[1] https://github.com/openwrt/actions-shared-workflows/commit/8dbf9b876eef092c46dd129ba6d3cf932f1e074a

Solves: https://github.com/openwrt/packages/pull/28306#discussion_r3402143526