### PR TITLE
avahi: update to 0.9-rc5

### DIFF
--- a/libs/avahi/Makefile
+++ b/libs/avahi/Makefile
@@ -6,13 +6,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=avahi
-PKG_VERSION:=0.9_rc4
+PKG_VERSION:=0.9_rc5
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-0.9-rc4.tar.gz
-PKG_SOURCE_URL:=https://codeload.github.com/avahi/avahi/tar.gz/v0.9-rc4?
-PKG_HASH:=08fcc57377ed05416ec4b3d8a179da716a7a9376821551a5ae16f8276a1ef0b5
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-0.9-rc4
+PKG_SOURCE:=$(PKG_NAME)-0.9-rc5.tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/avahi/avahi/tar.gz/v0.9-rc5?
+PKG_HASH:=5b0a9d88110b0fc8aaafc5cc0a26e83e7d2a4aca3a36bc27c9b626db7ead27b0
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-0.9-rc5
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=LGPL-2.1-or-later


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:**  me

**Description:**

Bump from the 0.9-rc4 pre-release to 0.9-rc5. Update PKG_VERSION, PKG_SOURCE, PKG_SOURCE_URL, PKG_BUILD_DIR and PKG_HASH accordingly.

The two carried patches (010-pkgconfig, 020-no-po-subdir) still apply unchanged, and test-version.sh already normalises the underscore in the apk version (0.9_rc5) back to the upstream 0.9-rc5 string.

Fixes https://github.com/openwrt/packages/issues/29844

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [ ] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
