### PR TITLE
python-pexpect: add package

### DIFF
--- a/lang/python/python-pexpect/Makefile
+++ b/lang/python/python-pexpect/Makefile
@@ -1,0 +1,40 @@
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-pexpect
+PKG_VERSION:=4.9.0
+PKG_RELEASE:=1
+
+PYPI_NAME:=pexpect
+PKG_HASH:=ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f
+
+PKG_LICENSE:=ISC
+PKG_LICENSE_FILES:=LICENSE
+PKG_MAINTAINER:=Philip Prindeville <philipp@redfish-solutions.com>, Alexandru Ardelean <alex@shruggie.ro>
+
+PKG_BUILD_DEPENDS:=python-setuptools/host
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-pexpect
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=Pexpect is a Pure Python Expect-like module
+  URL:=https://github.com/pexpect/pexpect
+  DEPENDS:=+python3-light +python3-ptyprocess
+endef
+
+define Package/python3-pexpect/description
+  Pexpect is a Pure Python Expect-like module
+
+  Pexpect makes Python a better tool for controlling other applications.
+endef
+
+$(eval $(call Py3Package,python3-pexpect))
+$(eval $(call BuildPackage,python3-pexpect))
+$(eval $(call BuildPackage,python3-pexpect-src))

--- a/lang/python/python-pexpect/test.sh
+++ b/lang/python/python-pexpect/test.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+[ "$1" = "python3-pexpect" ] || exit 0
+
+# current installed version from python metadata
+installed_version="$(python3 -c 'import pexpect; print(pexpect.__version__)')"
+
+# use expected version from package metadata/environment
+expected_version="${PKG_VERSION}"
+
+if [ "$installed_version" != "$expected_version" ]; then
+    echo "Wrong version: $installed_version (expected $expected_version)"
+    exit 1
+fi
+
+python3 - << 'EOF'
+import pexpect
+
+pattern = "pexpect-test"
+child = pexpect.spawn('sh', ['-c', 'printf "%s\\n" "pexpect-test"'], encoding='utf-8')
+child.expect_exact(pattern)
+child.expect(pexpect.EOF)
+child.close()
+assert child.exitstatus == 0, f"child exited {child.exitstatus}"
+
+print("python3-pexpect OK")
+EOF

--- a/lang/python/python-ptyprocess/Makefile
+++ b/lang/python/python-ptyprocess/Makefile
@@ -1,0 +1,38 @@
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-ptyprocess
+PKG_VERSION:=0.7.0
+PKG_RELEASE:=1
+
+PYPI_NAME:=ptyprocess
+PKG_HASH:=5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220
+
+PKG_LICENSE:=ISC
+PKG_LICENSE_FILES:=LICENSE
+PKG_MAINTAINER:=Philip Prindeville <philipp@redfish-solutions.com>, Alexandru Ardelean <alex@shruggie.ro>
+
+PKG_BUILD_DEPENDS:=python-setuptools/host
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-ptyprocess
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=Launch a subprocess in a pseudo terminal (pty), and interact with both the process and its pty.
+  URL:=https://github.com/pexpect/ptyprocess
+  DEPENDS:=+python3-light
+endef
+
+define Package/python3-ptyprocess/description
+  Launch a subprocess in a pseudo terminal (pty), and interact with both the process and its pty.
+endef
+
+$(eval $(call Py3Package,python3-ptyprocess))
+$(eval $(call BuildPackage,python3-ptyprocess))
+$(eval $(call BuildPackage,python3-ptyprocess-src))


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me, @commodo 

**Description:**
Useful for provisioning devices like modems that present themselves via a serial device.


---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** bpi-r4-pro-8x

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
