### PR TITLE
avahi: define missing DEFAULT_VARIANT and add conflicts

### DIFF
--- a/libs/avahi/Makefile
+++ b/libs/avahi/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=avahi
 PKG_VERSION:=0.9_rc5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-0.9-rc5.tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/avahi/avahi/tar.gz/v0.9-rc5?
@@ -82,10 +82,12 @@ define Package/avahi-dbus-daemon
   $(call Package/avahi/Default)
   PROVIDES:=avahi-daemon
   VARIANT:=dbus
+  DEFAULT_VARIANT:=1
   SUBMENU:=IP Addresses and Names
   DEPENDS:=+libavahi-dbus-support +libexpat +librt +libdaemon
   TITLE+= (daemon)
   USERID:=avahi=105:avahi=105
+  CONFLICTS:=libavahi-nodbus-support
 endef
 
 define Package/avahi-nodbus-daemon
@@ -167,8 +169,10 @@ endef
 define Package/libavahi-dbus-support
   $(call Package/libavahi/Default)
   VARIANT:=dbus
-  DEPENDS:=+dbus
+  DEFAULT_VARIANT:=1
+  DEPENDS:=+PACKAGE_libavahi-dbus-support:dbus
   TITLE+= (D-Bus support)
+  CONFLICTS:=libavahi-nodbus-support
 endef
 
 define Package/libavahi-nodbus-support
@@ -207,6 +211,7 @@ define Package/libavahi-client
   VARIANT:=dbus
   DEPENDS:=+avahi-dbus-daemon
   TITLE+= (libavahi-client library)
+  CONFLICTS:=libavahi-nodbus-support
 endef
 
 define Package/libavahi-client/description
@@ -224,6 +229,7 @@ define Package/avahi-utils
   VARIANT:=dbus
   DEPENDS:=+libavahi-client +libgdbm
   TITLE+= (utilities)
+  CONFLICTS:=libavahi-nodbus-support
 endef
 
 define Package/avahi-utils/description


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:**  me

**Description:**

Set DEFAULT_VARIANT on the dbus side of both provides groups (avahi-daemon and libavahi) so a dependency on either virtual package resolves to the dbus variant, which is the more compatible one, instead of an arbitrary pick. Add CONFLICTS on the default (dbus) side to avoid mixing dbus and nodbus variants and to keep kconfig from hitting a recursive dependency. Make the dbus dependency of libavahi-dbus-support conditional so it is not pulled in when the package is not selected.

Rebased onto the current 0.9-rc5 tree and PKG_RELEASE bumped, addressing the review on the original submission.

Based on the work of @map-b in openwrt/packages#27905.

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [ ] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

