### PR TITLE
ser2net: filter non-printable characters from custom options

### DIFF
--- a/net/ser2net/Makefile
+++ b/net/ser2net/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ser2net
 PKG_VERSION:=4.6.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/ser2net

--- a/net/ser2net/files/ser2net.init
+++ b/net/ser2net/files/ser2net.init
@@ -15,6 +15,9 @@ list_cb_append() {
 	local value="$1"
 	local sep="${3:-,}"
 
+	# keep only printable ASCII characters (space through ~)
+	value="$(LC_ALL=C printf '%s' "$value" | tr -cd ' -~')"
+
 	eval "export ${NO_EXPORT:+-n} -- \"$var=\${$var:+\${$var}\${value:+\$sep}}\$value\""
 }
 


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me

**Description:**

Backport of https://github.com/openwrt/packages/pull/29909
  
The custom options are designed to carry only scalar options to be
added to the connector line.
    
This fixes a security issue when newlines are included in custom options
which can be used to add yet another, arbitrary connector lines.
    
See https://github.com/openwrt/packages/security/advisories/GHSA-w6q2-vr4f-49x3

--

## 🧪 Run Testing Details

- **OpenWrt Version:** https://github.com/openwrt/openwrt/commit/949e61ec65ad613256e82bd9e9b65683afe35706
- **OpenWrt Target/Subtarget:** bcm27xx/bcm2708
- **OpenWrt Device:** Raspberry Pi

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
