### PR TITLE
swgp-go: add at 1.10.0

### DIFF
--- a/net/swgp-go/Makefile
+++ b/net/swgp-go/Makefile
@@ -1,0 +1,55 @@
+#
+# Copyright (C) 2026 Florian Klink
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=swgp-go
+PKG_VERSION:=1.10.0
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/database64128/swgp-go/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=0d7e5ebce9c07237e71028eac31b27c51d155c5a72eefc7bceac4cc816725d23
+
+PKG_MAINTAINER:=Florian Klink <flokli@flokli.de>
+PKG_LICENSE:=AGPL-3.0-or-later
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_DEPENDS:=golang/host
+PKG_BUILD_PARALLEL:=1
+PKG_BUILD_FLAGS:=no-mips16
+
+GO_PKG:=github.com/database64128/swgp-go
+GO_PKG_TAGS:=swgpgo_nopprof
+
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/golang/golang-package.mk
+
+define Package/swgp-go
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=Simple WireGuard proxy
+  URL:=https://github.com/database64128/swgp-go
+  DEPENDS:=$(GO_ARCH_DEPENDS)
+endef
+
+define Package/swgp-go/description
+  Simple WireGuard proxy with minimal overhead for WireGuard traffic.
+endef
+
+define Package/swgp-go/conffiles
+/etc/swgp-go.json
+endef
+
+define Package/swgp-go/install
+	$(INSTALL_DIR) $(1)/usr/sbin $(1)/etc/init.d
+	$(INSTALL_BIN) $(GO_PKG_BUILD_BIN_DIR)/swgp-go $(1)/usr/sbin
+	$(INSTALL_BIN) ./files/swgp-go.init $(1)/etc/init.d/swgp-go
+	$(INSTALL_DATA) ./files/swgp-go.json $(1)/etc/swgp-go.json
+endef
+
+$(eval $(call BuildPackage,swgp-go))

--- a/net/swgp-go/README.md
+++ b/net/swgp-go/README.md
@@ -1,0 +1,20 @@
+# swgp-go
+This readme should help you configure swgp-go.
+
+## Configuration
+Edit `/etc/swgp-go.json` with your desired configuration (Client, Server or both).
+
+If you're configuring a server, also properly allow that port in your firewall.
+
+Note the pprof feature is disabled in this package. If you try to enable it
+regardless, `swgp-go` will show an error on startup.
+
+## Start daemon
+Once you have created your config, enable and run swgp-go using its init script:
+
+```
+/etc/init.d/swgp-go enable
+/etc/init.d/swgp-go start
+```
+
+Please refer to the [Project README](https://github.com/database64128/swgp-go) for more configuration info and examples.

--- a/net/swgp-go/files/swgp-go.init
+++ b/net/swgp-go/files/swgp-go.init
@@ -1,0 +1,19 @@
+#!/bin/sh /etc/rc.common
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
+USE_PROCD=1
+START=90
+
+SWGP_GO_BIN="/usr/sbin/swgp-go"
+SWGP_GO_CONF="/etc/swgp-go.json"
+
+start_service() {
+  procd_open_instance
+  procd_set_param command $SWGP_GO_BIN -confPath $SWGP_GO_CONF -logLevel DEBUG
+  procd_set_param file "$SWGP_GO_CONF"
+  procd_set_param stdout 1
+  procd_set_param stderr 1
+  procd_set_param respawn
+  procd_close_instance
+}

--- a/net/swgp-go/files/swgp-go.json
+++ b/net/swgp-go/files/swgp-go.json
@@ -1,0 +1,4 @@
+{
+  "servers": [],
+  "clients": []
+}

--- a/net/swgp-go/test.sh
+++ b/net/swgp-go/test.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+swgp-go -version 2>&1
+swgp-go -version 2>&1 | grep "$2"
+[ $? == 0 ] || {
+	echo "Problem or incorrect version for '$1'"
+	exit 1
+}


### PR DESCRIPTION
Compiled on x86_64-linux, successfully tested on mediatek/filogic, 25.12.5.

## 📦 Package Details

**Maintainer:** @flokli (me)

**Description:**
This acts as a proxy for wireguard connections, providing some levels of obfuscation on top.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12.5
- **OpenWrt Target/Subtarget:** mediatek/filogik
- **OpenWrt Device:** glinet_gl-mt6000
---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
