### PR TITLE
uspot: add version check override

### DIFF
--- a/net/uspot/test-version.sh
+++ b/net/uspot/test-version.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# shellcheck shell=busybox
+
+# uspot executables (radius-client, uspot, uspot-das) do not expose the
+# package version via --version or --help. Skip the generic version probe.
+
+case "$PKG_NAME" in
+uspot|uspotfilter|uspot-www)
+	exit 0
+	;;
+
+*)
+	echo "Untested package: $PKG_NAME" >&2
+	exit 1
+	;;
+esac


### PR DESCRIPTION
None of the uspot executables (radius-client, uspot, uspot-das) expose the package version via --version or --help flags. This causes the generic CI tests to fail with "No executables in the package provided version".

Add a test-version.sh to skip the version probe for the uspot, uspotfilter and uspot-www subpackages.

Found out in https://github.com/openwrt/packages/pull/29810