### PR TITLE
python-asgiref: improve version check in test.sh

### DIFF
--- a/lang/python/python-asgiref/test.sh
+++ b/lang/python/python-asgiref/test.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 [ "$1" = python3-asgiref ] || exit 0
-python3 - << 'EOF'
+python3 - << EOF
 import asgiref
-assert asgiref.__version__, "asgiref version is empty"
+assert asgiref.__version__ == "$2", "Incorrect asgiref version"
 
 from asgiref.sync import async_to_sync, sync_to_async
 import asyncio


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @peter-stadler

**Description:**
Verify that `asgiref.__version__` strictly equals the expected version
argument (`$2`), instead of just checking that it is non-empty.

Also remove single quotes from `EOF` to enable variable expansion.

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.