### PR TITLE
transmission: grant r/w access to config dir

### DIFF
--- a/net/transmission/Makefile
+++ b/net/transmission/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=transmission
 PKG_VERSION:=4.1.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/transmission/transmission/releases/download/$(PKG_VERSION)/

--- a/net/transmission/files/transmission.init
+++ b/net/transmission/files/transmission.init
@@ -163,10 +163,7 @@ transmission() {
 
 	procd_add_jail transmission log
 	procd_add_jail_mount "$config_file"
-	procd_add_jail_mount_rw "$config_dir/resume"
-	procd_add_jail_mount_rw "$config_dir/torrents"
-	procd_add_jail_mount_rw "$config_dir/blocklists"
-	procd_add_jail_mount_rw "$config_dir/stats.json"
+	procd_add_jail_mount_rw "$config_dir"
 	procd_add_jail_mount_rw "$download_dir"
 	[ "$incomplete_dir_enabled" = "1" ] && procd_add_jail_mount_rw "$incomplete_dir"
 	[ "$watch_dir_enabled" = "1" ] && procd_add_jail_mount_rw "$watch_dir"


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @dangowrt

**Description:**
Transmission seems to expect to have read/write access to its config directory. When it tries to update a file there, for example `stats.json`, it first creates a temporary file (like `stats.json.tmp.xxxxxx`) and then moves it into the proper place. However, with the current ujail configuration, this fails: `stats.json` does not get updated and the temp file is not removed. With a long-running transmission daemon, this makes the config directory fill up with stale temp files.

This PR grants the daemon write permission to files in the config directory except for `settings.json`. This makes file updates work and drastically reduces the amount of temp files lying around. The daemon still creates some when it occasionally tries and fails to write to `settings.json` (probably only on startup/shutdown). This seems to happen at a much lower rate than other writes though, and this way the settings file is kept in sync with UCI at all times.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12.4
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** asus_rt-ax59u

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
