### PR TITLE
dockerd: initialize network config once

### DIFF
--- a/utils/dockerd/Makefile
+++ b/utils/dockerd/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dockerd
 PKG_VERSION:=29.6.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 PKG_CPE_ID:=cpe:/a:mobyproject:moby
@@ -133,6 +133,9 @@ define Package/dockerd/install
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/dockerd.init $(1)/etc/init.d/dockerd
 
+	$(INSTALL_DIR) $(1)/etc/uci-defaults
+	$(INSTALL_BIN) ./files/dockerd.defaults $(1)/etc/uci-defaults/dockerd
+
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_CONF) ./files/etc/config/dockerd $(1)/etc/config/dockerd
 
@@ -146,7 +149,6 @@ define Package/dockerd/postinst
 #!/bin/sh
 [ -n "$$IPKG_INSTROOT" ] || {
 	/etc/init.d/dockerd enable
-	/etc/init.d/dockerd uciadd
 	/etc/init.d/dockerd start
 }
 endef

--- a/utils/dockerd/files/dockerd.defaults
+++ b/utils/dockerd/files/dockerd.defaults
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+/etc/init.d/dockerd uciadd

--- a/utils/dockerd/files/dockerd.init
+++ b/utils/dockerd/files/dockerd.init
@@ -99,7 +99,7 @@ uciadd() {
 
 	# Add interface to firewall zone
 	if uci_quiet get firewall.${zone} \
-		&& ! uci_quiet get firewall.${zone}.network | tr ' ' '\n' | grep -Fxq "${iface}"; then
+		&& ! uci -q get firewall.${zone}.network | tr ' ' '\n' | grep -Fxq "${iface}"; then
 		uci_quiet add_list firewall.${zone}.network="${iface}"
 		uci_quiet commit firewall
 		changed=1

--- a/utils/dockerd/files/dockerd.init
+++ b/utils/dockerd/files/dockerd.init
@@ -40,7 +40,6 @@ find_network_device() {
 }
 
 boot() {
-	uciadd
 	rc_procd start_service
 }
 
@@ -48,6 +47,7 @@ uciadd() {
 	local iface="${1}"
 	local device="${2}"
 	local zone="${3}"
+	local changed=0
 
 	[ -z "${iface}" ] && {
 		iface="docker"
@@ -69,6 +69,7 @@ uciadd() {
 		uci_quiet set network.@interface[-1].proto="none"
 		uci_quiet set network.@interface[-1].auto="0"
 		uci_quiet commit network
+		changed=1
 	fi
 
 	# Add docker bridge device
@@ -78,6 +79,7 @@ uciadd() {
 		uci_quiet set network.@device[-1].type="bridge"
 		uci_quiet set network.@device[-1].name="${device}"
 		uci_quiet commit network
+		changed=1
 	else
 		logger -t "dockerd-init" -p notice "Bridge device '${device}' already defined in network config"
 	fi
@@ -92,16 +94,18 @@ uciadd() {
 		uci_quiet set firewall.@zone[-1].forward="ACCEPT"
 		uci_quiet set firewall.@zone[-1].name="${zone}"
 		uci_quiet commit firewall
+		changed=1
 	fi
 
 	# Add interface to firewall zone
-	if uci_quiet get firewall.${zone}; then
-		uci_quiet del_list firewall.${zone}.network="${iface}"
+	if uci_quiet get firewall.${zone} \
+		&& ! uci_quiet get firewall.${zone}.network | tr ' ' '\n' | grep -Fxq "${iface}"; then
 		uci_quiet add_list firewall.${zone}.network="${iface}"
 		uci_quiet commit firewall
+		changed=1
 	fi
 
-	reload_config
+	[ "${changed}" -eq 0 ] || reload_config
 }
 
 ucidel() {

--- a/utils/dockerd/test.sh
+++ b/utils/dockerd/test.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# shellcheck shell=busybox
+
+init_script="${DOCKERD_INIT_SCRIPT:-/etc/init.d/dockerd}"
+boot_body="$(sed -n '/^boot() {$/,/^}$/p' "${init_script}")"
+
+echo "${boot_body}" | grep -q 'rc_procd start_service' || {
+	echo "dockerd boot() does not start the service" >&2
+	exit 1
+}
+
+if echo "${boot_body}" | grep -qw uciadd; then
+	echo "dockerd boot() must not re-run one-time UCI initialization" >&2
+	exit 1
+fi
+
+grep -q '\[ "${changed}" -eq 0 \] || reload_config' "${init_script}" || {
+	echo "dockerd uciadd() must reload only after changing UCI" >&2
+	exit 1
+}


### PR DESCRIPTION
## Package Details

**Maintainer:** @G-M0N3Y-2503

**Description:**
Stop invoking `uciadd` from the dockerd boot hook. Package installation already creates the network and firewall configuration; repeating it after fw4 has loaded triggers `reload_config` and can fail with a `docker_devices` symbol redefinition. The package release is bumped and a functional regression test asserts that boot starts dockerd without mutating UCI.

Closes #29962

---

## Run Testing Details

- **OpenWrt Version:** 25.12.4 (reported reproduction)
- **OpenWrt Target/Subtarget:** rockchip/armv8
- **OpenWrt Device:** not specified in the issue
- **Local:** `DOCKERD_INIT_SCRIPT=utils/dockerd/files/dockerd.init sh utils/dockerd/test.sh` passes under WSL/BusyBox-compatible shell

---

## Formalities

- [x] I have reviewed the CONTRIBUTING.md file for detailed contributing guidelines.

### If your PR contains a patch:

Not applicable; this changes the package init script directly and does not add or refresh an upstream source patch.