### PR TITLE
libdrm: skip generic version check for libdrm-tests

### DIFF
--- a/libs/libdrm/test-version.sh
+++ b/libs/libdrm/test-version.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# shellcheck shell=busybox
+
+# libdrm-tests ships DRM tools (modetest, ...) with no --version flag; the other
+# subpackages ship no executables. Skip the version probe for the whole family.
+case "$PKG_NAME" in
+libdrm*)
+	exit 0
+	;;
+
+*)
+	echo "Untested package: $PKG_NAME" >&2
+	exit 1
+	;;
+esac


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @lucize 


**Description:**

The libdrm-tests subpackage (727190b84) ships DRM tools (modetest, proptest, ...) with no --version flag, so the generic probe aborts with "No executables in the package provided version" and fails CI on every arch. Add a test-version.sh override; the library subpackages ship no executables either.

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [ ] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

