### PR TITLE
logrotate: conffiles should end directories with slash

### DIFF
--- a/utils/logrotate/Makefile
+++ b/utils/logrotate/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=logrotate
 PKG_VERSION:=3.22.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/logrotate/logrotate/releases/download/$(PKG_VERSION)
@@ -49,7 +49,7 @@ endef
 
 define Package/logrotate/conffiles
 /etc/logrotate.conf
-/etc/logrotate.d
+/etc/logrotate.d/
 endef
 
 CONFIGURE_ARGS += \


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @bk138 

**Description:**
`/etc/logrotate.d/` needs slash in `conffiles` to indicate it's a directory and not a flat file.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** pc-engines-apu6

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
