### PR TITLE
mdns-repeater: pass through CFLAGS/LDFLAGS and package version

### DIFF
--- a/net/mdns-repeater/Makefile
+++ b/net/mdns-repeater/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mdns-repeater
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=https://github.com/geekman/mdns-repeater.git
 PKG_SOURCE_PROTO=git
@@ -28,11 +28,10 @@ define Package/mdns-repeater
   URL:=https://github.com/geekman/mdns-repeater
 endef
 
-TARGET_CFLAGS += -I$(STAGING_DIR)/usr/include
-
-define Build/Compile
-	CFLAGS="$(TARGET_CFLAGS)" CPPFLAGS="$(TARGET_CPPFLAGS)" $(MAKE) -C $(PKG_BUILD_DIR) $(TARGET_CONFIGURE_OPTS)
-endef
+MAKE_FLAGS += \
+	HGVERSION='dummy' \
+	CFLAGS='$(TARGET_CFLAGS) $(TARGET_CPPFLAGS) -DHGVERSION="\"$(VERSION)\""' \
+	LDFLAGS='$(TARGET_LDFLAGS)'
 
 define Package/mdns-repeater/install
 	$(INSTALL_DIR) $(1)/usr/sbin


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @axkg 

**Description:**

Before the change, the feed Makefile would not rely on the predefined logic of building Makefile-based packages, rather it defined its own `Build/Compile` step that explicitly called `make`. This didn't play along well with the upstream Makefile, which doesn't respect the CFLAGS that come from the environment.

The effect of that was that, for example, `CONFIG_PKG_ASLR_PIE_ALL=y` was not respected: a non-PIE binary was generated regardless. Other compiler flags were ignored too in the same manner.

Also it would try to determine the mdns-repeater version by calling to git, which wouldn't work, since the build system downloaded a pre-made source tarball without a bundled `.git` directory. The result is an empty version string when calling `mdns-repeater -h`.

To address all of the above, switch to the built-in logic for Makefile-type projects. Append to MAKE_FLAGS to completely override upstream CFLAGS/LDFLAGS and pass through the package version. Set a dummy HGVERSION variable value to prevent the upstream Makefile from calling `git` unnecessarily.

## 🧪 Run Testing Details

- **OpenWrt Version:** snapshot r35180-aef2523de1
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** Banana-Pi R4 (2xSFP+ version)

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

---

What originally prompted this change is me trying to build an image with `CONFIG_PKG_ASLR_PIE_ALL=y`, and noticing that this specific package was the only one among the ones I have selected that produced a non-PIE binary.

Attached build logs before (`old`) and after (`new`) the change:
* [mdns-repeater.old.log](https://github.com/user-attachments/files/29932048/mdns-repeater.old.log)
* [mdns-repeater.new.log](https://github.com/user-attachments/files/29932049/mdns-repeater.new.log)

The version string fix:

```
root@owrt:~# ./mdns-repeater.old -h
mDNS repeater (version )
<snip>

root@owrt:~# ./mdns-repeater.new -h
mDNS repeater (version 2023.12.16~f714ec4d-r2)
<snip>
```

The one with OpenWrt-provided compiler/linker flags now correctly produced symbols and debug info (as seen under `build_dir`), and despite that ended up being noticeably smaller:

```
% ls -l mdns-repeater.old mdns-repeater.new
-rwxr-xr-x  1 forst  staff  67936 11 Jul 23:49 mdns-repeater.old
-rwxr-xr-x  1 forst  staff  26328 12 Jul 00:01 mdns-repeater.new

% file mdns-repeater.old mdns-repeater.new
mdns-repeater.old: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-musl-aarch64.so.1, stripped
mdns-repeater.new: ELF 64-bit LSB pie executable, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-musl-aarch64.so.1, with debug_info, not stripped
```

Tested working in my setup, IPv4 mDNS packets forwarded between two LAN segments as I would expect.