### PR TITLE
kea: bump to 3.0.3

### DIFF
--- a/net/kea/Makefile
+++ b/net/kea/Makefile
@@ -9,12 +9,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=kea
-PKG_VERSION:=3.0.2
+PKG_VERSION:=3.0.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://ftp.isc.org/isc/kea/$(PKG_VERSION)
-PKG_HASH:=29f4e44fa48f62fe15158d17411e003496203250db7b3459c2c79c09f379a541
+PKG_HASH:=09702ddb078b637e85de9236cbedd3fb9d7af7c6e797026c538b45748ad4d631
 
 PKG_MAINTAINER:=Philip Prindeville <philipp@redfish-solutions.com>, Noah Meyerhans <frodo@morgul.net>
 PKG_LICENSE:=MPL-2.0


### PR DESCRIPTION
This PR backports the Kea 3.0.3 security update from master to the stable `openwrt-25.12` branch.

It includes critical fixes for **CVE-2026-3608** (JSON payload stack overflow), a Control Agent null dereference issue, and UNIX command socket permission improvements.

- **Release notes:** https://ftp.isc.org/isc/kea/3.0.3/Kea-3.0.3-ReleaseNotes.txt
- **Upstream commit:** eb538bd758423647466c6f2a68b677f83391d700

---

## 📦 Package Details

**Maintainer:** Philip Prindeville, Noah Meyerhans

**Description:**
Backport the Kea 3.0.3 security update from master to the `openwrt-25.12` branch.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** OpenWrt 25.12-SNAPSHOT r33059-056aa185d9
- **OpenWrt Target/Subtarget:** bcm27xx/bcm2712
- **OpenWrt Device:** Raspberry Pi 5 Model B Rev 1.1

### Test Log Evidence:
The service starts successfully with multi-threading enabled and handles client requests smoothly:

```text
2026-07-07 12:51:53.307 INFO  [kea-dhcp4.dhcp4/13440.547607889104] DHCP4_MULTI_THREADING_INFO enabled: yes, number of threads: 4, queue size: 64
2026-07-07 12:51:53.307 INFO  [kea-dhcp4.dhcp4/13440.547607889104] DHCP4_STARTED Kea DHCPv4 server version 3.0.3 started
2026-07-07 12:51:59.758 INFO  [kea-dhcp4.packets/13440.547586939528] DHCP4_PACKET_RECEIVED [hwtype=1 02:0c:f4:aa:1d:67], cid=[01:02:0c:f4:aa:1d:67], tid=0x473b9168: DHCPREQUEST (type 3) received from 0.0.0.0 to 255.255.255.255 on interface br-ap
2026-07-07 12:51:59.758 INFO  [kea-dhcp4.leases/13440.547586939528] DHCP4_INIT_REBOOT [hwtype=1 02:0c:f4:aa:1d:67], cid=[01:02:0c:f4:aa:1d:67], tid=0x473b9168: client is in INIT-REBOOT state and requests address 192.168.3.109
2026-07-07 12:52:01.181 INFO  [kea-dhcp4.packets/13440.547586796168] DHCP4_PACKET_RECEIVED [hwtype=1 02:0c:f4:aa:1d:67], cid=[01:02:0c:f4:aa:1d:67], tid=0x473b9168: DHCPREQUEST (type 3) received from 0.0.0.0 to 255.255.255.255 on interface br-ap
```

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

