### PR TITLE
[25.12] backport Modemmanager fixes from master

### DIFF
--- a/net/modemmanager/Makefile
+++ b/net/modemmanager/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=modemmanager
 PKG_VERSION:=1.24.0
-PKG_RELEASE:=8
+PKG_RELEASE:=9
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://gitlab.freedesktop.org/mobile-broadband/ModemManager.git

--- a/net/modemmanager/Makefile
+++ b/net/modemmanager/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=modemmanager
 PKG_VERSION:=1.24.0
-PKG_RELEASE:=9
+PKG_RELEASE:=10
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://gitlab.freedesktop.org/mobile-broadband/ModemManager.git
@@ -61,6 +61,7 @@ define Package/modemmanager-rpcd
   URL:=https://www.freedesktop.org/wiki/Software/ModemManager
   DEPENDS:= \
 	modemmanager \
+	+lua \
 	+lua-cjson
 endef
 

--- a/net/modemmanager/files/lib/netifd/proto/modemmanager.sh
+++ b/net/modemmanager/files/lib/netifd/proto/modemmanager.sh
@@ -393,6 +393,7 @@ modemmanager_check_state_locked() {
 
 	local unlock_required unlock_retries unlock_retry unlock_lock
 	local unlock_value unlock_match
+	local sim_path
 
 	if [ -z "$pincode" ]; then
 		echo "PIN required"
@@ -434,7 +435,8 @@ modemmanager_check_state_locked() {
 		return 1
 	fi
 
-	mmcli --modem="${device}" -i any --pin=${pincode} || {
+	sim_path="$(modemmanager_get_field "${modemstatus}" "modem.generic.sim")"
+	mmcli --modem="${device}" -i "${sim_path}" --pin=${pincode} || {
 		proto_notify_error "${interface}" MM_PINCODE_WRONG
 		proto_block_restart "${interface}"
 		return 1

--- a/net/modemmanager/test-version.sh
+++ b/net/modemmanager/test-version.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+# shellcheck shell=busybox
+
+case "$PKG_NAME" in
+modemmanager)
+	ModemManager --version | grep -F "$PKG_VERSION"
+	;;
+
+modemmanager-rpcd)
+	# no version to check
+	exit 0
+	;;
+
+*)
+	echo "Untested package: $PKG_NAME" >&2
+	exit 1
+	;;
+esac

--- a/net/modemmanager/test.sh
+++ b/net/modemmanager/test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# shellcheck shell=busybox
+
+case "$PKG_NAME" in
+modemmanager)
+	exit 0
+	;;
+
+modemmanager-rpcd)
+	/usr/libexec/rpcd/modemmanager list ""
+	;;
+
+*)
+	echo "Untested package: $PKG_NAME" >&2
+	exit 1
+	;;
+esac


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** gone it seems

**Description:**
backport latest fixes to 25.12

I'm mostly interrested in the CI fix, 

## 🧪 Run Testing Details

none

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.