### PR TITLE
podman: update to 5.8.4

### DIFF
--- a/utils/podman/Makefile
+++ b/utils/podman/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=podman
-PKG_VERSION:=5.8.3
+PKG_VERSION:=5.8.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://github.com/containers/podman/archive/v$(PKG_VERSION)
-PKG_HASH:=c54a2ec4b4fb5577288992aaa78684397ec3552fb2d1234d910ec50097d05c0f
+PKG_SOURCE_URL:=https://github.com/podman-container-tools/podman/archive/v$(PKG_VERSION)
+PKG_HASH:=be01c20923ed7642a5ad039f83252e3b7d09f0e3431d01284a5beff6c123671c
 
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
- fix PKG_SOURCE_URL The official Podman GitHub repository has recently been transferred from containers/podman to podman-container-tools/podman

## 📦 Package Details

**Maintainer:** Oskari Rauta [oskari.rauta@gmail.com](mailto:oskari.rauta@gmail.com)

**Description:** Update Podman to v5.8.4.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** OpenWrt 25.12-SNAPSHOT
- **OpenWrt Target/Subtarget:** X86-64
- **OpenWrt Device:** CncTion Tiger Lake-6L

---

## ✅ Formalities

- [ √ ] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
