### PR TITLE
openwrt-25.12: update runc 1.3.6, containerd 2.2.5, dockerd 29.6.1, docker 29.6.1

### DIFF
--- a/utils/containerd/Makefile
+++ b/utils/containerd/Makefile
@@ -1,39 +1,43 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=containerd
-PKG_VERSION:=1.7.22
-PKG_RELEASE:=2
+PKG_VERSION:=2.2.5
+PKG_RELEASE:=1
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 PKG_CPE_ID:=cpe:/a:linuxfoundation:containerd
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/containerd/containerd/tar.gz/v${PKG_VERSION}?
-PKG_HASH:=8c5edde741b7596af63c021429a1212bd616350ed65a7b741eeffc47e27ee9a9
+PKG_HASH:=ca9c2084ab92b3ce073fa4e43f29a0cad33c2ea71d4e09777acfc082b90049db
 
 PKG_MAINTAINER:=Gerard Ryan <G.M0N3Y.2503@gmail.com>
 
 PKG_BUILD_DEPENDS:=golang/host dockerd
 PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
-PKG_BUILD_FLAGS:=no-mips16
 
 GO_PKG:=github.com/containerd/containerd
 
 include $(INCLUDE_DIR)/package.mk
 include ../../lang/golang/golang-package.mk
 
+EMPTY:=
+SPACE:=$(EMPTY) $(EMPTY)
+ARCH_DEPENDS:=@($(subst $(SPACE),||,$(strip $(filter-out mips mips64 mipsel mips64el,$(subst ||,$(SPACE),$(patsubst @(%),%,$(GO_ARCH_DEPENDS)))))))
+
 define Package/containerd
   SECTION:=utils
   CATEGORY:=Utilities
   TITLE:=containerd container runtime
   URL:=https://containerd.io/
-  DEPENDS:=$(GO_ARCH_DEPENDS) +btrfs-progs +runc
+  DEPENDS:=$(ARCH_DEPENDS) +btrfs-progs +runc
   MENU:=1
 endef
 
 define Package/containerd/description
-An industry-standard container runtime with an emphasis on simplicity, robustness and portability
+  An industry-standard container runtime with an emphasis on simplicity,
+  robustness and portability.
 endef
 
 GO_PKG_INSTALL_EXTRA:=\
@@ -59,7 +63,7 @@ Build/Compile=$(call Build/Compile/Default)
 
 define Package/containerd/install
 	$(INSTALL_DIR) $(1)/usr/bin/
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/bin/{ctr,containerd,containerd-stress,containerd-shim,containerd-shim-runc-v1,containerd-shim-runc-v2} $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/bin/{ctr,containerd,containerd-stress,containerd-shim-runc-v2} $(1)/usr/bin/
 endef
 
 $(eval $(call BuildPackage,containerd))

--- a/utils/docker/Makefile
+++ b/utils/docker/Makefile
@@ -1,8 +1,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=docker
-PKG_VERSION:=27.3.1
-PKG_RELEASE:=2
+PKG_VERSION:=29.6.1
+PKG_RELEASE:=1
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 
@@ -10,30 +10,33 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_GIT_URL:=github.com/docker/cli
 PKG_GIT_REF:=v$(PKG_VERSION)
 PKG_SOURCE_URL:=https://codeload.$(PKG_GIT_URL)/tar.gz/$(PKG_GIT_REF)?
-PKG_HASH:=df7d44387166d90954e290dfbe0a278649bf71d0e89933615bdc0757580b68e4
-PKG_GIT_SHORT_COMMIT:=ce12230 # SHA1 used within the docker executables
+PKG_HASH:=74d14dd212b07cd3328989dc6a029dde2ebbe6a878199eaaafad54916f456194
+PKG_GIT_SHORT_COMMIT:=8900f1d # SHA1 used within the docker executables
 
 PKG_MAINTAINER:=Gerard Ryan <G.M0N3Y.2503@gmail.com>
 
 PKG_BUILD_DEPENDS:=golang/host dockerd
 PKG_BUILD_PARALLEL:=1
-PKG_BUILD_FLAGS:=no-mips16
 
 GO_PKG:=$(PKG_GIT_URL)
 
 include $(INCLUDE_DIR)/package.mk
 include ../../lang/golang/golang-package.mk
 
+EMPTY:=
+SPACE:=$(EMPTY) $(EMPTY)
+ARCH_DEPENDS:=@($(subst $(SPACE),||,$(strip $(filter-out mips mips64 mipsel mips64el,$(subst ||,$(SPACE),$(patsubst @(%),%,$(GO_ARCH_DEPENDS)))))))
+
 define Package/docker
   SECTION:=utils
   CATEGORY:=Utilities
   TITLE:=Docker Community Edition CLI
   URL:=https://www.docker.com/
-  DEPENDS:=$(GO_ARCH_DEPENDS)
+  DEPENDS:=$(ARCH_DEPENDS)
 endef
 
 define Package/docker/description
-The CLI used in the Docker CE and Docker EE products.
+  The CLI used in the Docker CE and Docker EE products.
 endef
 
 GO_PKG_INSTALL_EXTRA:=\
@@ -44,27 +47,24 @@ TAR_OPTIONS:=--strip-components 1 $(TAR_OPTIONS)
 TAR_CMD=$(HOST_TAR) -C $(1) $(TAR_OPTIONS)
 TARGET_LDFLAGS += $(if $(CONFIG_USE_GLIBC),-lc -lgcc_eh)
 
+# Verify PKG_GIT_SHORT_COMMIT
 define Build/Prepare
 	$(Build/Prepare/Default)
 
-	# Verify PKG_GIT_SHORT_COMMIT
-	( \
-		EXPECTED_PKG_GIT_SHORT_COMMIT=$$$$( $(CURDIR)/../dockerd/git-short-commit.sh '$(PKG_GIT_URL)' '$(PKG_GIT_REF)' '$(TMP_DIR)/git-short-commit/$(PKG_NAME)-$(PKG_VERSION)' ); \
-		if [ "$$$${EXPECTED_PKG_GIT_SHORT_COMMIT}" != "$(strip $(PKG_GIT_SHORT_COMMIT))" ]; then \
-			echo "ERROR: Expected 'PKG_GIT_SHORT_COMMIT:=$$$${EXPECTED_PKG_GIT_SHORT_COMMIT}', found 'PKG_GIT_SHORT_COMMIT:=$(strip $(PKG_GIT_SHORT_COMMIT))'"; \
-			exit 1; \
-		fi \
-	)
+	EXPECTED_PKG_GIT_SHORT_COMMIT=$$$$( $(CURDIR)/../dockerd/git-short-commit.sh '$(PKG_GIT_URL)' '$(PKG_GIT_REF)' '$(TMP_DIR)/git-short-commit/$(PKG_NAME)-$(PKG_VERSION)' ); \
+	if [ "$$$${EXPECTED_PKG_GIT_SHORT_COMMIT}" != "$(strip $(PKG_GIT_SHORT_COMMIT))" ]; then \
+		echo "ERROR: Expected 'PKG_GIT_SHORT_COMMIT:=$$$${EXPECTED_PKG_GIT_SHORT_COMMIT}', found 'PKG_GIT_SHORT_COMMIT:=$(strip $(PKG_GIT_SHORT_COMMIT))'"; \
+		exit 1; \
+	fi
 endef
 
 define Build/Compile
-	( \
-		cd $(PKG_BUILD_DIR); \
-		$(GO_PKG_VARS) \
-		GITCOMMIT=$(PKG_GIT_SHORT_COMMIT) \
-		VERSION=$(PKG_VERSION) \
-		./scripts/build/binary; \
-	)
+	cd $(PKG_BUILD_DIR); \
+	$(GO_PKG_VARS) \
+	GITCOMMIT=$(PKG_GIT_SHORT_COMMIT) \
+	VERSION=$(PKG_VERSION) \
+	TARGET=$(PKG_BUILD_DIR)/build \
+	./scripts/build/binary
 endef
 
 define Package/docker/install

--- a/utils/dockerd/Makefile
+++ b/utils/dockerd/Makefile
@@ -1,28 +1,32 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dockerd
-PKG_VERSION:=27.3.1
-PKG_RELEASE:=4
+PKG_VERSION:=29.6.1
+PKG_RELEASE:=1
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
+PKG_CPE_ID:=cpe:/a:mobyproject:moby
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_GIT_URL:=github.com/moby/moby
-PKG_GIT_REF:=v$(PKG_VERSION)
+PKG_GIT_REF:=docker-v$(PKG_VERSION)
 PKG_SOURCE_URL:=https://codeload.$(PKG_GIT_URL)/tar.gz/$(PKG_GIT_REF)?
-PKG_HASH:=d18208d9e0b6421307342cdef266193984c97c87177b9262b1113e6e9e7e020e
-PKG_GIT_SHORT_COMMIT:=41ca978 # SHA1 used within the docker executables
+PKG_HASH:=a97bd870c4b072b7d9cc053b2a806ca3d920f192f9dc6a662e17c1b69f56f2e1
+PKG_GIT_SHORT_COMMIT:=8ec5ab3 # SHA1 used within the docker executables
 
 PKG_MAINTAINER:=Gerard Ryan <G.M0N3Y.2503@gmail.com>
 
 PKG_BUILD_DEPENDS:=golang/host
 PKG_BUILD_PARALLEL:=1
-PKG_BUILD_FLAGS:=no-mips16
 
 GO_PKG:=github.com/docker/docker
 
 include $(INCLUDE_DIR)/package.mk
 include ../../lang/golang/golang-package.mk
+
+EMPTY:=
+SPACE:=$(EMPTY) $(EMPTY)
+ARCH_DEPENDS:=@($(subst $(SPACE),||,$(strip $(filter-out mips mips64 mipsel mips64el,$(subst ||,$(SPACE),$(patsubst @(%),%,$(GO_ARCH_DEPENDS)))))))
 
 define Package/dockerd/config
   source "$(SOURCE)/Config.in"
@@ -33,7 +37,7 @@ define Package/dockerd
   CATEGORY:=Utilities
   TITLE:=Docker Community Edition Daemon
   URL:=https://www.docker.com/
-  DEPENDS:=$(GO_ARCH_DEPENDS) \
+  DEPENDS:=$(ARCH_DEPENDS) \
     +ca-certificates \
     +containerd \
     +iptables \
@@ -46,8 +50,7 @@ define Package/dockerd
     +kmod-nf-ipvs \
     +kmod-veth \
     +tini \
-    +uci-firewall \
-    @!(mips||mips64||mipsel)
+    +uci-firewall
   USERID:=docker:docker
   MENU:=1
 endef
@@ -57,65 +60,45 @@ define Package/dockerd/conffiles
 endef
 
 define Package/dockerd/description
-The Docker CE Engine.
+  The Docker CE Engine.
 endef
 
 TAR_OPTIONS:=--strip-components 1 $(TAR_OPTIONS)
 TAR_CMD=$(HOST_TAR) -C $(1) $(TAR_OPTIONS)
 TARGET_LDFLAGS += $(if $(CONFIG_USE_GLIBC),-lc -lgcc_eh)
 
-# $(1) = path to dependent package 'Makefile'
-# $(2) = relevant dependency '.installer' file
+# $(1) = OpenWrt dependent PKG_NAME
 define EnsureVendoredVersion
-	( \
-		DEP_VER=$$$$( grep --only-matching --perl-regexp '(?<=PKG_VERSION:=)(.*)' "$(1)" ); \
-		VEN_VER=$$$$( grep --only-matching --perl-regexp '(?<=_VERSION:=v)(.*)(?=})' "$(PKG_BUILD_DIR)/hack/dockerfile/install/$(2)" ); \
-		if [ "$$$${VEN_VER}" != "$$$${DEP_VER}" ]; then \
-			echo "ERROR: $(PKG_NAME) Expected 'PKG_VERSION:=$$$${VEN_VER}' in '$(1)', found 'PKG_VERSION:=$$$${DEP_VER}'"; \
-			exit 1; \
-		fi \
-	)
-endef
-
-# $(1) = path to dependent package 'Makefile'
-# $(2) = relevant dependency '.installer' file
-define EnsureVendoredCommit
-	( \
-		DEP_VER=$$$$( grep --only-matching --perl-regexp '(?<=PKG_SOURCE_VERSION:=)(.*)' "$(1)" ); \
-		VEN_VER=$$$$( grep --only-matching --perl-regexp '(?<=_COMMIT:=)(.*)(?=})' "$(PKG_BUILD_DIR)/hack/dockerfile/install/$(2)" ); \
-		if [ "$$$${VEN_VER}" != "$$$${DEP_VER}" ]; then \
-			echo "ERROR: Expected 'PKG_SOURCE_VERSION:=$$$${VEN_VER}' in '$(1)', found 'PKG_SOURCE_VERSION:=$$$${DEP_VER}'"; \
-			exit 1; \
-		fi \
-	)
+	DEP_VER=$$$$( grep --only-matching --perl-regexp '(?<=PKG_VERSION:=)(.*)' "../$(1)/Makefile" ); \
+	VEN_VER=$$$$( grep --only-matching --perl-regexp '(?<=$(call toupper,$(1))_VERSION=v)(.*)' "$(PKG_BUILD_DIR)/Dockerfile" ); \
+	if [ "$$$${VEN_VER}" != "$$$${DEP_VER}" ]; then \
+		echo "ERROR: $(PKG_NAME) Expected 'PKG_VERSION:=$$$${VEN_VER}' in '$(1)', found 'PKG_VERSION:=$$$${DEP_VER}'"; \
+		exit 1; \
+	fi
 endef
 
 define Build/Prepare
 	$(Build/Prepare/Default)
 
 	# Verify dependencies are the vendored version
-	$(call EnsureVendoredVersion,../containerd/Makefile,containerd.installer)
-	$(call EnsureVendoredVersion,../runc/Makefile,runc.installer)
-	$(call EnsureVendoredVersion,../tini/Makefile,tini.installer)
+	$(call EnsureVendoredVersion,containerd)
+	$(call EnsureVendoredVersion,runc)
+	$(call EnsureVendoredVersion,tini)
 
 	# Verify CLI is the same version
-	( \
-		CLI_MAKEFILE="../docker/Makefile"; \
-		CLI_VERSION=$$$$( grep --only-matching --perl-regexp '(?<=PKG_VERSION:=)(.*)' "$$$${CLI_MAKEFILE}" ); \
-		if [ "$$$${CLI_VERSION}" != "$(PKG_VERSION)" ]; then \
-			echo "ERROR: Expected 'PKG_VERSION:=$(PKG_VERSION)' in '$$$${CLI_MAKEFILE}', found 'PKG_VERSION:=$$$${CLI_VERSION}'"; \
-			exit 1; \
-		fi \
-	)
+	CLI_MAKEFILE="../docker/Makefile"; \
+	CLI_VERSION=$$$$( grep --only-matching --perl-regexp '(?<=PKG_VERSION:=)(.*)' "$$$${CLI_MAKEFILE}" ); \
+	if [ "$$$${CLI_VERSION}" != "$(PKG_VERSION)" ]; then \
+		echo "ERROR: Expected 'PKG_VERSION:=$(PKG_VERSION)' in '$$$${CLI_MAKEFILE}', found 'PKG_VERSION:=$$$${CLI_VERSION}'"; \
+		exit 1; \
+	fi
 
 	# Verify PKG_GIT_SHORT_COMMIT
-	( \
-		EXPECTED_PKG_GIT_SHORT_COMMIT=$$$$( $(CURDIR)/git-short-commit.sh '$(PKG_GIT_URL)' '$(PKG_GIT_REF)' '$(TMP_DIR)/git-short-commit/$(PKG_NAME)-$(PKG_VERSION)' ); \
-		if [ "$$$${EXPECTED_PKG_GIT_SHORT_COMMIT}" != "$(strip $(PKG_GIT_SHORT_COMMIT))" ]; then \
-			echo "ERROR: Expected 'PKG_GIT_SHORT_COMMIT:=$$$${EXPECTED_PKG_GIT_SHORT_COMMIT}', found 'PKG_GIT_SHORT_COMMIT:=$(strip $(PKG_GIT_SHORT_COMMIT))'"; \
-			exit 1; \
-		fi \
-	)
+	EXPECTED_PKG_GIT_SHORT_COMMIT=$$$$( $(CURDIR)/git-short-commit.sh '$(PKG_GIT_URL)' '$(PKG_GIT_REF)' '$(TMP_DIR)/git-short-commit/$(PKG_NAME)-$(PKG_VERSION)' ); \
+	if [ "$$$${EXPECTED_PKG_GIT_SHORT_COMMIT}" != "$(strip $(PKG_GIT_SHORT_COMMIT))" ]; then \
+		echo "ERROR: Expected 'PKG_GIT_SHORT_COMMIT:=$$$${EXPECTED_PKG_GIT_SHORT_COMMIT}', found 'PKG_GIT_SHORT_COMMIT:=$(strip $(PKG_GIT_SHORT_COMMIT))'"; \
+		exit 1; \
+	fi
 endef
 
 BUILDTAGS:=
@@ -127,14 +110,12 @@ BUILDTAGS += selinux
 endif
 
 define Build/Compile
-	( \
-		cd $(PKG_BUILD_DIR); \
-		$(GO_PKG_VARS) \
-		DOCKER_GITCOMMIT=$(PKG_GIT_SHORT_COMMIT) \
-		DOCKER_BUILDTAGS='$(BUILDTAGS)' \
-		VERSION=$(PKG_VERSION) \
-		./hack/make.sh binary; \
-	)
+	cd $(PKG_BUILD_DIR); \
+	$(GO_PKG_VARS) \
+	DOCKER_GITCOMMIT=$(PKG_GIT_SHORT_COMMIT) \
+	DOCKER_BUILDTAGS='$(BUILDTAGS)' \
+	VERSION=$(PKG_VERSION) \
+	./hack/make.sh binary
 endef
 
 define Package/dockerd/install

--- a/utils/runc/Makefile
+++ b/utils/runc/Makefile
@@ -1,38 +1,42 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=runc
-PKG_VERSION:=1.1.14
-PKG_RELEASE:=2
+PKG_VERSION:=1.3.6
+PKG_RELEASE:=1
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 PKG_CPE_ID:=cpe:/a:linuxfoundation:runc
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/opencontainers/runc/tar.gz/v${PKG_VERSION}?
-PKG_HASH:=563cf57c38d2e7149234dbe6f63ca0751eb55ef8f586ed12a543dedc1aceba68
+PKG_HASH:=8816e8d4181d13012d16733e837425f5f67df57dfac28bc58a68f7dfcd54291b
 
 PKG_MAINTAINER:=Gerard Ryan <G.M0N3Y.2503@gmail.com>
 
 PKG_BUILD_DEPENDS:=golang/host dockerd
 PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
-PKG_BUILD_FLAGS:=no-mips16
 
 GO_PKG:=github.com/opencontainers/runc
 
 include $(INCLUDE_DIR)/package.mk
 include ../../lang/golang/golang-package.mk
 
+EMPTY:=
+SPACE:=$(EMPTY) $(EMPTY)
+ARCH_DEPENDS:=@($(subst $(SPACE),||,$(strip $(filter-out mips mips64 mipsel mips64el,$(subst ||,$(SPACE),$(patsubst @(%),%,$(GO_ARCH_DEPENDS)))))))
+
 define Package/runc
   SECTION:=utils
   CATEGORY:=Utilities
   TITLE:=runc container runtime
   URL:=https://www.opencontainers.org/
-  DEPENDS:=$(GO_ARCH_DEPENDS) +KERNEL_SECCOMP_FILTER:libseccomp
+  DEPENDS:=$(ARCH_DEPENDS) +KERNEL_SECCOMP_FILTER:libseccomp
 endef
 
 define Package/runc/description
-runc is a CLI tool for spawning and running containers according to the OCI specification.
+  runc is a CLI tool for spawning and running containers according to the OCI
+  specification.
 endef
 
 GO_PKG_INSTALL_ALL:=1


### PR DESCRIPTION
Backport updates to 25.12 stable branch. 4 separate commits:

1. runc: 1.1.14 -> 1.3.6
2. containerd: 1.7.22 -> 2.2.5 (removed deprecated shim binaries)
3. dockerd: 27.3.1 -> 29.6.1 (MIPS exclusion, config updates)
4. docker: 27.3.1 -> 29.6.1

Adapted from master PR #29218.