### PR TITLE
iPerf3: add procd service

### DIFF
--- a/net/iperf3/Makefile
+++ b/net/iperf3/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=iperf
 PKG_VERSION:=3.21
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.es.net/pub/iperf
@@ -97,11 +97,17 @@ endef
 define Package/iperf3/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/iperf3 $(1)/usr/bin/
+
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/etc/init.d/iperf3 $(1)/etc/init.d/iperf3
 endef
 
 define Package/iperf3-ssl/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/iperf3 $(1)/usr/bin/
+
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/etc/init.d/iperf3 $(1)/etc/init.d/iperf3
 endef
 
 define Package/libiperf3/install

--- a/net/iperf3/files/etc/init.d/iperf3
+++ b/net/iperf3/files/etc/init.d/iperf3
@@ -1,0 +1,27 @@
+#!/bin/sh /etc/rc.common
+
+USE_PROCD=1
+
+START=99
+STOP=01
+
+prog_path="/usr/bin/iperf3"
+
+service_data() {
+  "${prog_path}" -v | grep -E '^iperf \d+\.\d+.*$'
+}
+
+start_service() {
+  procd_open_instance
+  procd_set_param command "${prog_path}" -s
+  procd_set_param stdout 1
+  procd_set_param stderr 1
+  procd_set_param respawn 10 10 10
+  procd_set_param user nobody
+  procd_close_instance
+}
+
+reload_service() {
+  stop
+  start
+}

--- a/net/iperf3/test.sh
+++ b/net/iperf3/test.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+case "$1" in
+    "iperf3"|"iperf3-ssl")
+        service iperf3 start
+        sleep 2
+        iperf3 --client localhost --time 3 --bitrate 1M --connect-timeout 2000
+        result=$?
+        service iperf3 stop
+        exit ${result}
+        ;;
+    *)
+        echo "Untested package: ${1}" >&2
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
## 📦 Package Details

**Felix Fietkau:** @nbd168

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

Added a basic procd service file and test.

---

## 🧪 Run Testing Details

- **OpenWrt Version: 25.12.5**
- **OpenWrt Target/Subtarget: mediatek/filogic** (MT7986AV CPU)
- **OpenWrt Device: [Banana Pi BPi-R3 Mini](https://openwrt.org/toh/sinovoip/bananapi_bpi_r3_mini)**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.


