### PR TITLE
gpgme: use target staging gpgrt-config

### DIFF
--- a/libs/gpgme/Makefile
+++ b/libs/gpgme/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gpgme
 PKG_VERSION:=2.1.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://gnupg.org/ftp/gcrypt/$(PKG_NAME)
@@ -18,6 +18,8 @@ PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
+
+CONFIGURE_VARS += ac_cv_path_GPGRT_CONFIG="$(STAGING_DIR)/usr/bin/gpgrt-config"
 
 define Package/libgpgme
   SECTION:=libs


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @dangowrt
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

`gpgme`'s configure script looks up `gpgrt-config` through `PATH`. When the host tool is installed, configure may select the host copy and inject host paths such as `/usr/include` and `/usr/lib` into the cross build, mixing glibc headers with the target musl headers.

This change pins the configure lookup to the target staging tool:

```make
CONFIGURE_VARS += ac_cv_path_GPGRT_CONFIG="$(STAGING_DIR)/usr/bin/gpgrt-config"
```

This matches the existing handling in `libassuan`. `PKG_RELEASE` is also incremented from 2 to 3.

Related: #19880

The fix was validated in an OpenWrt-derived x86_64 full image build: configure no longer selected the host `gpgrt-config`, and `gpgme` compiled successfully.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** `master`
- **OpenWrt Target/Subtarget:** `x86/64`
- **OpenWrt Device:** `Not run on upstream master; issue reproduced in an OpenWrt-derived x86_64 build`

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
