### PR TITLE
net-snmp: allow mulitple library installations

### DIFF
--- a/net/net-snmp/Makefile
+++ b/net/net-snmp/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=net-snmp
 PKG_VERSION:=5.9.5.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/net-snmp
@@ -315,7 +315,7 @@ Package/snmpd-ssl/conffiles = $(Package/snmpd-nossl/conffiles)
 
 define Package/libnetsnmp-nossl/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libnetsnmp{,agent,helpers,mibs}.so* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libnetsnmp{,agent,helpers,mibs}.so.* $(1)/usr/lib/
 endef
 Package/libnetsnmp-ssl/install = $(Package/libnetsnmp-nossl/install)
 


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @stintel 
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
As written by @feckert in https://github.com/openwrt/packages/pull/28867#discussion_r3480024190 it is necessary to allow the installation of multiple libraries. Also it has to be backported to stable versions as @BKPepe wrote https://github.com/openwrt/packages/pull/28867#issuecomment-4825779327

To allow multiple libraries on the target this glob is targeting multiple libraries.
<!-- Briefly describe what this package does or what changes are introduced -->

---

## 🧪 Run Testing Details

- **OpenWrt Version:** openwrt-25.12
- **OpenWrt Target/Subtarget:** x86/64

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.