### PR TITLE
nut: enable SSL via NSS by default

### DIFF
--- a/net/nut/Config.in
+++ b/net/nut/Config.in
@@ -1,22 +1,32 @@
 	config NUT_SSL
-		depends on PACKAGE_nut
+		depends on PACKAGE_nut && !NUT_SSL_NSS
 		bool "Build with support for OpenSSL"
 		help
 			SSL allows sessions between upsd and clients to be encrypted and can
 			also be used to authenticate servers. This means that stealing port
 			3493 from upsd will no longer net you interesting passwords. SSL is
-			available via OpenSSL on OpenWRT (NSS doesn't seem to work). If you
-			are happy with using passwords to authenticate clients, you can save
-			some space and build NUT without SSL support.
+			available via OpenSSL on OpenWrt. If you are happy with using passwords
+			to authenticate clients, you can save some space and build NUT without
+			SSL support. Defaults to n due to licensing (NUT is GPL with no OpenSSL
+			exception).
 		default n
-	
+
+	config NUT_SSL_NSS
+		depends on PACKAGE_nut
+		bool "Build with support for NSS for SSL"
+		help
+			SSL allows sessions between upsd and clients to be encrypted and can
+			also be used to authenticate servers. This means that stealing port
+			3493 from upsd will no longer net you interesting passwords.
+		default y
+
 	config NUT_DRIVER_USB
 		depends on PACKAGE_nut
 		bool "Build with support for USB drivers"
 		help
 			If you have a UPS connected via USB, select this.
 		default y
-	
+
 	config NUT_DRIVER_SNMP
 		depends on PACKAGE_nut
 		bool "Build with support for SNMP drivers"
@@ -31,9 +41,9 @@
 			If you have a UPS connected via serial cable, select this.
 		default y
 
-        config NUT_DRIVER_NEON
-                depends on PACKAGE_nut
-                bool "Build with support for netxml drivers"
-                help
-                        If you have a UPS connected via netxml, select this.
-                default y
+	config NUT_DRIVER_NEON
+		depends on PACKAGE_nut
+		bool "Build with support for netxml drivers"
+		help
+			If you have a UPS connected via netxml, select this.
+		default y

--- a/net/nut/Config.in
+++ b/net/nut/Config.in
@@ -20,6 +20,14 @@
 			3493 from upsd will no longer net you interesting passwords.
 		default y
 
+	config NUT_SSL_CERTVERIFY
+		depends on PACKAGE_nut && (NUT_SSL || NUT_SSL_NSS)
+		bool "Build with support for certificate verification when using SSL"
+		help
+			When using SSL, enables configuration options for verification of peer's
+			certificate before connecting to the peer.
+		default y
+
 	config NUT_DRIVER_USB
 		depends on PACKAGE_nut
 		bool "Build with support for USB drivers"

--- a/net/nut/Makefile
+++ b/net/nut/Makefile
@@ -27,6 +27,7 @@ PKG_CONFIG_DEPENDS:= \
 	CONFIG_NUT_DRIVER_USB \
 	CONFIG_NUT_DRIVER_SERIAL \
 	CONFIG_NUT_DRIVER_NEON \
+	CONFIG_NUT_SSL_NSS \
 	CONFIG_NUT_SSL \
 	CONFIG_PACKAGE_nut-web-cgi
 
@@ -105,7 +106,8 @@ define Package/nut-common
 		+NUT_DRIVER_SNMP:libnetsnmp \
 		+NUT_DRIVER_USB:libusb-compat \
 		+NUT_DRIVER_NEON:libneon \
-		+NUT_SSL:libopenssl
+		+NUT_SSL:libopenssl \
+		+NUT_SSL_NSS:libnss
 endef
 
 define Package/nut-common/description
@@ -152,9 +154,9 @@ endef
 
 define Package/nut-upsmon
   $(call Package/nut/Default)
-	TITLE+= (monitor)
-	DEPENDS:=nut +nut-common
-	USERID:=nutmon=114:nutmon=114
+  TITLE+= (monitor)
+  DEPENDS:=nut +nut-common
+  USERID:=nutmon=114:nutmon=114
 endef
 
 define Package/nut-upsmon/description
@@ -571,11 +573,16 @@ $(eval $(call DriverDescription,usb,nutdrv_atcl_usb,\
 $(eval $(call DriverDescription,usb,nutdrv_qx,\
 	Driver for Q* protocol serial and USB based UPS equipment))
 $(eval $(call DriverDescription,neon,netxml-ups,\
-        Driver for NetXML based UPS equipment))
+	Driver for NetXML based UPS equipment))
 
 CONFIGURE_VARS += \
 	ac_cv_path_AR=$(TARGET_AR)
 
+# as flagged by Qwen 3.6 27B, --without-ssl also disables NSS so only use it
+# to disable all SSL backends. This can be verified in the applicable
+# upstream code which disables _all_ ssl when --with-ssl=no or the equivalent
+# --without-ssl is used. See:
+# https://github.com/networkupstools/nut/blob/26177060be94a738bf2d612441af264c90ac37a9/configure.ac#L2930
 CONFIGURE_ARGS += \
 	--sysconfdir=/etc \
 	--with-confdir-suffix=/nut \
@@ -586,7 +593,7 @@ CONFIGURE_ARGS += \
 	--$(if $(CONFIG_NUT_DRIVER_SNMP),with,without)-snmp \
 	--$(if $(CONFIG_NUT_DRIVER_SERIAL),with,without)-serial \
 	--without-doc \
-        --$(if $(CONFIG_NUT_DRIVER_NEON),with,without)-neon \
+	--$(if $(CONFIG_NUT_DRIVER_NEON),with,without)-neon \
 	--without-powerman \
 	--without-wrap \
 	--with-hotplug-dir=/etc/hotplug \
@@ -594,7 +601,9 @@ CONFIGURE_ARGS += \
 	--without-ipmi \
 	--without-freeipmi \
 	--without-linux-i2c \
-	--$(if $(CONFIG_NUT_SSL),with,without)-ssl $(if $(CONFIG_NUT_SSL),--with-openssl) \
+	$(if $(CONFIG_NUT_SSL),--with-ssl=openssl) \
+	$(if $(CONFIG_NUT_SSL_NSS),--with-ssl=nss,--without-nss) \
+	$(if $(CONFIG_NUT_SSL),,$(if $(CONFIG_NUT_SSL_NSS),,--without-ssl)) \
 	--without-libltdl \
 	--enable-docs-changelog=no \
 	--without-macosx_ups \

--- a/net/nut/Makefile
+++ b/net/nut/Makefile
@@ -611,8 +611,7 @@ CONFIGURE_VARS += \
 # --without-ssl is used. See:
 # https://github.com/networkupstools/nut/blob/26177060be94a738bf2d612441af264c90ac37a9/configure.ac#L2930
 CONFIGURE_ARGS += \
-  --sysconfdir=/etc \
-  --with-confdir-suffix=/nut \
+  --with-confdir=/etc/nut \
   --datadir=/usr/share/nut \
   --with-dev \
   --$(if $(CONFIG_NUT_DRIVER_USB),with,without)-usb \

--- a/net/nut/Makefile
+++ b/net/nut/Makefile
@@ -123,10 +123,15 @@ define Package/nut-common/install
 	$(INSTALL_DIR) $(1)/etc/nut
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(INSTALL_DIR) $(1)/lib/functions/nut
+	$(INSTALL_DIR) $(1)/usr/share/nut
 	$(INSTALL_DATA) ./files/nut-common.sh.functions $(1)/lib/functions/nut/nut-common.sh
 	$(INSTALL_DATA) ./files/nut-service.sh.functions $(1)/lib/functions/nut/nut-service.sh
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libupsclient.so* $(1)/usr/lib/
 	ln -sf /var/etc/nut/nut.conf $(1)/etc/nut/nut.conf
+	$(if $(CONFIG_NUT_SSL),printf "%s" "openssl" >$(PKG_BUILD_DIR)/ssl_backend)
+	$(if $(CONFIG_NUT_SSL_NSS),printf "%s" "nss" >$(PKG_BUILD_DIR)/ssl_backend)
+	$(if $(CONFIG_NUT_SSL)$(CONFIG_NUT_SSL_NSS),,printf "%s" "none" >$(PKG_BUILD_DIR)/ssl_backend)
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/ssl_backend $(1)/usr/share/nut/ssl_backend
 endef
 
 define Package/nut-server

--- a/net/nut/Makefile
+++ b/net/nut/Makefile
@@ -23,13 +23,14 @@ PKG_MAINTAINER:=Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>
 PKG_INSTALL:=1
 
 PKG_CONFIG_DEPENDS:= \
+  CONFIG_PACKAGE_nut-web-cgi \
+  CONFIG_NUT_DRIVER_NEON \
+  CONFIG_NUT_DRIVER_SERIAL \
   CONFIG_NUT_DRIVER_SNMP \
   CONFIG_NUT_DRIVER_USB \
-  CONFIG_NUT_DRIVER_SERIAL \
-  CONFIG_NUT_DRIVER_NEON \
-  CONFIG_NUT_SSL_NSS \
   CONFIG_NUT_SSL \
-  CONFIG_PACKAGE_nut-web-cgi
+  CONFIG_NUT_SSL_CERTVERIFY \
+  CONFIG_NUT_SSL_NSS
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -609,6 +610,7 @@ CONFIGURE_ARGS += \
   $(if $(CONFIG_NUT_SSL),--with-ssl=openssl) \
   $(if $(CONFIG_NUT_SSL_NSS),--with-ssl=nss,--without-nss) \
   $(if $(CONFIG_NUT_SSL),,$(if $(CONFIG_NUT_SSL_NSS),,--without-ssl)) \
+  $(if $(CONFIG_NUT_SSL)$(CONFIG_NUT_SSL_NSS),$(if $(CONFIG_NUT_SSL_CERTVERIFY),--with-ssl-client-validation,--without-ssl-client-validation)) \
   --without-libltdl \
   --enable-docs-changelog=no \
   --without-macosx_ups \

--- a/net/nut/Makefile
+++ b/net/nut/Makefile
@@ -165,12 +165,6 @@ define Package/nut-server/conffiles
 /etc/nut/ups.conf
 endef
 
-define Package/nut-server/postinst
-#!/bin/sh
-[ -n "$${IPKG_INSTROOT}" ] || (. /etc/uci-defaults/90_nut-server) && rm -f /etc/uci-defaults/90_nut-server
-exit 0
-endef
-
 define Package/nut-upsmon
   $(call Package/nut/Default)
   TITLE+= (monitor)
@@ -192,12 +186,6 @@ endef
 define Package/nut-upsmon/conffiles
 /etc/config/nut_monitor
 /etc/nut/upsmon.conf
-endef
-
-define Package/nut-upsmon/postinst
-#!/bin/sh
-[ -n "$${IPKG_INSTROOT}" ] || (. /etc/uci-defaults/90_nut-upsmon) && rm -f /etc/uci-defaults/90_nut-upsmon
-exit 0
 endef
 
 define Package/nut-upsmon/install

--- a/net/nut/Makefile
+++ b/net/nut/Makefile
@@ -23,21 +23,21 @@ PKG_MAINTAINER:=Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>
 PKG_INSTALL:=1
 
 PKG_CONFIG_DEPENDS:= \
-	CONFIG_NUT_DRIVER_SNMP \
-	CONFIG_NUT_DRIVER_USB \
-	CONFIG_NUT_DRIVER_SERIAL \
-	CONFIG_NUT_DRIVER_NEON \
-	CONFIG_NUT_SSL_NSS \
-	CONFIG_NUT_SSL \
-	CONFIG_PACKAGE_nut-web-cgi
+  CONFIG_NUT_DRIVER_SNMP \
+  CONFIG_NUT_DRIVER_USB \
+  CONFIG_NUT_DRIVER_SERIAL \
+  CONFIG_NUT_DRIVER_NEON \
+  CONFIG_NUT_SSL_NSS \
+  CONFIG_NUT_SSL \
+  CONFIG_PACKAGE_nut-web-cgi
 
 include $(INCLUDE_DIR)/package.mk
 
 define Package/nut/Default
-	SECTION:=net
-	CATEGORY:=Network
-	URL:=https://networkupstools.org/
-	TITLE:=Network UPS Tools (NUT)
+  SECTION:=net
+  CATEGORY:=Network
+  URL:=https://networkupstools.org/
+  TITLE:=Network UPS Tools (NUT)
 endef
 
 define Package/nut/description/Default
@@ -49,8 +49,8 @@ changes.
 endef
 
 define Package/nut
-	$(call Package/nut/Default)
-	MENU:=1
+  $(call Package/nut/Default)
+  MENU:=1
 endef
 
 define Package/nut/description
@@ -58,7 +58,7 @@ $(call Package/nut/description/Default)
 endef
 
 define Package/nut/config
-	source "$(SOURCE)/Config.in"
+  source "$(SOURCE)/Config.in"
 endef
 
 define Package/nut/install
@@ -100,14 +100,14 @@ define Package/nut-server/install
 endef
 
 define Package/nut-common
-	$(call Package/nut/Default)
-	TITLE+= (common)
-	DEPENDS:= nut \
-		+NUT_DRIVER_SNMP:libnetsnmp \
-		+NUT_DRIVER_USB:libusb-compat \
-		+NUT_DRIVER_NEON:libneon \
-		+NUT_SSL:libopenssl \
-		+NUT_SSL_NSS:libnss
+  $(call Package/nut/Default)
+  TITLE+= (common)
+  DEPENDS:=nut \
+    +NUT_DRIVER_SNMP:libnetsnmp \
+    +NUT_DRIVER_USB:libusb-compat \
+    +NUT_DRIVER_NEON:libneon \
+    +NUT_SSL:libopenssl \
+    +NUT_SSL_NSS:libnss
 endef
 
 define Package/nut-common/description
@@ -130,10 +130,10 @@ define Package/nut-common/install
 endef
 
 define Package/nut-server
-	$(call Package/nut/Default)
-	TITLE+= (server)
-	DEPENDS:=nut +nut-common
-	USERID:=nut=113:nut=113
+  $(call Package/nut/Default)
+  TITLE+= (server)
+  DEPENDS:=nut +nut-common
+  USERID:=nut=113:nut=113
 endef
 
 define Package/nut-server/description
@@ -196,10 +196,10 @@ define Package/nut-upsmon/conffiles
 endef
 
 define Package/nut-upsmon-sendmail-notify
-	$(call Package/nut/Default)
-	TITLE+= (upsmon with notifications via sendmail)
-	DEPENDS:=nut +nut-upsmon
-	CONFLICTS:=nut-upssched
+  $(call Package/nut/Default)
+  TITLE+= (upsmon with notifications via sendmail)
+  DEPENDS:=nut +nut-upsmon
+  CONFLICTS:=nut-upssched
 endef
 
 define Package/nut-upsmon-sendmail-notify/description
@@ -215,9 +215,9 @@ define Package/nut-upsmon-sendmail-notify/install
 endef
 
 define Package/nut-upsc
-	$(call Package/nut/Default)
-	TITLE+= (upsc command)
-	DEPENDS:=nut +nut-common
+  $(call Package/nut/Default)
+  TITLE+= (upsc command)
+  DEPENDS:=nut +nut-common
 endef
 
 define Package/nut-upsc/description
@@ -233,9 +233,9 @@ define Package/nut-upsc/install
 endef
 
 define Package/nut-upslog
-	$(call Package/nut/Default)
-	TITLE+= (logging client)
-	DEPENDS:=nut +nut-common
+  $(call Package/nut/Default)
+  TITLE+= (logging client)
+  DEPENDS:=nut +nut-common
 endef
 
 define Package/nut-upslog/description
@@ -250,9 +250,9 @@ define Package/nut-upslog/install
 endef
 
 define Package/nut-upscmd
-	$(call Package/nut/Default)
-	TITLE+= (controller)
-	DEPENDS:=nut +nut-common
+  $(call Package/nut/Default)
+  TITLE+= (controller)
+  DEPENDS:=nut +nut-common
 endef
 
 define Package/nut-upscmd/description
@@ -270,9 +270,9 @@ define Package/nut-upscmd/install
 endef
 
 define Package/nut-upsrw
-	$(call Package/nut/Default)
-	TITLE+= (variable editor)
-	DEPENDS:=nut +nut-common
+  $(call Package/nut/Default)
+  TITLE+= (variable editor)
+  DEPENDS:=nut +nut-common
 endef
 
 define Package/nut-upsrw/description
@@ -291,9 +291,9 @@ define Package/nut-upsrw/install
 endef
 
 define Package/nut-upssched
-	$(call Package/nut/Default)
-	TITLE+= (helper for triggering events from upsmon)
-	DEPENDS:=nut +nut-common +nut-upsmon
+  $(call Package/nut/Default)
+  TITLE+= (helper for triggering events from upsmon)
+  DEPENDS:=nut +nut-common +nut-upsmon
 endef
 
 define Package/nut-upssched/description
@@ -326,9 +326,9 @@ define Package/nut-upssched/conffiles
 endef
 
 define Package/nut-web-cgi
-	$(call Package/nut/Default)
-	TITLE+= Web CGI interface
-	DEPENDS:=nut +nut-common +PACKAGE_nut-web-cgi:libgd
+  $(call Package/nut/Default)
+  TITLE+= Web CGI interface
+  DEPENDS:=nut +nut-common +PACKAGE_nut-web-cgi:libgd
 endef
 
 define Package/nut-web-cgi/description
@@ -365,9 +365,9 @@ define Package/nut-web-cgi/install
 endef
 
 define Package/nut-avahi-service
-	$(call Package/nut/Default)
-	TITLE+= (Avahi service)
-	DEPENDS:=nut +avahi-daemon
+  $(call Package/nut/Default)
+  TITLE+= (Avahi service)
+  DEPENDS:=nut +avahi-daemon
 endef
 
 define Package/nut-avahi-service/description
@@ -388,18 +388,18 @@ endef
 # maintainer had a neat solution which just needed some tweaking.
 define DriverPackage
         define Package/nut-driver-$(2)
-		$(call Package/nut/Default)
-		TITLE:=$(2) (NUT $(1) driver)
-		DEPENDS:=nut +nut-server
-		$(if $(filter $(1),snmp),DEPENDS+= @NUT_DRIVER_SNMP)
-		$(if $(filter $(1),usb),DEPENDS+= @NUT_DRIVER_USB)
-		$(if $(filter $(1),serial),DEPENDS+= @NUT_DRIVER_SERIAL)
-		$(if $(filter $(1),neon),DEPENDS+= @NUT_DRIVER_NEON)
+          $(call Package/nut/Default)
+          TITLE:=$(2) (NUT $(1) driver)
+          DEPENDS:=nut +nut-server
+          $(if $(filter $(1),snmp),DEPENDS+= @NUT_DRIVER_SNMP)
+          $(if $(filter $(1),usb),DEPENDS+= @NUT_DRIVER_USB)
+          $(if $(filter $(1),serial),DEPENDS+= @NUT_DRIVER_SERIAL)
+          $(if $(filter $(1),neon),DEPENDS+= @NUT_DRIVER_NEON)
         endef
-	# Deliberately empty description in order to trigger a build failure.
-	# It should be overridden by the list below, and when updating to a
-	# new version of nut we will need to provide descriptions for any new
-	# drivers.
+        # Deliberately empty description in order to trigger a build failure.
+        # It should be overridden by the list below, and when updating to a
+        # new version of nut we will need to provide descriptions for any new
+        # drivers.
         define Package/nut-driver-$(2)/description
 
         endef
@@ -411,7 +411,7 @@ define DriverPackage
 endef
 define DriverDescription
         define Package/nut-driver-$(2)/description
-		$(3)
+        $(3)
         endef
 endef
 # These lists are lifted *directly* from drivers/Makefile.am in the nut
@@ -453,130 +453,130 @@ $(foreach d,$(USB_LIBUSB_DRIVERLIST),$(eval $(call DriverPackage,usb,$(d))))
 $(foreach d,$(NEONXML_DRIVERLIST),$(eval $(call DriverPackage,neon,$(d))))
 
 $(eval $(call DriverDescription,software,dummy-ups,\
-	Driver for multi-purpose UPS emulation))
+  Driver for multi-purpose UPS emulation))
 $(eval $(call DriverDescription,software,clone,\
-	UPS driver clone))
+  UPS driver clone))
 $(eval $(call DriverDescription,software,failover,\
-	UPS Failover Driver))
+  UPS Failover Driver))
 $(eval $(call DriverDescription,software,apcupsd-ups,\
-	Driver for apcupsd client access))
+  Driver for apcupsd client access))
 $(eval $(call DriverDescription,serial,al175,\
-	Driver for Eltek UPS models with AL175 alarm module))
+  Driver for Eltek UPS models with AL175 alarm module))
 $(eval $(call DriverDescription,serial,bcmxcp,\
-	Driver for UPSes supporting the serial BCM/XCP protocol))
+  Driver for UPSes supporting the serial BCM/XCP protocol))
 $(eval $(call DriverDescription,serial,belkin,\
-	Driver for Belkin serial UPS equipment))
+  Driver for Belkin serial UPS equipment))
 $(eval $(call DriverDescription,serial,belkinunv,\
-	Driver for Belkin "Universal UPS" and compatible))
+  Driver for Belkin "Universal UPS" and compatible))
 $(eval $(call DriverDescription,serial,bestfcom,\
-	Driver for Best Power Fortress/Ferrups))
+  Driver for Best Power Fortress/Ferrups))
 $(eval $(call DriverDescription,serial,bestfortress,\
-	Driver for old Best Fortress UPS equipment))
+  Driver for old Best Fortress UPS equipment))
 $(eval $(call DriverDescription,serial,bestuferrups,\
-	Driver for Best Power Micro-Ferrups))
+  Driver for Best Power Micro-Ferrups))
 $(eval $(call DriverDescription,serial,bestups,\
-	Driver for Best Power / SOLA (Phoenixtec protocol) UPS equipment))
+  Driver for Best Power / SOLA (Phoenixtec protocol) UPS equipment))
 $(eval $(call DriverDescription,serial,etapro,\
-	Driver for ETA UPS equipment))
+  Driver for ETA UPS equipment))
 $(eval $(call DriverDescription,serial,everups,\
-	Driver for Ever UPS models))
+  Driver for Ever UPS models))
 $(eval $(call DriverDescription,serial,gamatronic,\
-	Driver for Gamatronic UPS equipment))
+  Driver for Gamatronic UPS equipment))
 $(eval $(call DriverDescription,serial,genericups,\
-	Driver for contact-closure UPS equipment))
+  Driver for contact-closure UPS equipment))
 $(eval $(call DriverDescription,serial,isbmex,\
-	Driver for ISBMEX UPS equipment))
+  Driver for ISBMEX UPS equipment))
 $(eval $(call DriverDescription,serial,liebert,\
-	Driver for Liebert contact-closure UPS equipment))
+  Driver for Liebert contact-closure UPS equipment))
 $(eval $(call DriverDescription,serial,liebert-esp2,\
-	Driver for Liebert UPS, using the ESP-II serial protocol))
+  Driver for Liebert UPS, using the ESP-II serial protocol))
 $(eval $(call DriverDescription,serial,liebert-gxe,\
-	Driver for Liebert GXE series UPS, using the YDN23 serial protocol))
+  Driver for Liebert GXE series UPS, using the YDN23 serial protocol))
 $(eval $(call DriverDescription,serial,masterguard,\
-	Driver for Masterguard UPS equipment))
+  Driver for Masterguard UPS equipment))
 $(eval $(call DriverDescription,serial,metasys,\
-	Driver for Meta System UPS equipment))
+  Driver for Meta System UPS equipment))
 $(eval $(call DriverDescription,serial,mge-utalk,\
-	Driver for MGE UPS SYSTEMS UTalk protocol equipment))
+  Driver for MGE UPS SYSTEMS UTalk protocol equipment))
 $(eval $(call DriverDescription,serial,microdowell,\
-	Driver for Microdowell Enterprise UPS series))
+  Driver for Microdowell Enterprise UPS series))
 $(eval $(call DriverDescription,serial,microsol-apc,\
-	Driver for APC Back-UPS BR UPS equipment))
+  Driver for APC Back-UPS BR UPS equipment))
 $(eval $(call DriverDescription,serial,mge-shut,\
-	Driver for SHUT Protocol UPS equipment))
+  Driver for SHUT Protocol UPS equipment))
 $(eval $(call DriverDescription,serial,nutdrv_hashx,\
-	Driver for #* protocol serial based UPS equipment))
+  Driver for #* protocol serial based UPS equipment))
 $(eval $(call DriverDescription,serial,oneac,\
-	Driver for Oneac UPS equipment))
+  Driver for Oneac UPS equipment))
 $(eval $(call DriverDescription,serial,optiups,\
-	Driver for Opti-UPS (Viewsonic) UPS and Zinto D (ONLINE-USV) equipment))
+  Driver for Opti-UPS (Viewsonic) UPS and Zinto D (ONLINE-USV) equipment))
 $(eval $(call DriverDescription,serial,powercom,\
-	Driver for serial Powercom/Trust/Advice UPS equipment))
+  Driver for serial Powercom/Trust/Advice UPS equipment))
 $(eval $(call DriverDescription,serial,powervar_cx_ser,\
-	Driver for Powervar UPM Series UPS equipment with Serial connection))
+  Driver for Powervar UPM Series UPS equipment with Serial connection))
 $(eval $(call DriverDescription,serial,rhino,\
-	Driver for Brazilian Microsol RHINO UPS equipment))
+  Driver for Brazilian Microsol RHINO UPS equipment))
 $(eval $(call DriverDescription,serial,safenet,\
-	Driver for SafeNet compatible UPS equipment))
+  Driver for SafeNet compatible UPS equipment))
 $(eval $(call DriverDescription,serial,nutdrv_siemens-sitop,\
-	Driver for the Siemens SITOP UPS500 series UPS))
+  Driver for the Siemens SITOP UPS500 series UPS))
 $(eval $(call DriverDescription,serial,solis,\
-	Driver for Brazilian Microsol SOLIS UPS equipment))
+  Driver for Brazilian Microsol SOLIS UPS equipment))
 $(eval $(call DriverDescription,serial,tripplite,\
-	Driver for Tripp-Lite SmartPro UPS equipment))
+  Driver for Tripp-Lite SmartPro UPS equipment))
 $(eval $(call DriverDescription,serial,tripplitesu,\
-	Driver for Tripp-Lite SmartOnline (SU) UPS equipment))
+  Driver for Tripp-Lite SmartOnline (SU) UPS equipment))
 $(eval $(call DriverDescription,serial,upscode2,\
-	Driver for UPScode II compatible UPS equipment))
+  Driver for UPScode II compatible UPS equipment))
 $(eval $(call DriverDescription,serial,victronups,\
-	Driver for IMV/Victron UPS unit Match, Match Lite, NetUps))
+  Driver for IMV/Victron UPS unit Match, Match Lite, NetUps))
 $(eval $(call DriverDescription,serial,powerpanel,\
-	Driver for PowerPanel Plus compatible UPS equipment))
+  Driver for PowerPanel Plus compatible UPS equipment))
 $(eval $(call DriverDescription,serial,blazer_ser,\
-	Driver for Megatec/Q1 protocol serial based UPS equipment))
+  Driver for Megatec/Q1 protocol serial based UPS equipment))
 $(eval $(call DriverDescription,serial,ivtscd,\
-	Driver for the IVT Solar Controller Device))
+  Driver for the IVT Solar Controller Device))
 $(eval $(call DriverDescription,serial,apcsmart,\
-	Driver for American Power Conversion Smart Protocol UPS equipment))
+  Driver for American Power Conversion Smart Protocol UPS equipment))
 $(eval $(call DriverDescription,serial,apcsmart-old,\
-	Driver for American Power Conversion Smart Protocol UPS equipment))
+  Driver for American Power Conversion Smart Protocol UPS equipment))
 $(eval $(call DriverDescription,serial,riello_ser,\
-	Driver for Riello UPS Protocol UPS equipment))
+  Driver for Riello UPS Protocol UPS equipment))
 $(eval $(call DriverDescription,serial,sms_ser,\
-	Driver for SMS UPS Protocol 1Phase.))
+  Driver for SMS UPS Protocol 1Phase.))
 $(eval $(call DriverDescription,serial,bicker_ser,\
-	Driver for Bicker DC UPS via serial port connections))
+  Driver for Bicker DC UPS via serial port connections))
 $(eval $(call DriverDescription,serial,ve-direct,\
-	Driver for Victron UPS unit running on VE.Direct serial protocol))
+  Driver for Victron UPS unit running on VE.Direct serial protocol))
 $(eval $(call DriverDescription,serial,meanwell_ntu,\
-	Driver for Mean Well NTU series equipment with serial port))
+  Driver for Mean Well NTU series equipment with serial port))
 $(eval $(call DriverDescription,serial,nhs_ser,\
-	Driver for NHS Nobreaks - senoidal line - with serial port))
+  Driver for NHS Nobreaks - senoidal line - with serial port))
 $(eval $(call DriverDescription,snmp,snmp-ups,\
-	Multi-MIB Driver for SNMP UPS equipment))
+  Multi-MIB Driver for SNMP UPS equipment))
 $(eval $(call DriverDescription,usb,usbhid-ups,\
-	Driver for USB/HID UPS equipment))
+  Driver for USB/HID UPS equipment))
 $(eval $(call DriverDescription,usb,bcmxcp_usb,\
-	Experimental driver for UPSes supporting the BCM/XCP protocol over USB))
+  Experimental driver for UPSes supporting the BCM/XCP protocol over USB))
 $(eval $(call DriverDescription,usb,tripplite_usb,\
-	Driver for older Tripp Lite USB UPSes (not PDC HID)))
+  Driver for older Tripp Lite USB UPSes (not PDC HID)))
 $(eval $(call DriverDescription,usb,blazer_usb,\
-	Driver for Megatec/Q1 protocol USB based UPS equipment))
+  Driver for Megatec/Q1 protocol USB based UPS equipment))
 $(eval $(call DriverDescription,usb,richcomm_usb,\
-	Driver for UPS equipment using Richcomm dry-contact to USB solution))
+  Driver for UPS equipment using Richcomm dry-contact to USB solution))
 $(eval $(call DriverDescription,usb,riello_usb,\
-	Driver for Riello UPS Protocol UPS equipment via USB))
+  Driver for Riello UPS Protocol UPS equipment via USB))
 $(eval $(call DriverDescription,usb,powervar_cx_usb,\
-	Driver for Powervar GTS and UPM Series UPS equipment with USB connection))
+  Driver for Powervar GTS and UPM Series UPS equipment with USB connection))
 $(eval $(call DriverDescription,usb,nutdrv_atcl_usb,\
-	Driver for ATCL FOR UPS equipment))
+  Driver for ATCL FOR UPS equipment))
 $(eval $(call DriverDescription,usb,nutdrv_qx,\
-	Driver for Q* protocol serial and USB based UPS equipment))
+  Driver for Q* protocol serial and USB based UPS equipment))
 $(eval $(call DriverDescription,neon,netxml-ups,\
-	Driver for NetXML based UPS equipment))
+  Driver for NetXML based UPS equipment))
 
 CONFIGURE_VARS += \
-	ac_cv_path_AR=$(TARGET_AR)
+  ac_cv_path_AR=$(TARGET_AR)
 
 # as flagged by Qwen 3.6 27B, --without-ssl also disables NSS so only use it
 # to disable all SSL backends. This can be verified in the applicable
@@ -584,37 +584,37 @@ CONFIGURE_VARS += \
 # --without-ssl is used. See:
 # https://github.com/networkupstools/nut/blob/26177060be94a738bf2d612441af264c90ac37a9/configure.ac#L2930
 CONFIGURE_ARGS += \
-	--sysconfdir=/etc \
-	--with-confdir-suffix=/nut \
-	--datadir=/usr/share/nut \
-	--with-dev \
-	--$(if $(CONFIG_NUT_DRIVER_USB),with,without)-usb \
-	--without-avahi \
-	--$(if $(CONFIG_NUT_DRIVER_SNMP),with,without)-snmp \
-	--$(if $(CONFIG_NUT_DRIVER_SERIAL),with,without)-serial \
-	--without-doc \
-	--$(if $(CONFIG_NUT_DRIVER_NEON),with,without)-neon \
-	--without-powerman \
-	--without-wrap \
-	--with-hotplug-dir=/etc/hotplug \
-	--with$(if $(CONFIG_PACKAGE_nut-web-cgi),,out)-cgi \
-	--without-ipmi \
-	--without-freeipmi \
-	--without-linux-i2c \
-	$(if $(CONFIG_NUT_SSL),--with-ssl=openssl) \
-	$(if $(CONFIG_NUT_SSL_NSS),--with-ssl=nss,--without-nss) \
-	$(if $(CONFIG_NUT_SSL),,$(if $(CONFIG_NUT_SSL_NSS),,--without-ssl)) \
-	--without-libltdl \
-	--enable-docs-changelog=no \
-	--without-macosx_ups \
-	--without-nut_monitor \
-	--with-statepath=/var/run/nut \
-	--with-pidpath=/var/run \
-	--with-drvpath=/usr/libexec/nut \
-	--with-user=nut \
-	--with-group=nut \
-	$(if $(CONFIG_PACKAGE_nut-web-cgi),--with-gd-includes="`pkg-config --cflags gdlib`") \
-	$(if $(CONFIG_PACKAGE_nut-web-cgi),--with-gd-libs="`pkg-config --libs gdlib`")
+  --sysconfdir=/etc \
+  --with-confdir-suffix=/nut \
+  --datadir=/usr/share/nut \
+  --with-dev \
+  --$(if $(CONFIG_NUT_DRIVER_USB),with,without)-usb \
+  --without-avahi \
+  --$(if $(CONFIG_NUT_DRIVER_SNMP),with,without)-snmp \
+  --$(if $(CONFIG_NUT_DRIVER_SERIAL),with,without)-serial \
+  --without-doc \
+  --$(if $(CONFIG_NUT_DRIVER_NEON),with,without)-neon \
+  --without-powerman \
+  --without-wrap \
+  --with-hotplug-dir=/etc/hotplug \
+  --with$(if $(CONFIG_PACKAGE_nut-web-cgi),,out)-cgi \
+  --without-ipmi \
+  --without-freeipmi \
+  --without-linux-i2c \
+  $(if $(CONFIG_NUT_SSL),--with-ssl=openssl) \
+  $(if $(CONFIG_NUT_SSL_NSS),--with-ssl=nss,--without-nss) \
+  $(if $(CONFIG_NUT_SSL),,$(if $(CONFIG_NUT_SSL_NSS),,--without-ssl)) \
+  --without-libltdl \
+  --enable-docs-changelog=no \
+  --without-macosx_ups \
+  --without-nut_monitor \
+  --with-statepath=/var/run/nut \
+  --with-pidpath=/var/run \
+  --with-drvpath=/usr/libexec/nut \
+  --with-user=nut \
+  --with-group=nut \
+  $(if $(CONFIG_PACKAGE_nut-web-cgi),--with-gd-includes="`pkg-config --cflags gdlib`") \
+  $(if $(CONFIG_PACKAGE_nut-web-cgi),--with-gd-libs="`pkg-config --libs gdlib`")
 
 TARGET_CXXFLAGS += -std=c++98
 

--- a/net/nut/Makefile
+++ b/net/nut/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nut
 PKG_VERSION:=2.8.5
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.networkupstools.org/source/2.8/
@@ -98,6 +98,8 @@ define Package/nut-server/install
 		$(PKG_BUILD_DIR)/libhid-ups.parsed-usermap
 	$(SED) 's^### insert libhid-ups.parsed-usermap content here ###^\ncat "$(PKG_BUILD_DIR)/libhid-ups.parsed-usermap"^e' $(PKG_BUILD_DIR)/30-libhid-ups
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/30-libhid-ups $(1)/etc/hotplug.d/usb/30-libhid-ups
+	$(INSTALL_DIR) $(1)/etc/uci-defaults
+	$(INSTALL_DATA) ./files/nut-server.default $(1)/etc/uci-defaults/90_nut-server
 endef
 
 define Package/nut-common
@@ -108,7 +110,8 @@ define Package/nut-common
     +NUT_DRIVER_USB:libusb-compat \
     +NUT_DRIVER_NEON:libneon \
     +NUT_SSL:libopenssl \
-    +NUT_SSL_NSS:libnss
+    +NUT_SSL_NSS:libnss \
+    +NUT_SSL_NSS:nss-utils
 endef
 
 define Package/nut-common/description
@@ -118,6 +121,7 @@ endef
 
 define Package/nut-common/conffiles
 /etc/nut/nut.conf
+/etc/nut/cert_db/
 endef
 
 define Package/nut-common/install
@@ -133,12 +137,15 @@ define Package/nut-common/install
 	$(if $(CONFIG_NUT_SSL_NSS),printf "%s" "nss" >$(PKG_BUILD_DIR)/ssl_backend)
 	$(if $(CONFIG_NUT_SSL)$(CONFIG_NUT_SSL_NSS),,printf "%s" "none" >$(PKG_BUILD_DIR)/ssl_backend)
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/ssl_backend $(1)/usr/share/nut/ssl_backend
+	$(INSTALL_DIR) $(1)/etc/uci-defaults
+	$(INSTALL_DATA) ./files/nut-common.default $(1)/etc/uci-defaults/89_nut-common
 endef
 
 define Package/nut-server
   $(call Package/nut/Default)
   TITLE+= (server)
-  DEPENDS:=nut +nut-common
+  DEPENDS:=nut \
+    +nut-common
   USERID:=nut=113:nut=113
 endef
 
@@ -158,10 +165,17 @@ define Package/nut-server/conffiles
 /etc/nut/ups.conf
 endef
 
+define Package/nut-server/postinst
+#!/bin/sh
+[ -n "$${IPKG_INSTROOT}" ] || (. /etc/uci-defaults/90_nut-server) && rm -f /etc/uci-defaults/90_nut-server
+exit 0
+endef
+
 define Package/nut-upsmon
   $(call Package/nut/Default)
   TITLE+= (monitor)
-  DEPENDS:=nut +nut-common
+  DEPENDS:=nut \
+    +nut-common
   USERID:=nutmon=114:nutmon=114
 endef
 
@@ -180,6 +194,12 @@ define Package/nut-upsmon/conffiles
 /etc/nut/upsmon.conf
 endef
 
+define Package/nut-upsmon/postinst
+#!/bin/sh
+[ -n "$${IPKG_INSTROOT}" ] || (. /etc/uci-defaults/90_nut-upsmon) && rm -f /etc/uci-defaults/90_nut-upsmon
+exit 0
+endef
+
 define Package/nut-upsmon/install
 	$(INSTALL_DIR) $(1)/etc/nut
 	$(INSTALL_DIR) $(1)/usr/sbin
@@ -194,6 +214,7 @@ define Package/nut-upsmon/install
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_CONF) ./files/nut_monitor $(1)/etc/config/nut_monitor
 	ln -sf /var/etc/nut/upsmon.conf $(1)/etc/nut/upsmon.conf
+	$(INSTALL_DATA) ./files/nut-upsmon.default $(1)/etc/uci-defaults/90_nut-upsmon
 endef
 
 define Package/nut-upsmon/conffiles

--- a/net/nut/files/nut-common.default
+++ b/net/nut/files/nut-common.default
@@ -1,0 +1,67 @@
+#!/bin/sh
+# In recent (relevant) versions of shellcheck busybox is a valid shell type
+# shellcheck shell=busybox
+
+# uci-defaults script to setup nut-common package
+#  * create (if not present) shared group for directories shared with nut-upsmon
+#  * install/create NSS certificate/key database
+
+# IPKG_INSTROOT is intentionally only set when building an image and
+# is intentionally empty on a live OpenWrt device
+
+# Shellcheck source paths intentionally point to the location of files of
+# the scripts in the development environment (where shellcheck is used), not
+# on the live OpenWrt device.
+
+# This script lives in nut-common package, which is independent of the
+# nut-upsmon package in which nut-upsmon.default lives
+
+# The separate packages limit the opportunities for code-sharing across the
+# scripts.
+
+# Only run this uci-defaults script on a live OpenWrt device
+[ -z "${IPKG_INSTROOT}" ] || exit 0
+
+# shellcheck source=net/nut/files/functions.sh.functions
+. /lib/functions.sh || {
+	# As the uci-defaults environment in which this runs does not have logging
+	# available, nor is stderr captured or displayed on the console, these messages
+	# exist only to assist when debugging manual runs of the script.
+	printf "'%s': '%s'" "nut-common.default" "FATAL: Unable to source 'functions.sh'" || true
+	exit 1
+}
+
+if ! group_exists "nutgrp"; then
+	group_add_next "nutgrp"
+fi
+
+if [ -n "$(command -v certutil)" ]; then
+	if [ ! -d /etc/nut/cert_db ]; then
+		old_umask="$(umask)"
+		umask 027
+		{
+			mkdir -p /etc/nut/cert_db
+			chgrp nutgrp /etc/nut/cert_db
+		} || {
+			printf "'%s': '%s'" "nut-common.default" "FATAL: Unable to create '/etc/nut/cert_db' with the needed group and permissions" || true
+			umask "$old_umask"
+			exit 1
+		}
+		umask "$old_umask"
+
+		# We only create the database if the directory did not exist before running this script, as we
+		# do not wish to overwrite an existing database
+		certutil -N -d /etc/nut/cert_db --empty-password || {
+			printf "'%s': '%s'" "nut-common.default" "FATAL: Unable to create empty certificate database"
+			umask "$old_umask"
+			exit 1
+		}
+		chgrp nutgrp /etc/nut/cert_db/*
+		# certutil does not honour umask so we must set permissions with chmod
+		chmod 0640 /etc/nut/cert_db/*
+	else
+		# If /etc/nut/cert_db already exists, we assume it is a pre-existing install
+		# and do not override potential system administrator initiated changes.
+		:
+	fi
+fi

--- a/net/nut/files/nut-monitor-config.sh.functions
+++ b/net/nut/files/nut-monitor-config.sh.functions
@@ -112,9 +112,16 @@ upsmon_conf_get_write() {
 nut_upsmon_conf() {
 	local config_file="$1"
 	local cfg="upsmon"
-	local val defaultnotify nut_option uci_option conf_ret
+	local val defaultnotify nut_option uci_option conf_ret ssl_backend
 	local event_notify_flags_not_found upsmon_bool_options nut_bool
 	upsmon_bool_options=" $NUT_UPSMON_BOOL_OPTIONS "
+
+	ssl_backend="$(cat /usr/share/nut/ssl_backend)"
+
+	[ -n "$ssl_backend" ] || {
+		log_error_exit "Missing ssl_backend indicator. Bailing rather than running without SSL." "nut-monitor-config.sh" "nut-monitor-config"
+		return 1
+	}
 
 	# Note that we use '-u $RUNAS' on the daemon command line in preference to
 	# the RUN_AS_USER configuration in "$config_file"
@@ -192,6 +199,44 @@ nut_upsmon_conf() {
 			;;
 		POWERDOWNFLAG)
 			upsmon_conf_get_write "$cfg" "$config_file" "$uci_option" "$nut_option" "false" "$NUT_KILLPOWER"
+			conf_ret=$?
+			if [ "$conf_ret" -eq 1 ]; then
+				return 1
+			fi
+			;;
+		CERTPATH | CERTIDENT | CERTHOST)
+			# if not compiled with SSL (OpenSSL or NSS), then do not attempt to use
+			# SSL configuration
+			if [ "$ssl_backend" != "openssl" ] && [ "$ssl_backend" != "nss" ]; then
+				continue
+			fi
+			# If no certpath or certfile is specified, then SSL will not be used, even if
+			# other SSL config exists
+			upsmon_conf_get_write "$cfg" "$config_file" "$uci_option" "$nut_option" "false"
+			conf_ret=$?
+			if [ "$conf_ret" -eq 1 ]; then
+				return 1
+			fi
+			;;
+		CERTVERIFY | FORCESSL)
+			# if not compiled with SSL (OpenSSL or NSS), then do not attempt to use
+			# SSL configuration
+			if [ "$ssl_backend" != "openssl" ] && [ "$ssl_backend" != "nss" ]; then
+				continue
+			fi
+			upsmon_conf_get_write "$cfg" "$config_file" "$uci_option" "$nut_option" "true"
+			conf_ret=$?
+			if [ "$conf_ret" -eq 1 ]; then
+				return 1
+			fi
+			;;
+		CERTFILE)
+			# if not compiled with OpenSSL, then do not attempt to use CERTFILE (it is
+			# OpenSSL specific)
+			if [ "$ssl_backend" != "openssl" ]; then
+				continue
+			fi
+			upsmon_conf_get_write "$cfg" "$config_file" "$uci_option" "$nut_option" "false"
 			conf_ret=$?
 			if [ "$conf_ret" -eq 1 ]; then
 				return 1

--- a/net/nut/files/nut-server-config.sh.functions
+++ b/net/nut/files/nut-server-config.sh.functions
@@ -67,7 +67,8 @@ listen_address() {
 srv_config() {
 	local srv="$1"
 	local config_file="$2"
-	local maxage maxconn certfile
+	local ssl_backend
+	local maxage maxconn val certfile
 
 	config_get maxage "$srv" maxage
 	[ -n "$maxage" ] && printf "MAXAGE %s\n" "$maxage" >>"$config_file"
@@ -77,9 +78,39 @@ srv_config() {
 	config_get maxconn "$srv" maxconn
 	[ -n "$maxconn" ] && printf "MAXCONN %s\n" "$maxconn" >>"$config_file"
 
-	# NOTE: certs only apply to SSL-enabled version
+	ssl_backend="$(cat /usr/share/nut/ssl_backend)"
+
+	[ -n "$ssl_backend" ] || {
+		log_error_exit "Missing ssl_backend indicator. Bailing rather than running without SSL." "nut-server-config.sh" "nut-server-config"
+		return 1
+	}
+
+	# NOTE: certfile only applies to OpenSSL-enabled version
 	config_get certfile "$srv" certfile
-	[ -n "$certfile" ] && printf "CERTFILE %s\n" "$certfile" >>"$config_file"
+	[ -n "$certfile" ] && [ "$ssl_backend" = "openssl" ] && printf "CERTFILE %s\n" "$certfile" >>"$config_file"
+
+	# if not compiled with SSL (OpenSSL or NSS), then do not attempt to use
+	# SSL configuration
+	if [ "$ssl_backend" = "openssl" ] || [ "$ssl_backend" = "nss" ]; then
+		# If no certpath or certfile is specified, then SSL will not be used, even if
+		# other SSL config exists
+		config_get val "$srv" certpath
+		[ -n "$val" ] && printf "CERTPATH %s\n" "$val" >>"$config_file"
+
+		config_get val "$srv" certident
+		[ -n "$val" ] && printf "CERTIDENT %s\n" "$val" >>"$config_file"
+
+		config_get val "$srv" certrequest
+		[ -n "$val" ] && printf "CERTREQUEST %s\n" "$val" >>"$config_file"
+
+		config_get_bool val "$srv" disable_weak_ssl 0
+		printf "DISABLE_WEAK_SSL %s\n" "$val" >>"$config_file"
+	fi
+
+	config_get val "$srv" debug_min
+	[ -n "$val" ] && printf "DEBUG_MIN %s\n" "$val" >>"$config_file"
+
+	return 0
 }
 
 nut_user_instcmd() {
@@ -141,7 +172,7 @@ build_server_config() {
 	config_foreach nut_user_add user "$USERS_C.new"
 	config_foreach listen_address listen_address "$UPSD_C.new"
 	if have_section_named "upsd" "upsd"; then
-		srv_config upsd "$UPSD_C.new"
+		srv_config upsd "$UPSD_C.new" || return 1
 	else
 		# If config 'nut_server' does not have a 'upsd' section, use a default
 		# configuration

--- a/net/nut/files/nut-server-config.sh.functions
+++ b/net/nut/files/nut-server-config.sh.functions
@@ -77,7 +77,7 @@ srv_config() {
 	config_get maxconn "$srv" maxconn
 	[ -n "$maxconn" ] && printf "MAXCONN %s\n" "$maxconn" >>"$config_file"
 
-	#NOTE: certs only apply to SSL-enabled version
+	# NOTE: certs only apply to SSL-enabled version
 	config_get certfile "$srv" certfile
 	[ -n "$certfile" ] && printf "CERTFILE %s\n" "$certfile" >>"$config_file"
 }

--- a/net/nut/files/nut-server.default
+++ b/net/nut/files/nut-server.default
@@ -1,0 +1,38 @@
+#!/bin/sh
+# In recent (relevant) versions of shellcheck busybox is a valid shell type
+# shellcheck shell=busybox
+
+# uci-defaults script to setup nut-server package
+#  * create (if not present) shared group for directories shared with nut-upsmon
+#  * install/create NSS certificate/key database
+
+# IPKG_INSTROOT is intentionally only set when building an image and
+# is intentionally empty on a live OpenWrt device
+
+# Shellcheck source paths intentionally point to the location of files of
+# the scripts in the development environment (where shellcheck is used), not
+# on the live OpenWrt device.
+
+# This script lives in nut-server package, which is independent of the
+# nut-upsmon package in which nut-upsmon.default lives
+
+# The separate packages limit the opportunities for code-sharing across the
+# scripts.
+
+# Only run this uci-defaults script on a live OpenWrt device
+[ -z "${IPKG_INSTROOT}" ] || exit 0
+
+# shellcheck source=net/nut/files/functions.sh.functions
+. /lib/functions.sh || {
+	# As the uci-defaults environment in which this runs does not have logging
+	# available, nor is stderr captured or displayed on the console, these messages
+	# exist only to assist when debugging manual runs of the script.
+	printf "'%s': '%s'" "nut-server.default" "FATAL: Unable to source 'functions.sh'" || true
+	exit 1
+}
+
+if ! group_exists "nutgrp"; then
+	group_add_next "nutgrp"
+fi
+
+group_add_user "nutgrp" "nut"

--- a/net/nut/files/nut-upsmon.default
+++ b/net/nut/files/nut-upsmon.default
@@ -1,0 +1,38 @@
+#!/bin/sh
+# In recent (relevant) versions of shellcheck busybox is a valid shell type
+# shellcheck shell=busybox
+
+# uci-defaults script to setup nut-upsmon package
+#  * create (if not present) shared group for directories shared with nut-server
+#  * install/create NSS certificate/key database
+
+# IPKG_INSTROOT is intentionally only set when building an image and
+# is intentionally empty on a live OpenWrt device
+
+# Shellcheck source paths intentionally point to the location of files of
+# the scripts in the development environment (where shellcheck is used), not
+# on the live OpenWrt device.
+
+# This script lives in nut-upsmon package, which is independent of the
+# nut-server package in which nut-server.default lives
+
+# The separate packages limit the opportunities for code-sharing across the
+# scripts.
+
+# Only run this uci-defaults script on a live OpenWrt device
+[ -z "${IPKG_INSTROOT}" ] || exit 0
+
+# shellcheck source=net/nut/files/functions.sh.functions
+. /lib/functions.sh || {
+	# As the uci-defaults environment in which this runs does not have logging
+	# available, nor is stderr captured or displayed on the console, these messages
+	# exist only to assist when debugging manual runs of the script.
+	printf "'%s': '%s'" "nut-upsmon.default" "FATAL: Unable to source 'functions.sh'" || true
+	exit 1
+}
+
+if ! group_exists "nutgrp"; then
+	group_add_next "nutgrp"
+fi
+
+group_add_user "nutgrp" "nutmon"

--- a/net/nut/files/nut_monitor
+++ b/net/nut/files/nut_monitor
@@ -28,7 +28,16 @@
 #	option rbwarntime 43200 # replace battery warn time
 #	option alarmcritical 1
 #	option shutdownexit 0
-#	option certpath /path/to/ca/dir
+# NB: certificates only apply to SSL-enabled version
+# See https://github.com/networkupstools/nut/blob/master/docs/security.txt
+# openssl client certificate chain and private key
+#	option certfile /usr/local/etc/upsmon.pem
+# NSS or OpenSSL
+# For NSS path the directory with certificate and key databases
+# For OpenSSL path a file with one or more CA certificates
+#	option certpath /etc/nut/cert_db
+# Client certificate name and password to unlock the key for the certificate
+#	option certident '"certificate name" "database password"'
 #	option certverify 0
 #	option forcessl 0
 #	option debugmin 0

--- a/net/nut/files/nut_server
+++ b/net/nut/files/nut_server
@@ -37,6 +37,18 @@
 #	option maxconn 1024
 #	option runas nut
 #	option interface_reload_delay 3000 # in milliseconds
-# NB: certificates only apply to SSL-enabled version
-#	option certfile /usr/local/etc/upsd.pem
 #	option triggerlist all # not configured by default
+#	option debug_min 0
+# NB: certificates only apply to SSL-enabled version
+# See https://github.com/networkupstools/nut/blob/master/docs/security.txt
+# openssl server certificate chain and private key
+#	option certfile /usr/local/etc/upsd.pem
+# NSS or OpenSSL
+# For NSS path the directory with certificate and key databases
+# For OpenSSL path a file with one or more CA certificates
+#	option certpath /etc/nut/cert_db
+# Server certificate name and password to unlock the key for the certificate
+#	option certident '"certificate name" "database password"'
+# 0 - NO, 1 - REQUEST, 2 - REQUIRE (and verify)
+#	option certrequest 0
+#	option disable_weak_ssl 0


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @danielfdickinson

**Description:**

Enable libnss (Mozilla NSS) for SSL, and make it the default.

- [x] Check if NSS causes problems for non-SSL setups. If so, add a nossl variant. 
      * A nossl variant is not required. That is, with no certificate configured NSS-enabled version accepts the old default (no SSL) version's connections and vice-versa. Behaviour with certificates configured depends on whether SSL required is configured.
- [x] Verify NSS as currently packaged for OpenWrt has all necessary capabilities for NUT.
- [x] Ensure NUT build and configuration can completely support SSL with NSS
     - [x] Add missing configuration options to `nut-server-config.sh`
     - [x] Add missing configuration options to `nut-monitor-config.sh`
     - [x] Update CONFIGURE_ARGS to support certificate verification
     - [x] Allow to opt-out of build with cert verification for custom builds
- [x] Allow disabling SSL support at runtime
- [x] Re-test with these changes

---

## 🧪 Run Testing Details

- **OpenWrt Version:** OpenWrt SNAPSHOT r35062-a1ab701efa
- **OpenWrt Target/Subtarget:** 27xx/2709
- **OpenWrt Device:** Raspberry Pi 2 Model B Rev 1.1
- **UPS:** Tripp-Lite ECO550UPS

and

- **OpenWrt Version:** OpenWrt SNAPSHOT r35438-bacda03b76
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** OpenWrt One

and

- **OpenWrt Version:** OpenWrt SNAPSHOT r35431-4f2dc5cc64
- **OpenWrt Target/Subtarget:** 27xx/2709
- **OpenWrt Device:** Raspberry Pi 2 Model B Rev 1.1

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.