### PR TITLE
nss: add version override

### DIFF
--- a/libs/nss/test-version.sh
+++ b/libs/nss/test-version.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+if [ "$PKG_NAME" = "nss" ]; then
+	# nss package does not build any binaries that emit a version, so
+	# override the version check and indicate success
+	exit 0
+fi


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @lucize 

**Description:**

NSS source package does not build any binaries that emit a version. Therefore add a version override (to keep CI happy).


---

## 🧪 Run Testing Details

N/A: Does not change any package files, only allows CI to pass.

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
