### PR TITLE
fwupd: allow enabling the devlink plugin

### DIFF
--- a/utils/fwupd/Config.in
+++ b/utils/fwupd/Config.in
@@ -36,6 +36,12 @@ config FWUPD_LIBDRM
 	help
 	  Compile fwupd with libdrm support
 
+config FWUPD_PLUGIN_DEVLINK
+	bool "devlink plugin"
+	default y
+	help
+	  Compile fwupd with devlink plugin
+
 config FWUPD_PLUGIN_MODEMMANAGER
 	bool "ModemManager plugin"
 	default y

--- a/utils/fwupd/Makefile
+++ b/utils/fwupd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fwupd
 PKG_VERSION:=2.1.6
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/fwupd/fwupd/releases/download/$(PKG_VERSION)
@@ -56,6 +56,7 @@ define Package/fwupd-libs
 	+FWUPD_GNUTLS:libgnutls \
 	+FWUPD_OPENSSL:libopenssl \
 	+FWUPD_LIBDRM:libdrm \
+	+FWUPD_PLUGIN_DEVLINK:libmnl \
 	+FWUPD_PLUGIN_MODEMMANAGER:modemmanager \
 	+FWUPD_PLUGIN_MODEMMANAGER:libqmi \
 	+FWUPD_PLUGIN_MODEMMANAGER:libmbim
@@ -104,7 +105,7 @@ MESON_ARGS += \
 	-Dhsi=$(if $(CONFIG_FWUPD_HSI),enabled,disabled) \
 	-Dintrospection=disabled \
 	-Dlibdrm=$(if $(CONFIG_FWUPD_LIBDRM),enabled,disabled) \
-	-Dlibmnl=disabled \
+	-Dlibmnl=$(if $(CONFIG_FWUPD_PLUGIN_DEVLINK),enabled,disabled) \
 	-Dlogind=disabled \
 	-Dlvfs=$(if $(CONFIG_FWUPD_LVFS),true,false) \
 	-Dman=false \


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @lvoegl 

**Description:**
The devlink plugin allows updating firmware of network devices implementing the kernel devlink interface. It is gated on libmnl, which was hard-disabled so far. Wire the libmnl meson option to a new `FWUPD_PLUGIN_DEVLINK` config symbol, enabled by default, and add the corresponding libmnl runtime dependency to fwupd-libs.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** snapshot
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** BananaPi R4 Pro

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.