### PR TITLE
[25.12] fsh: fix a typo in fshs.init

### DIFF
--- a/net/fsh/Makefile
+++ b/net/fsh/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fsh
 PKG_VERSION:=4.11.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/heiher/hev-fsh/releases/download/$(PKG_VERSION)

--- a/net/fsh/files/fshs.init
+++ b/net/fsh/files/fshs.init
@@ -11,8 +11,8 @@ validate_section_fshs() {
 		'enable:bool:0' \
 		'addr:string' \
 		'port:port' \
-		'tokens:string'
-		'params:string' \
+		'tokens:string' \
+		'params:string'
 }
 
 fshs_instance() {


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @heiher (me)

**Description:** fix a typo in fshs.init

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12
- **OpenWrt Target/Subtarget:** armv8
- **OpenWrt Device:** armsr

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.