### PR TITLE
ddns-scripts: add version check override

### DIFF
--- a/net/ddns-scripts/test-version.sh
+++ b/net/ddns-scripts/test-version.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# shellcheck shell=busybox
+
+# None of the ddns-scripts executables or scripts print the package version.
+# Skip the generic version probe.
+
+case "$PKG_NAME" in
+ddns-scripts*)
+	exit 0
+	;;
+
+*)
+	echo "Untested package: $PKG_NAME" >&2
+	exit 1
+	;;
+esac


### PR DESCRIPTION
None of the ddns-scripts executables or scripts report the package version when run, which causes the generic version probe to fail.

Add a test-version.sh to skip the version check for ddns-scripts and all of its subpackages.