### PR TITLE
modemmanager: fix dependency and ci

### DIFF
--- a/net/modemmanager/Makefile
+++ b/net/modemmanager/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=modemmanager
 PKG_VERSION:=1.24.0
-PKG_RELEASE:=9
+PKG_RELEASE:=10
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://gitlab.freedesktop.org/mobile-broadband/ModemManager.git
@@ -61,6 +61,7 @@ define Package/modemmanager-rpcd
   URL:=https://www.freedesktop.org/wiki/Software/ModemManager
   DEPENDS:= \
 	modemmanager \
+	+lua \
 	+lua-cjson
 endef
 

--- a/net/modemmanager/test-version.sh
+++ b/net/modemmanager/test-version.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+# shellcheck shell=busybox
+
+case "$PKG_NAME" in
+modemmanager)
+	ModemManager --version | grep -F "$PKG_VERSION"
+	;;
+
+modemmanager-rpcd)
+	# no version to check
+	exit 0
+	;;
+
+*)
+	echo "Untested package: $PKG_NAME" >&2
+	exit 1
+	;;
+esac

--- a/net/modemmanager/test.sh
+++ b/net/modemmanager/test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# shellcheck shell=busybox
+
+case "$PKG_NAME" in
+modemmanager)
+	exit 0
+	;;
+
+modemmanager-rpcd)
+	/usr/libexec/rpcd/modemmanager list ""
+	;;
+
+*)
+	echo "Untested package: $PKG_NAME" >&2
+	exit 1
+	;;
+esac


### PR DESCRIPTION


## 📦 Package Details

**Maintainer:** `Nicholas Smith` (account deleted ??)

**Description:**
lua-cjson depends on liblua, so add missing lua dependency.
modemmanager-rpcd has no version, so add a simple test, and skip version check.

## 🧪 Run Testing Details

none

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.