### PR TITLE
adblock-fast: make gatewaycheck configurable

### DIFF
--- a/net/adblock-fast/Makefile
+++ b/net/adblock-fast/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock-fast
 PKG_VERSION:=1.2.4
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
 PKG_LICENSE:=AGPL-3.0-or-later
 

--- a/net/adblock-fast/files/etc/config/adblock-fast
+++ b/net/adblock-fast/files/etc/config/adblock-fast
@@ -21,6 +21,7 @@ config adblock-fast 'config'
 #	option download_max_time ''
 	option download_allow_insecure '1'
 	option force_dns '1'
+	option gateway_check 'netifd'
 	list force_dns_port '53'
 	list force_dns_port '853'
 # ports listed below are used by some

--- a/net/adblock-fast/files/etc/init.d/adblock-fast
+++ b/net/adblock-fast/files/etc/init.d/adblock-fast
@@ -95,6 +95,7 @@ load_validate_config() {
 	uci_load_validate "$packageName" "$packageName" "$1" "${2}${3:+ ${3}}" \
 		'enabled:bool:0' \
 		'force_dns:bool:1' \
+		'gateway_check:or("netifd", "kernel", "none"):netifd' \
 		'force_dns_interface:list(network):lan' \
 		'force_dns_port:list(integer):53,853' \
 		'parallel_downloads:bool:1' \

--- a/net/adblock-fast/files/lib/adblock-fast/adblock-fast.uc
+++ b/net/adblock-fast/files/lib/adblock-fast/adblock-fast.uc
@@ -912,6 +912,7 @@ const config_schema = { // ucode-lsp disable
 	download_connect_timeout: ['string', '10'],
 	download_max_time:       ['string'],
 	download_timeout:        ['string', '20'],
+	gateway_check:           ['string', 'netifd'],
 	heartbeat_sleep_timeout: ['string', '10'],
 	led:                     ['string'],
 	pause_timeout:           ['string', '20'],
@@ -1224,7 +1225,7 @@ env.load = function(param, validation_result) {
 		}
 	};
 
-	let _check_wan_gateway = function() {
+	let _check_netifd_gateway = function() {
 		let ub = connect();
 		if (!ub) return false;
 		let dump = ub.call('network.interface', 'dump');
@@ -1232,9 +1233,26 @@ env.load = function(param, validation_result) {
 		if (!dump?.interface) return false;
 		for (let iface in dump.interface) {
 			for (let r in (iface.route || []))
-				if (r.target == '0.0.0.0') return true;
+				if (r.target == '0.0.0.0' || r.target == '::') return true;
 		}
 		return false;
+	};
+
+	let _check_kernel_gateway = function() {
+		return system("ip -4 route show default 2>/dev/null | grep -q '^default'") == 0 ||
+			system("ip -6 route show default 2>/dev/null | grep -q '^default'") == 0;
+	};
+
+	let _check_wan_gateway = function() {
+		switch (cfg.gateway_check) {
+		case 'none':
+			return true;
+		case 'kernel':
+			return _check_kernel_gateway();
+		case 'netifd':
+		default:
+			return _check_netifd_gateway();
+		}
 	};
 
 	// ── param-driven branches ───────────────────────────────────────
@@ -3081,4 +3099,3 @@ export default {
 	emit_procd_shell,
 	process_file_url,
 };
-


### PR DESCRIPTION
Allow the startup gateway readiness check to be selected via UCI:

  option gateway_check 'netifd'
  option gateway_check 'kernel'
  option gateway_check 'none'

Keep the existing netifd/ubus behavior as the default. The new kernel mode checks IPv4 and IPv6 default routes via iproute2, while none skips the readiness check for routing-daemon or policy-routing setups where a netifd WAN gateway is not expected.

Also treat IPv6 default routes from netifd as valid gateway readiness.

## 📦 Package Details

**Maintainer:** @stangri 
## 🧪 Run Testing Details
- **OpenWrt Version:** OpenWrt-25.12-Snapshot
- **OpenWrt Target/Subtarget:** mediatek
- **OpenWrt Device:** Linksys E8450

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
