### PR TITLE
giflib: add version check override

### DIFF
--- a/libs/giflib/test-version.sh
+++ b/libs/giflib/test-version.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# shellcheck shell=busybox
+
+# None of the giflib-utils executables print the package version.
+# Skip the generic version probe.
+
+case "$PKG_NAME" in
+giflib|giflib-utils)
+	exit 0
+	;;
+
+*)
+	echo "Untested package: $PKG_NAME" >&2
+	exit 1
+	;;
+esac


### PR DESCRIPTION
The giflib-utils executables (gif2rgb, gifbuild, gifclrmp, giffix, giftext, giftool) do not report the package version when run, which causes the generic version probe to fail.

Add a test-version.sh to skip the version check for the giflib and giflib-utils packages.
