### PR TITLE
ip-timezone: add new package

### DIFF
--- a/utils/ip-timezone/Makefile
+++ b/utils/ip-timezone/Makefile
@@ -1,0 +1,41 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=ip-timezone
+PKG_VERSION:=1.0.0
+PKG_RELEASE:=1
+
+PKG_MAINTAINER:=Renn Akaza <openwrt.org-ip-timezone@akaza.ren>
+PKG_LICENSE:=GPL-3.0-or-later
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/ip-timezone
+	SECTION:=utils
+	CATEGORY:=Utilities
+	TITLE:=Auto set timezone by IP
+	PKGARCH:=all
+	DEPENDS:=+zoneinfo-all
+endef
+
+define Package/ip-timezone/description
+Hotplug script to ipmatically configure the timezone UCI settings based on the IP address.
+
+The user needs to set their own endpoint to get the IANA timezone string, e.g.:
+	uci set ip-timezone.config.endpoint="https://domain.tld/timezone"
+	uci commit ip-timezone
+
+The endpoint is expected to respond GET requests by a plaintext one-line IANA timezone string, e.g. "Europe/London".
+The endpoint can be verified by directly accessing the its URL from a browser by the address bar.
+endef
+
+define Build/Compile
+endef
+
+define Package/ip-timezone/install
+	$(INSTALL_DIR) $(1)/etc/hotplug.d/iface/
+	$(INSTALL_DATA) ./files/99-ip-timezone $(1)/etc/hotplug.d/iface/
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_CONF) ./files/ip-timezone.config $(1)/etc/config/ip-timezone
+endef
+
+$(eval $(call BuildPackage,ip-timezone))

--- a/utils/ip-timezone/files/99-ip-timezone
+++ b/utils/ip-timezone/files/99-ip-timezone
@@ -1,0 +1,58 @@
+#!/bin/sh
+
+if [ "${INTERFACE}" = "loopback" ]; then
+    exit 0
+fi
+if [ "${ACTION}" != "ifup" ] && [ "${ACTION}" != "ifupdate" ]; then
+    exit 0
+fi
+if [ "${ACTION}" = "ifupdate" ] && [ -z "${IFUPDATE_ADDRESSES}" ] && [ -z "${IFUPDATE_DATA}" ]; then
+    exit 0
+fi
+
+log() {
+    logger -t "ip-timezone" "$@"
+}
+
+log_info() {
+    log -p user.info "$*"
+}
+
+log_error() {
+    log -p user.err "$*"
+}
+
+get_posix_timezone() {
+    iana_timezone=$1
+    tail -n1 /usr/share/zoneinfo/${iana_timezone}
+}
+
+endpoint="$(uci -q get ip-timezone.config.endpoint)"
+if [ $? -ne 0 ]; then
+    log_error "Endpoint not set"
+    exit 1
+fi
+
+for i in {1..5}; do
+    timezone_iana="$(wget --timeout=5 -qO- "${endpoint}")" && break || sleep 1
+done
+
+if [ -z "${timezone_iana}" ]; then
+    log_error "Failed to get timezone"
+    exit 1
+fi
+
+timezone_posix="$(get_posix_timezone ${timezone_iana})"
+if [ $? -ne 0 ]; then
+    log_error "Invalid timezone"
+    exit 1
+fi
+
+if [ "${timezone_iana}" != "$(uci get system.@system[0].zonename)" ] || [  "${timezone_posix}" != "$(uci get system.@system[0].timezone)" ]; then
+    log_info "Updating timezone, IANA: ${timezone_iana}, POSIX: ${timezone_posix}"
+    uci set system.@system[0].zonename="${timezone_iana}"
+    uci set system.@system[0].timezone="${timezone_posix}"
+    uci commit system
+    /etc/init.d/system reload
+    /etc/init.d/cron restart
+fi

--- a/utils/ip-timezone/files/ip-timezone.config
+++ b/utils/ip-timezone/files/ip-timezone.config
@@ -1,0 +1,1 @@
+config ip-timezone 'config'


### PR DESCRIPTION
Hotplug script to automatically configure the timezone UCI settings based on the IP address.

The user needs to set their own endpoint to get the IANA timezone string, e.g.:
  uci set ip-timezone.config.endpoint=https://domain.tld/json

## 📦 Package Details

**Maintainer:** @<github-user>
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [ ] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
