### PR TITLE
runc 1.3.6, containerd 2.2.5, dockerd 29.6.1, docker 29.6.1

### DIFF
--- a/utils/containerd/Makefile
+++ b/utils/containerd/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=containerd
-PKG_VERSION:=2.2.3
+PKG_VERSION:=2.2.5
 PKG_RELEASE:=1
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
@@ -9,7 +9,7 @@ PKG_CPE_ID:=cpe:/a:linuxfoundation:containerd
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/containerd/containerd/tar.gz/v${PKG_VERSION}?
-PKG_HASH:=b97780bde4b01ed3596b0b0c6f55bfb130794a3db4e6fe2e0fc9719244933945
+PKG_HASH:=ca9c2084ab92b3ce073fa4e43f29a0cad33c2ea71d4e09777acfc082b90049db
 
 PKG_MAINTAINER:=Gerard Ryan <G.M0N3Y.2503@gmail.com>
 

--- a/utils/docker/Makefile
+++ b/utils/docker/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=docker
-PKG_VERSION:=29.4.1
+PKG_VERSION:=29.6.1
 PKG_RELEASE:=1
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
@@ -10,8 +10,8 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_GIT_URL:=github.com/docker/cli
 PKG_GIT_REF:=v$(PKG_VERSION)
 PKG_SOURCE_URL:=https://codeload.$(PKG_GIT_URL)/tar.gz/$(PKG_GIT_REF)?
-PKG_HASH:=b45d935ab8f5faff8b0a03eb6c5c658636f47bc8170d892152b8eb57f5931315
-PKG_GIT_SHORT_COMMIT:=055a478 # SHA1 used within the docker executables
+PKG_HASH:=74d14dd212b07cd3328989dc6a029dde2ebbe6a878199eaaafad54916f456194
+PKG_GIT_SHORT_COMMIT:=8900f1d # SHA1 used within the docker executables
 
 PKG_MAINTAINER:=Gerard Ryan <G.M0N3Y.2503@gmail.com>
 
@@ -24,7 +24,7 @@ include $(INCLUDE_DIR)/package.mk
 include ../../lang/golang/golang-package.mk
 
 EMPTY:=
-SPACE:= $(EMPTY) $(EMPTY)
+SPACE:=$(EMPTY) $(EMPTY)
 ARCH_DEPENDS:=@($(subst $(SPACE),||,$(strip $(filter-out mips mips64 mipsel mips64el,$(subst ||,$(SPACE),$(patsubst @(%),%,$(GO_ARCH_DEPENDS)))))))
 
 define Package/docker

--- a/utils/dockerd/Makefile
+++ b/utils/dockerd/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dockerd
-PKG_VERSION:=29.4.1
+PKG_VERSION:=29.6.1
 PKG_RELEASE:=1
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
@@ -11,8 +11,8 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_GIT_URL:=github.com/moby/moby
 PKG_GIT_REF:=docker-v$(PKG_VERSION)
 PKG_SOURCE_URL:=https://codeload.$(PKG_GIT_URL)/tar.gz/$(PKG_GIT_REF)?
-PKG_HASH:=89ef4a0f681ae2c9f7449591243e1e932d86e6086ac3392a47da80c10b1a3d58
-PKG_GIT_SHORT_COMMIT:=6c91b92 # SHA1 used within the docker executables
+PKG_HASH:=a97bd870c4b072b7d9cc053b2a806ca3d920f192f9dc6a662e17c1b69f56f2e1
+PKG_GIT_SHORT_COMMIT:=8ec5ab3 # SHA1 used within the docker executables
 
 PKG_MAINTAINER:=Gerard Ryan <G.M0N3Y.2503@gmail.com>
 
@@ -25,7 +25,7 @@ include $(INCLUDE_DIR)/package.mk
 include ../../lang/golang/golang-package.mk
 
 EMPTY:=
-SPACE:= $(EMPTY) $(EMPTY)
+SPACE:=$(EMPTY) $(EMPTY)
 ARCH_DEPENDS:=@($(subst $(SPACE),||,$(strip $(filter-out mips mips64 mipsel mips64el,$(subst ||,$(SPACE),$(patsubst @(%),%,$(GO_ARCH_DEPENDS)))))))
 
 define Package/dockerd/config

--- a/utils/runc/Makefile
+++ b/utils/runc/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=runc
-PKG_VERSION:=1.3.5
+PKG_VERSION:=1.3.6
 PKG_RELEASE:=1
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
@@ -9,7 +9,7 @@ PKG_CPE_ID:=cpe:/a:linuxfoundation:runc
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/opencontainers/runc/tar.gz/v${PKG_VERSION}?
-PKG_HASH:=72620f9b0e62d8da80c0c08a6265ab10d24330c544115c30713ba1429bde706d
+PKG_HASH:=8816e8d4181d13012d16733e837425f5f67df57dfac28bc58a68f7dfcd54291b
 
 PKG_MAINTAINER:=Gerard Ryan <G.M0N3Y.2503@gmail.com>
 


### PR DESCRIPTION
Bump to latest upstream versions. 4 separate commits:

1. runc: 1.1.14 -> 1.3.6
2. containerd: 2.2.3 -> 2.2.5
3. dockerd: 29.4.1 -> 29.6.1
4. docker: 29.4.1 -> 29.6.1

Docker 29.6.1 includes security fixes for GHSA-mjcv-p78q-w5fw,
GHSA-jpcc-p29g-p8mq, GHSA-72x6-4j93-7w86, GHSA-7236-3392-c5c6.