### PR TITLE
zabbix: do not error in postinst when no ubusd

### DIFF
--- a/admin/zabbix/Makefile
+++ b/admin/zabbix/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zabbix
 PKG_VERSION:=7.0.27
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://cdn.zabbix.com/zabbix/sources/stable/$(basename $(PKG_VERSION))/ \
@@ -581,7 +581,7 @@ endef
 define Package/zabbix-extra-network/postinst
 #!/bin/sh
 if [ -z "$${IPKG_INSTROOT}" ]; then
-  killall -s HUP ubusd
+  killall -s HUP ubusd || true
 fi
 endef
 
@@ -594,7 +594,7 @@ endef
 define Package/zabbix-extra-wifi/postinst
 #!/bin/sh
 if [ -z "$${IPKG_INSTROOT}" ]; then
-  killall -s HUP ubusd
+  killall -s HUP ubusd || true
 fi
 endef
 


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @danielfdickinson 

**Description:**
Now that post install is running properly, when CI executes the tests the zabbix-extra-* packages that have a posinst exit the post install with an error if ubusd is not running.

Drop the error code from killall with no usbd running to fix this.

---

## 🧪 Run Testing Details

Not yet run-tested, but its straightforward and minor.

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
