### PR TITLE
modemmanager: choose plugins for build

### DIFF
--- a/net/modemmanager/Config.in
+++ b/net/modemmanager/Config.in
@@ -33,4 +33,9 @@ config MODEMMANAGER_WITH_AT_COMMAND_VIA_DBUS
 	help
 	  Compile ModemManager allowing AT commands without debug flag
 
+config MODEMMANAGER_WITH_BUILTIN_PLUGINS
+	bool "Build modemmanager with builtin plugins"
+	default y
+	help
+	  Build ModemManager with builtin plugins
 endmenu

--- a/net/modemmanager/Makefile
+++ b/net/modemmanager/Makefile
@@ -84,7 +84,7 @@ MESON_ARGS += \
 	-Dintrospection=false \
 	-Dman=false \
 	-Dbash_completion=false \
-	-Dbuiltin_plugins=true \
+	-Dbuiltin_plugins=$(if $(CONFIG_MODEMMANAGER_WITH_BUILTIN_PLUGINS),true,false) \
 	-Db_lto=true \
 	-Dmbim=$(if $(CONFIG_MODEMMANAGER_WITH_MBIM),true,false) \
 	-Dqmi=$(if $(CONFIG_MODEMMANAGER_WITH_QMI),true,false) \
@@ -119,6 +119,10 @@ define Package/modemmanager/install
 
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libmm-glib.so.* $(1)/usr/lib
+
+	$(INSTALL_DIR) $(1)/usr/lib/ModemManager
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/ModemManager/libmm-shared-*.so* $(1)/usr/lib/ModemManager
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/ModemManager/libmm-plugin-*.so* $(1)/usr/lib/ModemManager
 
 	$(INSTALL_DIR) $(1)/usr/lib/ModemManager/connection.d
 	$(INSTALL_BIN) ./files/usr/lib/ModemManager/connection.d/10-report-down \

--- a/net/modemmanager/Makefile
+++ b/net/modemmanager/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=modemmanager
 PKG_VERSION:=1.24.0
-PKG_RELEASE:=10
+PKG_RELEASE:=11
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://gitlab.freedesktop.org/mobile-broadband/ModemManager.git

--- a/net/modemmanager/Makefile
+++ b/net/modemmanager/Makefile
@@ -33,11 +33,15 @@ define Package/modemmanager/config
   source "$(SOURCE)/Config.in"
 endef
 
-define Package/modemmanager
+define Package/modemmanager/Default
   SECTION:=net
   CATEGORY:=Network
-  TITLE:=Control utility for any kind of mobile broadband modem
   URL:=https://www.freedesktop.org/wiki/Software/ModemManager
+endef
+
+define Package/modemmanager
+  $(call Package/modemmanager/Default)
+  TITLE:=Control utility for any kind of mobile broadband modem
   DEPENDS:= \
 	$(INTL_DEPENDS) \
 	+glib2 \
@@ -120,10 +124,6 @@ define Package/modemmanager/install
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libmm-glib.so.* $(1)/usr/lib
 
-	$(INSTALL_DIR) $(1)/usr/lib/ModemManager
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/ModemManager/libmm-shared-*.so* $(1)/usr/lib/ModemManager
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/ModemManager/libmm-plugin-*.so* $(1)/usr/lib/ModemManager
-
 	$(INSTALL_DIR) $(1)/usr/lib/ModemManager/connection.d
 	$(INSTALL_BIN) ./files/usr/lib/ModemManager/connection.d/10-report-down \
 		$(1)/usr/lib/ModemManager/connection.d
@@ -166,6 +166,60 @@ ifeq ($(CONFIG_MODEMMANAGER_WITH_NETIFD),y)
 endif
 endef
 
+# 1: shared name
+define BuildShared
+
+  define Package/modemmanager-shared-$(1)
+    $(call Package/modemmanager/Default)
+    TITLE:=$(1) shared
+    DEPENDS:= \
+	modemmanager
+  endef
+
+  define Package/modemmanager-shared-$(1)/config
+    depends on !MODEMMANAGER_WITH_BUILTIN_PLUGINS
+  endef
+
+  define Package/modemmanager-shared-$(1)/install
+	$(INSTALL_DIR) $$(1)/usr/lib/ModemManager
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/ModemManager/libmm-shared-$(1).so* \
+		$$(1)/usr/lib/ModemManager
+  endef
+
+  $$(eval $$(call BuildPackage,modemmanager-shared-$(1)))
+endef
+
+# 1: plugin name/title/description
+# 2: dependencies
+define BuildPlugin
+
+  define Package/modemmanager-plugin-$(1)
+    $(call Package/modemmanager/Default)
+    TITLE:=$(1) plugin
+    DEPENDS:= \
+	modemmanager \
+	$(if $(2),$(2))
+  endef
+
+  define Package/modemmanager-plugin-$(1)/config
+    depends on !MODEMMANAGER_WITH_BUILTIN_PLUGINS
+  endef
+
+  define Package/modemmanager-plugin-$(1)/install
+	$(INSTALL_DIR) $$(1)/usr/lib/ModemManager
+
+	if [ "$(1)" = "mbm" ]; then \
+		$(CP) $(PKG_INSTALL_DIR)/usr/lib/ModemManager/libmm-plugin-ericsson-mbm.so* \
+		$$(1)/usr/lib/ModemManager ; \
+	else \
+		$(CP) $(PKG_INSTALL_DIR)/usr/lib/ModemManager/libmm-plugin-$(1).so* \
+		$$(1)/usr/lib/ModemManager ; \
+	fi
+  endef
+
+  $$(eval $$(call BuildPackage,modemmanager-plugin-$(1)))
+endef
+
 define Package/modemmanager-rpcd/install
 	$(INSTALL_DIR) $(1)/usr/libexec/rpcd
 	$(INSTALL_BIN) ./files/usr/libexec/rpcd/modemmanager \
@@ -174,3 +228,57 @@ endef
 
 $(eval $(call BuildPackage,modemmanager))
 $(eval $(call BuildPackage,modemmanager-rpcd))
+$(eval $(call BuildShared,fibocom))
+$(eval $(call BuildShared,foxconn))
+$(eval $(call BuildShared,icera))
+$(eval $(call BuildShared,mtk))
+$(eval $(call BuildShared,novatel))
+$(eval $(call BuildShared,option))
+$(eval $(call BuildShared,sierra))
+$(eval $(call BuildShared,telit))
+$(eval $(call BuildShared,xmm))
+$(eval $(call BuildShared,quectel))
+$(eval $(call BuildPlugin,altair-lte,))
+$(eval $(call BuildPlugin,anydata,))
+$(eval $(call BuildPlugin,broadmobi,))
+$(eval $(call BuildPlugin,cellient,))
+$(eval $(call BuildPlugin,cinterion,))
+$(eval $(call BuildPlugin,dell,+modemmanager-shared-novatel +modemmanager-shared-sierra +modemmanager-shared-telit +modemmanager-shared-xmm +MODEMMANAGER_WITH_MBIM:modemmanager-shared-foxconn))
+$(eval $(call BuildPlugin,dlink,))
+$(eval $(call BuildPlugin,fibocom,+modemmanager-shared-xmm +modemmanager-shared-fibocom))
+$(eval $(call BuildPlugin,foxconn,+modemmanager-shared-foxconn @MODEMMANAGER_WITH_MBIM))
+$(eval $(call BuildPlugin,generic,))
+$(eval $(call BuildPlugin,gosuncn,))
+$(eval $(call BuildPlugin,haier,))
+$(eval $(call BuildPlugin,huawei,))
+$(eval $(call BuildPlugin,intel,+modemmanager-shared-xmm))
+$(eval $(call BuildPlugin,iridium,))
+$(eval $(call BuildPlugin,linktop,))
+$(eval $(call BuildPlugin,longcheer,))
+$(eval $(call BuildPlugin,mbm,))
+$(eval $(call BuildPlugin,motorola,))
+$(eval $(call BuildPlugin,mtk-legacy,+modemmanager-shared-mtk +MODEMMANAGER_WITH_MBIM:modemmanager-shared-fibocom))
+$(eval $(call BuildPlugin,mtk,+modemmanager-shared-mtk +MODEMMANAGER_WITH_MBIM:modemmanager-shared-fibocom))
+$(eval $(call BuildPlugin,netprisma,+modemmanager-shared-quectel))
+$(eval $(call BuildPlugin,nokia,))
+$(eval $(call BuildPlugin,nokia-icera,+modemmanager-shared-icera))
+$(eval $(call BuildPlugin,novatel,+modemmanager-shared-novatel))
+$(eval $(call BuildPlugin,novatel-lte,))
+$(eval $(call BuildPlugin,option,+modemmanager-shared-option))
+$(eval $(call BuildPlugin,option-hso,+modemmanager-shared-option))
+$(eval $(call BuildPlugin,pantech,))
+$(eval $(call BuildPlugin,qcom-soc,@MODEMMANAGER_WITH_QMI))
+$(eval $(call BuildPlugin,quectel,+modemmanager-shared-quectel))
+$(eval $(call BuildPlugin,rolling,+modemmanager-shared-fibocom +modemmanager-shared-mtk))
+$(eval $(call BuildPlugin,samsung,+modemmanager-shared-icera))
+$(eval $(call BuildPlugin,sierra-legacy,+modemmanager-shared-icera +modemmanager-shared-sierra))
+$(eval $(call BuildPlugin,sierra,+modemmanager-shared-xmm))
+$(eval $(call BuildPlugin,simtech,))
+$(eval $(call BuildPlugin,telit,+modemmanager-shared-telit))
+$(eval $(call BuildPlugin,thuraya,))
+$(eval $(call BuildPlugin,tplink,))
+$(eval $(call BuildPlugin,ublox,))
+$(eval $(call BuildPlugin,via,))
+$(eval $(call BuildPlugin,wavecom,))
+$(eval $(call BuildPlugin,x22x,))
+$(eval $(call BuildPlugin,zte,+modemmanager-shared-icera))


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @feckert 

**Description:**

If modemmanager is integrated into slower devices, compiling all plugins
may be too much.
This adds the feature to choose which plugins to include or not.

 Also it is possible to decide whether the plugins should be included into binary blob via `MODEMMANAGER_WITH_BUILTIN_PLUGINS`.

<img width="1892" height="318" alt="image" src="https://github.com/user-attachments/assets/bd36d9db-c78e-492d-b43a-f9b4b1f0d239" />

<img width="1892" height="953" alt="image" src="https://github.com/user-attachments/assets/aa128543-f241-4907-9095-46fc0f4fe28a" />


<!-- Briefly describe what this package does or what changes are introduced -->
---

## 🧪 Run Testing Details

- **OpenWrt Version:** openwrt-25.12
- **OpenWrt Target/Subtarget:** x86/64

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
