### PR TITLE
opengnb: add opengnb 1.6.8 to openwrt

### DIFF
--- a/net/opengnb/Makefile
+++ b/net/opengnb/Makefile
@@ -1,0 +1,54 @@
+#
+# Copyright 2026 Charles Chan <hollidgelongsun157@gmail.com>
+#
+# This is free software, licensed under the GNU General Public License v3.0-or-later
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=opengnb
+PKG_VERSION:=1.6.8
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://github.com/opengnb/opengnb/releases/download/$(PKG_VERSION)/
+PKG_HASH:=4c6a603080efa79457b889e43e87c1a3a070e7cf7cd7621d1a106a06a161f829
+
+PKG_MAINTAINER:=Charles Chan <hollidgelongsun157@gmail.com>
+PKG_LICENSE:=GPL-3.0-or-later
+PKG_LICENSE_FILES:=LICENSE
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/opengnb
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=VPN
+  TITLE:=OpenGNB - P2P Decentralized Virtual Network
+  URL:=https://github.com/opengnb/opengnb
+  DEPENDS:=+kmod-tun +libpthread +zlib
+endef
+
+define Package/opengnb/description
+  OpenGNB is an open source P2P decentralized Software Defined Virtual Network
+  with extreme intranet penetration capability.
+endef
+
+define Build/Compile
+	$(MAKE) -C $(PKG_BUILD_DIR) \
+		$(TARGET_CONFIGURE_OPTS) \
+		CFLAGS="$(TARGET_CFLAGS) $(TARGET_CPPFLAGS)" \
+		LDFLAGS="$(TARGET_LDFLAGS)" \
+		-f Makefile.openwrt
+endef
+
+define Package/opengnb/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/gnb        $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/gnb_ctl    $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/gnb_crypto $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/gnb_es     $(1)/usr/sbin/
+endef
+
+$(eval $(call BuildPackage,opengnb))


### PR DESCRIPTION
Update opengnb package to the latest version 1.6.8.

## 📦 Package Details

PKG_MAINTAINER:= Charles Chan [hollidgelongsun157@gmail.com](mailto:hollidgelongsun157@gmail.com)
opengnb: add version 1.6.8 to openwrt

Description:
OpenGNB is an open source P2P decentralized Software Defined Virtual Network with extreme intranet penetration capability,Allows you to combine your company-home network into a direct-access LAN.

All code related to the GNB project is released as open source, and the currently released source code supports the following platforms: FreeBSD Linux OpenWRT Raspberrypi OpenBSD macOS

GNB Features
Intranet penetration P2P VPN
No public IP required
Extreme link capability
Unlimited speed effects
Data Security
Reliable authentication between GNB nodes based on elliptic curve digital signature
Multi-platform support
GNB is developed in C language. It does not need to refer to third-party library files when compiling. It can be easily ported to the current popular operating systems. Currently supported operating systems and platforms include Linux_x86_64, Windows10_x86_64, macOS, FreeBSD_AMD64, OpenBSD_AMD64, Raspberry Pi, OpenWRT; as big as server environment, desktop system, as small as OpenWRT router with only 32M memory can run GNB network very well.

🧪 Run Testing Details
**OpenWrt Version:OpenWrt SNAPSHOT, r35007-9f385a71a7
**OpenWrt Target/Subtarget:x86/x86_64
**OpenWrt Device:intel NUC 11

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.