### PR TITLE
fluent-bit: update to 5.0.8, adopt maintainer, fix musl startup segfault

### DIFF
--- a/admin/fluent-bit/Makefile
+++ b/admin/fluent-bit/Makefile
@@ -1,14 +1,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fluent-bit
-PKG_VERSION:=4.2.0
-PKG_RELEASE:=3
+PKG_VERSION:=5.0.8
+PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/fluent/fluent-bit.git
 PKG_SOURCE_VERSION=v$(PKG_VERSION)
-PKG_MIRROR_HASH:=cad2d94cf7a720a3910c781f80187e2c399aa8acbfa1046aa7445a4d1495fafd
+PKG_MIRROR_HASH:=e512206f301abee2f326a62faeaae258d1a2b3a5d698d6c4dc45909d0a9e0dca
 
+PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 PKG_CPE_ID:=cpe:/a:treasuredata:fluent_bit
@@ -36,6 +37,8 @@ endef
 
 TARGET_LDFLAGS += $(if $(CONFIG_USE_MUSL),-lfts) -latomic
 
+# Force native __thread TLS: GCC 14 makes upstream's C-TLS probe fail (undeclared
+# __tls_get_addr), and its pthread_key fallback segfaults on musl at startup.
 CMAKE_OPTIONS+= \
 	-DFLB_RELEASE=Yes \
 	-DEXCLUDE_FROM_ALL=true \
@@ -47,7 +50,8 @@ CMAKE_OPTIONS+= \
 	-DFLB_CORO_STACK_SIZE=4096 \
 	-DWITH_SASL=No \
 	-DWITH_ZLIB=No \
-	-DWITH_ZSTD=No
+	-DWITH_ZSTD=No \
+	-DFLB_HAVE_C_TLS=Yes
 
 define Package/fluent-bit/install
 	$(INSTALL_DIR) $(1)/usr/sbin


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:**  me

**Description:**

Update 4.2.0 -> 5.0.8 and adopt maintainership. fluent-bit segfaulted at
startup on every musl target: under GCC 14 the upstream C-TLS probe no longer
compiles (undeclared __tls_get_addr), so the pthread_key fallback calls
pthread_getspecific() before pthread_key_create() and derefs a NULL tsd array
on musl (glibc is unaffected). Force -DFLB_HAVE_C_TLS:BOOL=On for __thread TLS.


Fixes https://github.com/openwrt/packages/issues/29777

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [ ] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

