### PR TITLE
libucontext: bump to 1.5.1 & glibc support

### DIFF
--- a/libs/libucontext/Makefile
+++ b/libs/libucontext/Makefile
@@ -1,13 +1,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libucontext
-PKG_VERSION:=1.3.2
+PKG_VERSION:=1.5.1
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
-PKG_SOURCE_URL:=https://github.com/kaniini/libucontext
+PKG_SOURCE_URL:=https://github.com/kaniini/libucontext.git
 PKG_SOURCE_VERSION:=$(PKG_NAME)-$(PKG_VERSION)
-PKG_MIRROR_HASH:=eef55c05aca03c6d62672838638f49daa95ab8f9bf87126df32cedfe150e333c
+PKG_MIRROR_HASH:=6c5f756f32418d8db52b715e1837e46ea2d94926ba93e74d202e2cf891eda1f0
 
 PKG_MAINTAINER:=Volker Christian <me@vchrist.at>
 PKG_LICENSE:=ISC
@@ -23,7 +23,6 @@ define Package/libucontext
   CATEGORY:=Libraries
   TITLE:=libucontext is a library which provides the ucontext.h C API
   URL:=https://github.com/kaniini/libucontext
-  DEPENDS:=@USE_MUSL
 endef
 
 define Package/libucontext-tests
@@ -39,6 +38,18 @@ define Package/libucontext/description
   libraries/applications which need the SYS-V ucontext API.
 endef
 
+MESON_ARGS += \
+	-Ddocs=false
+
+ifneq ($(CONFIG_USE_MUSL),)
+MESON_ARGS += \
+	-Dfreestanding=false
+else ifneq ($(CONFIG_USE_GLIBC),)
+MESON_ARGS += \
+	-Dfreestanding=true \
+	-Dexport_unprefixed=false
+endif
+
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include $(1)/usr/lib/pkgconfig
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/libucontext $(1)/usr/include/
@@ -53,7 +64,9 @@ endef
 
 define Package/libucontext-tests/install
 	$(INSTALL_DIR) $(1)/usr/bin
+ifneq ($(CONFIG_USE_MUSL),)
 	$(INSTALL_BIN) $(MESON_BUILD_DIR)/test_libucontext_posix $(1)/usr/bin/
+endif
 	$(INSTALL_BIN) $(MESON_BUILD_DIR)/test_libucontext $(1)/usr/bin/
 endef
 

--- a/libs/libucontext/patches/001-fix-ppc-build.patch
+++ b/libs/libucontext/patches/001-fix-ppc-build.patch
@@ -1,0 +1,19 @@
+From: Aditya Nugraha <vortexilation@gmail.com>
+Date:   Wed Jul 10 22:49:00 2026 +0700
+Subject: [PATCH] Fixed ppc compilation
+
+    Fixed ppc compilation for KERNEL_UAPI_UCONTEXT_SIZE is not found.
+
+    Signed-off-by: Aditya Nugraha <vortexilation@gmail.com>
+
+--- a/arch/ppc/defs.h
++++ b/arch/ppc/defs.h
+@@ -1,7 +1,7 @@
+ #ifndef __ARCH_PPC_DEFS_H
+ #define __ARCH_PPC_DEFS_H
+ 
+-#define KERNEL_UAPI_CONTEXT_SIZE (1184)
++#define KERNEL_UAPI_UCONTEXT_SIZE (1184)
+ 
+ #define REG_R0		(0)
+ #define REG_R1		(1)


### PR DESCRIPTION
Changelog:
Changes from 1.5 to 1.5.1
-------------------------

* Rename public register definitions on x86 and x86_64 to avoid clashing with glibc definitions when built in freestanding mode. Patch contributed by Daan De Meyer.

Changes from 1.4 to 1.5
-----------------------

* Workaround various header compatibility issues in glibc and bionic.

* Allow ppc64 target to be built in freestanding mode.

Changes from 1.3.3 to 1.4
-------------------------

* Add hard-float support to most architectures where relevant. Some patches contributed by Richard Campbell.

Changes from 1.3.2 to 1.3.3
---------------------------

* Use `bl` instruction instead of explicit GOT lookup for `exit` in 64-bit PowerPC assembly.

* Fix installation path for standalone libucontext headers. Patch contributed by Marian Buschsieweke.

* Fix missing includes for freestanding builds. Patch contributed by David Leeds.

Makefile:
  Disabled documents. Added glibc supports, and removed musl dependency. 
  Put test_libucontext_posix only available in musl runtime.

Build system: x86/64
Build-tested: x86/64-glibc
Build-tested: x86/64-musl
Run-tested: x86/64-glibc

## 📦 Package Details

**Maintainer:** @VolkerChristian 

**Description:**
Updated into version 1.5.1 and adding glibc support.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** r35297-25ee12629e
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** generic x86_64 minipc
glibc

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [x] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
