### PR TITLE
lighttpd: update to lighttpd 1.4.85 release hash - backport to openwrt 24.10

### DIFF
--- a/net/lighttpd/Makefile
+++ b/net/lighttpd/Makefile
@@ -8,14 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lighttpd
-PKG_VERSION:=1.4.84
+PKG_VERSION:=1.4.85
 PKG_RELEASE:=1
 # release candidate ~rcX testing; remove for release
 #PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://download.lighttpd.net/lighttpd/releases-1.4.x
-PKG_HASH:=076dd43bec8f2ba9ce6db7e7ca7e8ad72271cd529805ead2400b56efaa026f70
+PKG_HASH:=18de51b393bac4a6827879e1a7ff377c169e414bae92cd245091d80fc2601d13
 
 PKG_MAINTAINER:=Glenn Strauss <gstrauss@gluelogic.com>
 PKG_LICENSE:=BSD-3-Clause

--- a/net/lighttpd/patches/030-Revert-TLS-modify-TLS-defaults-to-MinProtocol-TLSv1.3.patch
+++ b/net/lighttpd/patches/030-Revert-TLS-modify-TLS-defaults-to-MinProtocol-TLSv1.3.patch
@@ -70,7 +70,7 @@ Signed-off-by: Glenn Strauss <gstrauss@gluelogic.com>
  }
 --- a/src/mod_mbedtls.c
 +++ b/src/mod_mbedtls.c
-@@ -5071,8 +5071,6 @@ mod_mbedtls_ssl_conf_dhparameters(server
+@@ -5091,8 +5091,6 @@ mod_mbedtls_ssl_conf_dhparameters(server
  static void
  mod_mbedtls_ssl_conf_proto (server *srv, plugin_config_socket *s, const buffer *b, int max)
  {
@@ -79,7 +79,7 @@ Signed-off-by: Glenn Strauss <gstrauss@gluelogic.com>
      int v = MBEDTLS_SSL_MINOR_VERSION_3; /* default: TLS v1.2 */
      if (NULL == b) /* default: min TLSv1.2, max TLSv1.3 */
        #ifdef MBEDTLS_SSL_MINOR_VERSION_4
-@@ -5145,20 +5143,9 @@ mod_mbedtls_ssl_conf_proto (server *srv,
+@@ -5165,20 +5163,9 @@ mod_mbedtls_ssl_conf_proto (server *srv,
  static void
  mod_mbedtls_ssl_conf_proto (server *srv, plugin_config_socket *s, const buffer *b, int max)
  {
@@ -100,7 +100,7 @@ Signed-off-by: Glenn Strauss <gstrauss@gluelogic.com>
      else if (buffer_eq_icase_slen(b, CONST_STR_LEN("None"))) /*"disable" limit*/
          v = max ? MBEDTLS_SSL_VERSION_TLS1_3 : MBEDTLS_SSL_VERSION_TLS1_2;
      else if (buffer_eq_icase_slen(b, CONST_STR_LEN("TLSv1.2")))
-@@ -5180,9 +5167,6 @@ mod_mbedtls_ssl_conf_proto (server *srv,
+@@ -5200,9 +5187,6 @@ mod_mbedtls_ssl_conf_proto (server *srv,
              return;
          }
      }


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me (@gstrauss)

**Description:**
Backport: #29957

lighttpd: update to lighttpd 1.4.85 release hash

Release notes:
Ref: https://www.lighttpd.net/2026/07/08/1.4.85/

(cherry picked from commit 143195230bdc6aecf6c816a8e065fbd9c0b509c7)
---

## 🧪 Run Testing Details

Compile tested: arm_cortex-a9 OpenWrt 24.10

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>