### PR TITLE
ddns-scripts: add EuroDNS provider

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.3
-PKG_RELEASE:=7
+PKG_RELEASE:=8
 
 PKG_LICENSE:=GPL-2.0
 

--- a/net/ddns-scripts/files/usr/share/ddns/default/eurodns.com.json
+++ b/net/ddns-scripts/files/usr/share/ddns/default/eurodns.com.json
@@ -1,0 +1,11 @@
+{
+	"name": "eurodns.com",
+	"ipv4": {
+		"url": "https://[USERNAME]:[PASSWORD]@update.eurodyndns.org/update/?hostname=[DOMAIN]&myip=[IP]",
+		"answer": "good|nochg"
+	},
+	"ipv6": {
+		"url": "https://[USERNAME]:[PASSWORD]@update.eurodyndns.org/update/?hostname=[DOMAIN]&myip=[IP]",
+		"answer": "good|nochg"
+	}
+}

--- a/net/ddns-scripts/files/usr/share/ddns/list
+++ b/net/ddns-scripts/files/usr/share/ddns/list
@@ -33,6 +33,7 @@ dyndns.org
 dynu.com
 dynv6.com
 easydns.com
+eurodns.com
 goip.de
 google.com
 he.net


### PR DESCRIPTION
Add EuroDNS provider for IPv4 and IPv6

Howto:

    set [USERNAME] to username
    set [PASSWORD] to password
    set [DOMAIN] to domain

https://help.eurodns.com/s/article/How-do-I-configure-DYNDNS?language=en_US

## 📦 Package Details

**Maintainer:** @feckert 

**Description:**

Adds eurodns.com support in ddns-scripts

---

## 🧪 Run Testing Details

OpenWrt 24.10.5 r29087-d9c5716d1d / LuCI openwrt-24.10 branch 25.340.26705~d88390b
OpenWrt One

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
