### PR TITLE
zabbix: add agent active checks compression

### DIFF
--- a/admin/zabbix/Config.in
+++ b/admin/zabbix/Config.in
@@ -1,4 +1,12 @@
 menu "Modify features for non-core variants"
+	config ZABBIX_ENABLE_AGENT_COMPRESSION
+		bool "Agent active checks compression"
+		default y
+		help
+			Enable zlib compression for agent active checks. When disabled,
+			the agent drops its zlib dependency, unless another selected
+			Zabbix package makes the shared build link zlib anyway.
+
 	config ZABBIX_CURL
 		bool "cURL support (default SSL)"
 		default y

--- a/admin/zabbix/Config.in
+++ b/admin/zabbix/Config.in
@@ -1,4 +1,13 @@
 menu "Modify features for non-core variants"
+	config ZABBIX_ENABLE_AGENT_COMPRESSION
+		bool "Agent active checks compression"
+		default y
+		help
+			Enable zlib compression for agent active checks. When disabled,
+			active checks are sent uncompressed and the agent drops its zlib
+			dependency, unless another selected Zabbix package makes the
+			shared build link zlib anyway.
+
 	config ZABBIX_CURL
 		bool "cURL support (default SSL)"
 		default y

--- a/admin/zabbix/Makefile
+++ b/admin/zabbix/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zabbix
 PKG_VERSION:=7.0.30
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://cdn.zabbix.com/zabbix/sources/stable/$(basename $(PKG_VERSION))/ \
@@ -27,6 +27,7 @@ PKG_BUILD_PARALLEL:=1
 PKG_CONFIG_DEPENDS:= \
   CONFIG_ZABBIX_CURL \
   CONFIG_ZABBIX_CURL_GNUTLS \
+  CONFIG_ZABBIX_ENABLE_AGENT_COMPRESSION \
   CONFIG_ZABBIX_GNUTLS \
   CONFIG_ZABBIX_LDAP \
   CONFIG_ZABBIX_MYSQL \
@@ -36,6 +37,32 @@ PKG_CONFIG_DEPENDS:= \
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
+
+ZABBIX_NEEDS_ZLIB:=$(strip \
+  $(CONFIG_ZABBIX_ENABLE_AGENT_COMPRESSION) \
+  $(CONFIG_PACKAGE_zabbix-get) \
+  $(CONFIG_PACKAGE_zabbix-proxy) \
+  $(CONFIG_PACKAGE_zabbix-proxy-basic-sqlite) \
+  $(CONFIG_PACKAGE_zabbix-sender) \
+  $(CONFIG_PACKAGE_zabbix-server))
+
+ifeq ($(CONFIG_ZABBIX_ENABLE_AGENT_COMPRESSION),y)
+# Compile the classic agent's active-check compression path. The real
+# zbx_compress() implementation it relies on is selected by HAVE_ZLIB below.
+TARGET_CPPFLAGS += -DZBX_AGENT_COMPRESSION
+endif
+
+ifneq ($(ZABBIX_NEEDS_ZLIB),)
+# Zabbix only probes zlib when server or proxy support is enabled. Define
+# HAVE_ZLIB for every configuration which supplies ZLIB_LIBS so the build uses
+# the real zbx_compress() rather than the failing fallback implementation.
+TARGET_CPPFLAGS += -DHAVE_ZLIB
+
+CONFIGURE_VARS += \
+  ZLIB_CFLAGS="-I$(STAGING_DIR)/usr/include" \
+  ZLIB_LDFLAGS="-L$(STAGING_DIR)/usr/lib" \
+  ZLIB_LIBS="-lz"
+endif
 
 define Package/zabbix-agentd/config
 	source "$(SOURCE)/Config.in"
@@ -115,7 +142,12 @@ define Package/zabbix-agentd/Default
     $(ICONV_DEPENDS) \
     +libevent2-pthreads \
     +libpcre2 \
-    +zlib
+    +ZABBIX_ENABLE_AGENT_COMPRESSION:zlib \
+    +PACKAGE_zabbix-get:zlib \
+    +PACKAGE_zabbix-proxy:zlib \
+    +PACKAGE_zabbix-proxy-basic-sqlite:zlib \
+    +PACKAGE_zabbix-sender:zlib \
+    +PACKAGE_zabbix-server:zlib
   PROVIDES:=\
     @zabbix-agentd-any \
     zabbix-agentd-ssl \
@@ -380,8 +412,11 @@ CONFIGURE_ARGS+= \
   $(call autoconf_bool,CONFIG_IPV6,ipv6) \
   --disable-java \
   --with-libevent=$(STAGING_DIR)/usr/include \
-  --with-libpcre2=$(STAGING_DIR)/usr/include \
-  --with-zlib=$(STAGING_DIR)/usr/include
+  --with-libpcre2=$(STAGING_DIR)/usr/include
+
+ifneq ($(ZABBIX_NEEDS_ZLIB),)
+CONFIGURE_ARGS += --with-zlib=$(STAGING_DIR)/usr
+endif
 endif
 
 ifeq ($(BUILD_VARIANT),basic)

--- a/admin/zabbix/Makefile
+++ b/admin/zabbix/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zabbix
 PKG_VERSION:=7.0.29
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://cdn.zabbix.com/zabbix/sources/stable/$(basename $(PKG_VERSION))/ \
@@ -27,6 +27,7 @@ PKG_BUILD_PARALLEL:=1
 PKG_CONFIG_DEPENDS:= \
   CONFIG_ZABBIX_CURL \
   CONFIG_ZABBIX_CURL_GNUTLS \
+  CONFIG_ZABBIX_ENABLE_AGENT_COMPRESSION \
   CONFIG_ZABBIX_GNUTLS \
   CONFIG_ZABBIX_LDAP \
   CONFIG_ZABBIX_MYSQL \
@@ -36,6 +37,32 @@ PKG_CONFIG_DEPENDS:= \
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
+
+ZABBIX_NEEDS_ZLIB:=$(strip \
+  $(CONFIG_ZABBIX_ENABLE_AGENT_COMPRESSION) \
+  $(CONFIG_PACKAGE_zabbix-get) \
+  $(CONFIG_PACKAGE_zabbix-proxy) \
+  $(CONFIG_PACKAGE_zabbix-proxy-basic-sqlite) \
+  $(CONFIG_PACKAGE_zabbix-sender) \
+  $(CONFIG_PACKAGE_zabbix-server))
+
+ifeq ($(CONFIG_ZABBIX_ENABLE_AGENT_COMPRESSION),y)
+# Compile the classic agent's active-check compression path. The real
+# zbx_compress() implementation it relies on is selected by HAVE_ZLIB below.
+TARGET_CPPFLAGS += -DZBX_AGENT_COMPRESSION
+endif
+
+ifneq ($(ZABBIX_NEEDS_ZLIB),)
+# Zabbix only probes zlib when server or proxy support is enabled. Define
+# HAVE_ZLIB for every configuration which supplies ZLIB_LIBS so the build uses
+# the real zbx_compress() rather than the failing fallback implementation.
+TARGET_CPPFLAGS += -DHAVE_ZLIB
+
+CONFIGURE_VARS += \
+  ZLIB_CFLAGS="-I$(STAGING_DIR)/usr/include" \
+  ZLIB_LDFLAGS="-L$(STAGING_DIR)/usr/lib" \
+  ZLIB_LIBS="-lz"
+endif
 
 define Package/zabbix-agentd/config
 	source "$(SOURCE)/Config.in"
@@ -115,7 +142,12 @@ define Package/zabbix-agentd/Default
     $(ICONV_DEPENDS) \
     +libevent2-pthreads \
     +libpcre2 \
-    +zlib
+    +ZABBIX_ENABLE_AGENT_COMPRESSION:zlib \
+    +PACKAGE_zabbix-get:zlib \
+    +PACKAGE_zabbix-proxy:zlib \
+    +PACKAGE_zabbix-proxy-basic-sqlite:zlib \
+    +PACKAGE_zabbix-sender:zlib \
+    +PACKAGE_zabbix-server:zlib
   PROVIDES:=\
     @zabbix-agentd-any \
     zabbix-agentd-ssl \
@@ -380,8 +412,11 @@ CONFIGURE_ARGS+= \
   $(call autoconf_bool,CONFIG_IPV6,ipv6) \
   --disable-java \
   --with-libevent=$(STAGING_DIR)/usr/include \
-  --with-libpcre2=$(STAGING_DIR)/usr/include \
-  --with-zlib=$(STAGING_DIR)/usr/include
+  --with-libpcre2=$(STAGING_DIR)/usr/include
+
+ifneq ($(ZABBIX_NEEDS_ZLIB),)
+CONFIGURE_ARGS += --with-zlib=$(STAGING_DIR)/usr
+endif
 endif
 
 ifeq ($(BUILD_VARIANT),basic)

--- a/admin/zabbix/patches/120-zabbix-agentd-compress-active-checks.patch
+++ b/admin/zabbix/patches/120-zabbix-agentd-compress-active-checks.patch
@@ -1,0 +1,212 @@
+From c2bacd41e1f5f95352caa6f63e4f6e29bb044e42 Mon Sep 17 00:00:00 2001
+From: Gleb Pesin <dormancygrace@gmail.com>
+Date: Tue, 14 Jul 2026 23:30:58 +0000
+Subject: [PATCH] zabbix_agentd: add active checks compression
+
+Classic agent active checks use uncompressed transport. Agent2 already
+compresses the same traffic by default.
+
+Add an EnableCompression configuration parameter, enabled by default,
+and pass protocol flags through the redirect-aware exchange helper. Keep
+zabbix_sender traffic uncompressed.
+
+Upstream-Status: Submitted [https://github.com/zabbix/zabbix/pull/180]
+Link: https://support.zabbix.com/browse/ZBXNEXT-10703
+
+OpenWrt note: the ZBX_AGENT_COMPRESSION guards are local additions which
+keep agent compression independent from zlib users in the same build.
+
+Signed-off-by: Gleb Pesin <dormancygrace@gmail.com>
+---
+ conf/zabbix_agentd.conf                        | 11 +++++++++++
+ include/zbxcommshigh.h                         |  3 ++-
+ src/libs/zbxcommshigh/commshigh.c              |  9 +++++----
+ src/zabbix_agent/active_checks/active_checks.c | 13 ++++++++++---
+ src/zabbix_agent/active_checks/active_checks.h |  1 +
+ src/zabbix_agent/zabbix_agentd.c               |  8 ++++++++
+ src/zabbix_sender/win32/zabbix_sender.c        |  2 +-
+ src/zabbix_sender/zabbix_sender.c              |  4 ++--
+ 8 files changed, 40 insertions(+), 11 deletions(-)
+
+--- a/conf/zabbix_agentd.conf
++++ b/conf/zabbix_agentd.conf
+@@ -175,6 +175,17 @@ StartAgents=1
+ 
+ # ServerActive=127.0.0.1
+ 
++### Option: EnableCompression
++#	Enables compression for communications related to active checks.
++#	Zabbix server or proxy version 4.0 or later is required.
++#	0 - disable
++#	1 - enable
++#
++# Mandatory: no
++# Range: 0-1
++# Default:
++# EnableCompression=1
++
+ ### Option: Hostname
+ #	List of comma delimited unique, case sensitive hostnames.
+ #	Required for active checks and must match hostnames as configured on the server.
+--- a/include/zbxcommshigh.h
++++ b/include/zbxcommshigh.h
+@@ -49,7 +49,8 @@ int	zbx_parse_redirect_response(struct z
+ 
+ int	zbx_comms_exchange_with_redirect(const char *source_ip, zbx_vector_addr_ptr_t *addrs, int timeout,
+ 		int connect_timeout, int retry_interval, int loglevel, const zbx_config_tls_t *config_tls,
+-		const char *data, char *(*connect_callback)(void *), void *cb_data, char **out, char **error);
++		unsigned char protocol, const char *data, char *(*connect_callback)(void *), void *cb_data, char **out,
++		char **error);
+ 
+ void	zbx_addrs_failover(zbx_vector_addr_ptr_t *addrs);
+ 
+--- a/src/libs/zbxcommshigh/commshigh.c
++++ b/src/libs/zbxcommshigh/commshigh.c
+@@ -553,11 +553,11 @@ static int	comms_check_redirect(const ch
+  *                                                                            *
+  ******************************************************************************/
+ static int	zbx_comms_exchange_data(zbx_socket_t *sock, const char *data, zbx_addr_t *addr,
+-		char **out, char **error)
++		unsigned char protocol, char **out, char **error)
+ {
+ 	zabbix_log(LOG_LEVEL_DEBUG, "sending to [%s]:%d: %s", addr->ip, addr->port, data);
+ 
+-	if (SUCCEED != zbx_tcp_send(sock, data))
++	if (SUCCEED != zbx_tcp_send_ext(sock, data, strlen(data), 0, protocol, 0))
+ 	{
+ 		zabbix_log(LOG_LEVEL_DEBUG, "unable to send to [%s]:%d: %s",
+ 					addr->ip, addr->port, zbx_socket_strerror());
+@@ -613,7 +613,8 @@ static int	zbx_comms_exchange_data(zbx_s
+  ******************************************************************************/
+ int	zbx_comms_exchange_with_redirect(const char *source_ip, zbx_vector_addr_ptr_t *addrs, int timeout,
+ 		int connect_timeout, int retry_interval, int loglevel, const zbx_config_tls_t *config_tls,
+-		const char *data, char *(*connect_callback)(void *), void *cb_data, char **out, char **error)
++		unsigned char protocol, const char *data, char *(*connect_callback)(void *), void *cb_data, char **out,
++		char **error)
+ {
+ 	zbx_socket_t		sock;
+ 	int			conn_ret, ret = FAIL, retries = 0;
+@@ -640,7 +641,7 @@ int	zbx_comms_exchange_with_redirect(con
+ 		if (NULL != connect_callback)
+ 			data = connect_callback(cb_data);
+ 
+-		if (SUCCEED == (ret = zbx_comms_exchange_data(&sock, data, addrs->values[0], out, error)))
++		if (SUCCEED == (ret = zbx_comms_exchange_data(&sock, data, addrs->values[0], protocol, out, error)))
+ 		{
+ 			if (ZBX_REDIRECT_FAIL != (conn_ret = comms_check_redirect(sock.buffer, addrs)))
+ 			{
+--- a/src/zabbix_agent/active_checks/active_checks.c
++++ b/src/zabbix_agent/active_checks/active_checks.c
+@@ -97,6 +97,7 @@ static ZBX_THREAD_LOCAL zbx_hashset_t
+ static ZBX_THREAD_LOCAL zbx_vector_expression_t		regexps;
+ static ZBX_THREAD_LOCAL char				*session_token;
+ static ZBX_THREAD_LOCAL zbx_uint64_t			last_valueid = 0;
++static ZBX_THREAD_LOCAL unsigned char			active_comms_protocol = ZBX_TCP_PROTOCOL;
+ static ZBX_THREAD_LOCAL zbx_vector_pre_persistent_t	pre_persistent_vec;	/* used for staging of data going */
+ 										/* into persistent files */
+ /* used for deleting inactive persistent files */
+@@ -938,7 +939,7 @@ static int	refresh_active_checks(zbx_vec
+ 	level = SUCCEED != last_ret ? LOG_LEVEL_DEBUG : LOG_LEVEL_WARNING;
+ 
+ 	ret = zbx_comms_exchange_with_redirect(config_source_ip, addrs, config_timeout, config_timeout, 0, level,
+-			config_tls, json.buffer, NULL, NULL, &data, NULL);
++			config_tls, active_comms_protocol, json.buffer, NULL, NULL, &data, NULL);
+ 
+ 	if (SUCCEED == ret && '\0' == *data)
+ 	{
+@@ -1264,7 +1265,8 @@ static int	send_buffer(zbx_vector_addr_p
+ 	level = 0 == buffer.first_error ? LOG_LEVEL_WARNING : LOG_LEVEL_DEBUG;
+ 
+ 	ret = zbx_comms_exchange_with_redirect(config_source_ip, addrs, MIN(buffer.count * config_timeout, 60),
+-			config_timeout, 0, level, config_tls, json.buffer, connect_callback, &json, &data, NULL);
++			config_timeout, 0, level, config_tls, active_comms_protocol, json.buffer, connect_callback, &json,
++			&data, NULL);
+ 
+ 	if (SUCCEED == ret)
+ 	{
+@@ -1894,7 +1896,7 @@ static void	send_heartbeat_msg(zbx_vecto
+ 	level = SUCCEED != last_ret ? LOG_LEVEL_DEBUG : LOG_LEVEL_WARNING;
+ 
+ 	ret = zbx_comms_exchange_with_redirect(config_source_ip, addrs, config_timeout, config_timeout, 0, level,
+-			config_tls, json.buffer, NULL, NULL, NULL, &error);
++			config_tls, active_comms_protocol, json.buffer, NULL, NULL, NULL, &error);
+ 
+ 	if (SUCCEED == ret)
+ 	{
+@@ -1931,6 +1933,11 @@ ZBX_THREAD_ENTRY(active_checks_thread, a
+ 					process_num = ((zbx_thread_args_t *)args)->info.process_num;
+ 
+ 	activechks_args_in = (zbx_thread_activechk_args *)((((zbx_thread_args_t *)args))->args);
++	active_comms_protocol = ZBX_TCP_PROTOCOL;
++#ifdef ZBX_AGENT_COMPRESSION
++	if (0 != activechks_args_in->config_enable_compression)
++		active_comms_protocol |= ZBX_TCP_COMPRESS;
++#endif
+ 
+ 	zabbix_log(LOG_LEVEL_INFORMATION, "%s #%d started [%s #%d]", get_program_type_string(info->program_type),
+ 			server_num, get_process_type_string(process_type), process_num);
+--- a/src/zabbix_agent/active_checks/active_checks.h
++++ b/src/zabbix_agent/active_checks/active_checks.h
+@@ -35,6 +35,7 @@ typedef struct
+ 	const char		*config_hostname;
+ 	const char		*config_host_metadata;
+ 	const char		*config_host_metadata_item;
++	int			config_enable_compression;
+ 	int			config_heartbeat_frequency;
+ 	const char		*config_host_interface;
+ 	const char		*config_host_interface_item;
+--- a/src/zabbix_agent/zabbix_agentd.c
++++ b/src/zabbix_agent/zabbix_agentd.c
+@@ -44,6 +44,11 @@ ZBX_GET_CONFIG_VAR(int, zbx_config_unsaf
+ static int	zbx_config_listen_port = ZBX_DEFAULT_AGENT_PORT;
+ static char	*zbx_config_listen_ip = NULL;
+ static int	zbx_config_refresh_active_checks = 5;
++#ifdef ZBX_AGENT_COMPRESSION
++static int	zbx_config_enable_compression = 1;
++#else
++static int	zbx_config_enable_compression;
++#endif
+ ZBX_GET_CONFIG_VAR2(char*, const char *, zbx_config_source_ip, NULL)
+ static int	config_log_level = LOG_LEVEL_WARNING;
+ static int	zbx_config_buffer_size = 100;
+@@ -844,6 +849,7 @@ static int	add_serveractive_host_cb(cons
+ 				0 < hostnames->values_num ? hostnames->values[i] : "");
+ 		config_active_args[forks].config_host_metadata = zbx_config_host_metadata;
+ 		config_active_args[forks].config_host_metadata_item = zbx_config_host_metadata_item;
++		config_active_args[forks].config_enable_compression = zbx_config_enable_compression;
+ 		config_active_args[forks].config_heartbeat_frequency = zbx_config_heartbeat_frequency;
+ 		config_active_args[forks].config_host_interface = zbx_config_host_interface;
+ 		config_active_args[forks].config_host_interface_item = zbx_config_host_interface_item;
+@@ -943,6 +949,8 @@ static void	zbx_load_config(int requirem
+ 				ZBX_CONF_PARM_OPT,	0,			0},
+ 		{"ServerActive",		&active_hosts,				ZBX_CFG_TYPE_STRING_LIST,
+ 				ZBX_CONF_PARM_OPT,	0,			0},
++		{"EnableCompression",		&zbx_config_enable_compression,		ZBX_CFG_TYPE_INT,
++				ZBX_CONF_PARM_OPT,	0,			1},
+ 		{"Hostname",			&zbx_config_hostnames,			ZBX_CFG_TYPE_STRING_LIST,
+ 				ZBX_CONF_PARM_OPT,	0,			0},
+ 		{"HostnameItem",		&config_hostname_item,			ZBX_CFG_TYPE_STRING,
+--- a/src/zabbix_sender/win32/zabbix_sender.c
++++ b/src/zabbix_sender/win32/zabbix_sender.c
+@@ -102,7 +102,7 @@ int	zabbix_sender_send_values(const char
+ 	config_tls.connect_mode = ZBX_TCP_SEC_UNENCRYPTED;
+ 
+ 	ret = zbx_comms_exchange_with_redirect(source, &zbx_addrs, GET_SENDER_TIMEOUT, 30, 0, 0, &config_tls,
+-			json.buffer, NULL, NULL, result, NULL);
++			ZBX_TCP_PROTOCOL, json.buffer, NULL, NULL, result, NULL);
+ 
+ 	if (SUCCEED != ret && NULL != result)
+ 		*result = zbx_strdup(NULL, zbx_socket_strerror());
+--- a/src/zabbix_sender/zabbix_sender.c
++++ b/src/zabbix_sender/zabbix_sender.c
+@@ -647,8 +647,8 @@ static	ZBX_THREAD_ENTRY(send_value, args
+ #endif
+ 
+ 	ret = zbx_comms_exchange_with_redirect(config_source_ip, sendval_args->addrs, CONFIG_SENDER_TIMEOUT,
+-			config_timeout, 0, LOG_LEVEL_DEBUG, sendval_args->zbx_config_tls, sendval_args->json->buffer,
+-			connect_callback, sendval_args->json, &data, NULL);
++			config_timeout, 0, LOG_LEVEL_DEBUG, sendval_args->zbx_config_tls, ZBX_TCP_PROTOCOL,
++			sendval_args->json->buffer, connect_callback, sendval_args->json, &data, NULL);
+ 
+ 
+ 	if (SUCCEED == ret)


### PR DESCRIPTION
## Package details

**Maintainer:** @danielfdickinson

Enable compression for classic Zabbix agent active-check traffic. The new `EnableCompression` agent configuration option defaults to `1` and can be set to `0` for servers or proxies older than 4.0.

The classic agent now passes the selected protocol flags through the redirect-aware exchange path. `zabbix_sender` remains uncompressed. The build also supplies zlib explicitly because upstream's configure script probes it only when server or proxy support is enabled.

### Upgrade note

`/etc/zabbix_agentd.conf` is a preserved conffile. Existing installations do not receive the new commented example when upgrading, although compression now defaults to enabled to match agent2. Administrators using a server or proxy older than 4.0 must add `EnableCompression=0` to their preserved config.

## Run testing details

- **OpenWrt build tree:** 25.12.5, Linux 6.12.94
- **OpenWrt target/subtarget:** ramips/mt7620 (`mipsel_24kc`, GCC 16.2.0)
- **Package source:** exact Zabbix 7.0.30-r2 PR branch

Validation against the exact current source:

- verified the downloaded Zabbix 7.0.30 source against the package SHA-256;
- applied all package patches in order with `--fuzz=0`, then ran `make package/zabbix/refresh`; every patch, including `120-zabbix-agentd-compress-active-checks.patch`, remained unchanged;
- built `zabbix-agentd-7.0.30-r2.apk` with agent compression enabled; the build used `ZBX_AGENT_COMPRESSION` and `HAVE_ZLIB`, the binary has `NEEDED libz.so.1`, and the APK depends on `zlib`;
- built agent-only with compression disabled; neither feature macro was present, the binary has no `libz.so.1` dependency, and the APK does not depend on `zlib`;
- built the mixed `zabbix-agentd + zabbix-sender` selection with agent compression disabled; the build used `HAVE_ZLIB` without `ZBX_AGENT_COMPRESSION`, the agent binary has `NEEDED libz.so.1`, and the agent APK correctly retains its `zlib` dependency;
- on the preceding 7.0.28-r4 revision, ran the generated MIPS32 agent under `qemu-mipsel`: configuration validation accepts `EnableCompression=0` and `1` and rejects `2`;
- captured the cross-built agent's active-check heartbeat on a local listener: disabled mode used flags `0x01`, a 109-byte original JSON payload and zero reserved length; enabled mode used flags `0x03`, a 98-byte zlib payload and the correct 109-byte uncompressed length;
- decompressed content from enabled mode is equivalent to the disabled payload. The seven source-code hunks implementing compression are unchanged on 7.0.30.

## Upstream

- https://github.com/zabbix/zabbix/pull/180
- https://support.zabbix.com/browse/ZBXNEXT-10703

The downstream patch header records both references.

## Formalities

- [x] I have reviewed `CONTRIBUTING.md`.
- [x] The patch can be applied with `git am`.
- [x] The patch was refreshed without offsets or fuzz.
- [x] The change is submitted upstream.
