### PR TITLE
haproxy: update to v3.4.2

### DIFF
--- a/net/haproxy/Makefile
+++ b/net/haproxy/Makefile
@@ -10,12 +10,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=haproxy
-PKG_VERSION:=3.4.1
+PKG_VERSION:=3.4.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.haproxy.org/download/3.4/src
-PKG_HASH:=2e62c4ce4fd77d3bc7cf17e586431663454456a078b7c8465b8f0125b5bc22f8
+PKG_HASH:=b1330dbb0d6e6bc4a72c4708a6a9e585579cd1156dfe5763c26305105bc12907
 
 PKG_MAINTAINER:=Thomas Heil <heil@terminal-consulting.de>, \
 		Christian Lachner <gladiac@gmail.com>


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @gladiac

**Description:**
- Updated haproxy PKG_VERSION and PKG_HASH
- See changes: http://git.haproxy.org/?p=haproxy-3.4.git;a=shortlog

---

## 🧪 Run Testing Details

- **OpenWrt Version:** Master
- **OpenWrt Target/Subtarget:** Mediatek MT798x
- **OpenWrt Device:** GL.iNet GL-MT6000

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.