### PR TITLE
arp-whisper: Bump to 1.0.0

### DIFF
--- a/utils/arp-whisper/Makefile
+++ b/utils/arp-whisper/Makefile
@@ -1,16 +1,16 @@
 # SPDX-License-Identifier: GPL-3.0-only
 #
-# Copyright (C) 2023 Facundo Acevedo
+# Copyright (C) 2026 Facundo Acevedo
 
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=arp-whisper
-PKG_VERSION:=0.1.2
-PKG_RELEASE:=2
+PKG_VERSION:=1.0.0
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/FacundoAcevedo/arp-whisper/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=13b393c64505d62b5abf7ace244eed0ce62f4b1562a688ddb5651bd42cc7c305
+PKG_HASH:=c7daae559b38bc8836de73f28ca645de4a7cd5ec8d3e8a9d82ae8e11e57bf32c
 
 PKG_MAINTAINER:=Facundo Acevedo <facevedo@disroot.org>
 PKG_LICENSE:=GPL-3.0-or-later

--- a/utils/arp-whisper/test.sh
+++ b/utils/arp-whisper/test.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+case "$1" in
+    "arp-whisper")
+        arp-whisper --version 2>&1 | grep "$2"
+        ;;
+esac


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @FacundoAcevedo

**Description:**
Updates package to v1.0.0 
Changes in the app: https://github.com/FacundoAcevedo/arp-whisper/compare/v0.1.2...v1.0.0
---

## 🧪 Run Testing Details

- **OpenWrt Version: openwrt/rootfs:1164645a5ed34d91b08077f7549884c01503ad18** latest atm
- **OpenWrt Target/Subtarget: amd64**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
