### PR TITLE
[25.12] bash: update to 5.3 patch level 15

### DIFF
--- a/utils/bash/Makefile
+++ b/utils/bash/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bash
 PKG_VERSION:=5.3
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@GNU/bash

--- a/utils/bash/patches/012-bash_5.3_patch_13.patch
+++ b/utils/bash/patches/012-bash_5.3_patch_13.patch
@@ -1,0 +1,31 @@
+From 427d51d84df2fecc3d1a20f28b16f38234cd9914 Mon Sep 17 00:00:00 2001
+From: Chet Ramey <chet.ramey@case.edu>
+Date: Wed, 10 Jun 2026 08:56:30 -0400
+Subject: Bash-5.3 patch 13: fix technically undefined behavior when comparing
+ return value from realloc to the original pointer
+
+--- a/builtins/read.def
++++ b/builtins/read.def
+@@ -788,8 +788,11 @@ read_builtin (WORD_LIST *list)
+ 	  char *x;
+ 	  x = (char *)xrealloc (input_string, size += 128);
+ 
+-	  /* Only need to change unwind-protect if input_string changes */
++#if 0
++	  /* This is, in theory, undefined behavior, since input_string may
++	     have been freed. */
+ 	  if (x != input_string)
++#endif
+ 	    {
+ 	      input_string = x;
+ 	      remove_unwind_protect ();
+--- a/patchlevel.h
++++ b/patchlevel.h
+@@ -25,6 +25,6 @@
+    regexp `^#define[ 	]*PATCHLEVEL', since that's what support/mkversion.sh
+    looks for to find the patch level (for the sccs version string). */
+ 
+-#define PATCHLEVEL 12
++#define PATCHLEVEL 13
+ 
+ #endif /* _PATCHLEVEL_H_ */

--- a/utils/bash/patches/013-bash_5.3_patch_14.patch
+++ b/utils/bash/patches/013-bash_5.3_patch_14.patch
@@ -1,0 +1,44 @@
+From a833685ecb9681b611b9c4c44b2e4c40932fcd6f Mon Sep 17 00:00:00 2001
+From: Chet Ramey <chet.ramey@case.edu>
+Date: Wed, 10 Jun 2026 08:58:29 -0400
+Subject: Bash-5.3 patch 14: update mapfile patch 11, removing stray line and
+ improving the efficiency of the original fix
+
+--- a/builtins/mapfile.def
++++ b/builtins/mapfile.def
+@@ -197,16 +197,16 @@ mapfile (int fd, long line_count_goal, l
+ 	    zsyncfd (fd);
+ 
+ 	  run_callback (callback, array_index, line);
+-	}
+-
+-      /* Bad things can happen if the callback modifies ENTRY, e.g.,
+-	 unsetting it or changing it to a non-indexed-array type, so we
+-	 look it up again every time we need to assign something */
+-      entry = bind_array_variable (array_name, array_index, line, 0);
+-      if (entry == 0 || ASSIGN_DISALLOWED (entry, 0))
+-	return EXECUTION_FAILURE;
+ 
+-      bind_array_element (entry, array_index, line, 0);
++	  /* Bad things can happen if the callback modifies ENTRY, e.g.,
++	     unsetting it or changing it to a non-indexed-array type, so we
++	     look it up again every time we need to assign something */
++	  entry = bind_array_variable (array_name, array_index, line, 0);
++	  if (entry == 0 || ASSIGN_DISALLOWED (entry, 0))
++	    return EXECUTION_FAILURE;
++	}
++      else
++	bind_array_element (entry, array_index, line, 0);
+ 
+       /* Have we exceeded # of lines to store? */
+       line_count++;
+--- a/patchlevel.h
++++ b/patchlevel.h
+@@ -25,6 +25,6 @@
+    regexp `^#define[ 	]*PATCHLEVEL', since that's what support/mkversion.sh
+    looks for to find the patch level (for the sccs version string). */
+ 
+-#define PATCHLEVEL 13
++#define PATCHLEVEL 14
+ 
+ #endif /* _PATCHLEVEL_H_ */

--- a/utils/bash/patches/014-bash_5.3_patch_15.patch
+++ b/utils/bash/patches/014-bash_5.3_patch_15.patch
@@ -1,0 +1,48 @@
+From b460816602167718f78a6233164e8875f49b75b2 Mon Sep 17 00:00:00 2001
+From: Chet Ramey <chet.ramey@case.edu>
+Date: Wed, 10 Jun 2026 08:59:27 -0400
+Subject: Bash-5.3 patch 15: fix read builtin to avoid cases where -1 is used
+ as an index into the input buffer
+
+--- a/builtins/read.def
++++ b/builtins/read.def
+@@ -538,7 +538,8 @@ read_builtin (WORD_LIST *list)
+ 	     so we have to save input_string temporarily, run the unwind-
+ 	     protects, then restore input_string so we can use it later */
+ 	  orig_input_string = 0;
+-	  input_string[i] = '\0';	/* make sure it's terminated */
++	  if (i >= 0)
++	    input_string[i] = '\0';	/* make sure it's terminated */
+ 	  if (i == 0)
+ 	    {
+ 	      t = (char *)xmalloc (1);
+@@ -592,8 +593,7 @@ read_builtin (WORD_LIST *list)
+ 	  termsave.attrs = ttattrs;
+ 
+ 	  ttset = ttattrs;	  
+-	  i = silent ? ttfd_cbreak (fd, &ttset) : ttfd_onechar (fd, &ttset);
+-	  if (i < 0)
++	  if ((silent ? ttfd_cbreak (fd, &ttset) : ttfd_onechar (fd, &ttset)) < 0)
+ 	    sh_ttyerror (1);
+ 	  tty_modified = 1;
+ 	  add_unwind_protect (uw_ttyrestore, &termsave);
+@@ -609,8 +609,7 @@ read_builtin (WORD_LIST *list)
+       termsave.attrs = ttattrs;
+ 
+       ttset = ttattrs;
+-      i = ttfd_noecho (fd, &ttset);			/* ttnoecho (); */
+-      if (i < 0)
++      if (ttfd_noecho (fd, &ttset) < 0)
+ 	sh_ttyerror (1);
+ 
+       tty_modified = 1;
+--- a/patchlevel.h
++++ b/patchlevel.h
+@@ -25,6 +25,6 @@
+    regexp `^#define[ 	]*PATCHLEVEL', since that's what support/mkversion.sh
+    looks for to find the patch level (for the sccs version string). */
+ 
+-#define PATCHLEVEL 14
++#define PATCHLEVEL 15
+ 
+ #endif /* _PATCHLEVEL_H_ */


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** Me

**Description:**
Update bash to 5.3 patch level 15.

Backport of https://github.com/openwrt/packages/pull/29772 to 25.12.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** OpenWrt 25.12
- **OpenWrt Target/Subtarget:** x86 / x86_64
- **OpenWrt Device:** QEMU

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>