### PR TITLE
[openwrt-24.10] haproxy: update to v3.0.25

### DIFF
--- a/net/haproxy/Makefile
+++ b/net/haproxy/Makefile
@@ -10,12 +10,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=haproxy
-PKG_VERSION:=3.0.19
+PKG_VERSION:=3.0.25
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.haproxy.org/download/3.0/src
-PKG_HASH:=85f2743a44e4226a0176926fbc8eebfa5551d22fe5f44366877570b6e18c6664
+PKG_HASH:=0e4fbd90826368297ce4d5374596dd1eff58f3ec00c27312a86e455e4fe1884f
 
 PKG_MAINTAINER:=Thomas Heil <heil@terminal-consulting.de>, \
 		Christian Lachner <gladiac@gmail.com>


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @gladiac

**Description:**
- Updated haproxy PKG_VERSION and PKG_HASH
- See changes: http://git.haproxy.org/?p=haproxy-3.0.git;a=shortlog

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 24.10
- **OpenWrt Target/Subtarget:** Qualcomm Atheros IPQ806X
- **OpenWrt Device:** NETGEAR Nighthawk X4S R7800

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.