### PR TITLE
strongswan: fixes for the strongswan config generation

### DIFF
--- a/net/strongswan/Makefile
+++ b/net/strongswan/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=strongswan
 PKG_VERSION:=6.0.7
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://download.strongswan.org/ https://download2.strongswan.org/

--- a/net/strongswan/Makefile
+++ b/net/strongswan/Makefile
@@ -566,6 +566,11 @@ define Package/strongswan-swanctl/install
 	$(INSTALL_BIN) ./files/swanctl.init $(1)/etc/init.d/swanctl
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_CONF) ./files/ipsec.config $(1)/etc/config/ipsec
+
+	# Install migration from 'ipsec@ipsec[-1]' to 'ipsec.globals'
+	$(INSTALL_DIR) $(1)/etc/uci-defaults
+	$(INSTALL_DATA) ./files/etc/uci-defaults/strongswan \
+		$(1)/etc/uci-defaults/strongswan
 endef
 
 define Package/strongswan-gencerts/install

--- a/net/strongswan/files/etc/uci-defaults/strongswan
+++ b/net/strongswan/files/etc/uci-defaults/strongswan
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+main() {
+	# Skip migration if the 'globals' section already exists
+	uci show ipsec.globals 1>/dev/null 2>/dev/null
+	[ "$?" = "0" ] && return
+
+	# Rename last ipsec section to 'globals'
+	uci -q rename ipsec.@ipsec[-1]=globals
+	uci -q commit ipsec
+}
+
+main
+
+exit 0

--- a/net/strongswan/files/ipsec.config
+++ b/net/strongswan/files/ipsec.config
@@ -1,2 +1,7 @@
 # For strongSwan ipsec config documentation see
 # https://openwrt.org/docs/guide-user/services/vpn/strongswan/start
+
+# This is the 'globals' config section for the 'strongswan.conf' file.
+# For LuCI the section type ipsec should only appear once. It must therefore
+# always be present and should not be added or removed manually.
+config ipsec 'globals'

--- a/net/strongswan/files/swanctl.init
+++ b/net/strongswan/files/swanctl.init
@@ -739,10 +739,6 @@ prepare_env() {
 	do_postamble
 }
 
-service_running() {
-	swanctl --stats > /dev/null 2>&1
-}
-
 reload_service() {
 	running && {
 		prepare_env


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @pprindeville

I've made a few improvements and fixes to the config generation. See the descriptions in the individual commits for details


**Description:**
```
strongswan: use procd running check
    Instead of using the standard procd check, the function is overridden, and
    the check to see if the service is running is performed using the command
    'swanctl --stats > /dev/null 2>&1'. The problem with this is, that this
    call is blocking if the strongswan charon socket is not available. The call
    does not  return until the timeout has expired.
    This block does not occur if we use the standard behavior of procd, which
    checks whether the service it started is actually running. This change
    therefore uses the standard call via procd, which returns the value without
    blocking.
```
```

strongswan: add one default named ipsec uci section 'globals'
    The UCI section 'ipsec' should only be available once, as these are
    general settings for 'strongswan.conf'. It makes no sense to configure them
    more than once. To ensure that the general settings can also be configured
    via LuCI, this section must be present at least once.
```


---

## 🧪 Run Testing Details

- **OpenWrt Version: master**
- **OpenWrt Target/Subtarget: x86_64**
- **OpenWrt Device: APU3**

---

## ✅ Formalities

- [ x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

