### PR TITLE
prometheus-node-exporter-lua: add dhcp-leases exporter

### DIFF
--- a/utils/prometheus-node-exporter-lua/Makefile
+++ b/utils/prometheus-node-exporter-lua/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=prometheus-node-exporter-lua
 PKG_VERSION:=2026.06.05
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Etienne CHAMPETIER <champetier.etienne@gmail.com>
 PKG_LICENSE:=Apache-2.0
@@ -79,6 +79,17 @@ endef
 define Package/prometheus-node-exporter-lua-dawn/install
 	$(INSTALL_DIR) $(1)/usr/lib/lua/prometheus-collectors
 	$(INSTALL_DATA) ./files/usr/lib/lua/prometheus-collectors/dawn.lua $(1)/usr/lib/lua/prometheus-collectors/
+endef
+
+define Package/prometheus-node-exporter-lua-dhcp-leases
+  $(call Package/prometheus-node-exporter-lua/Default)
+  TITLE+= (dhcp-leases collector)
+  DEPENDS:=prometheus-node-exporter-lua
+endef
+
+define Package/prometheus-node-exporter-lua-dhcp-leases/install
+	$(INSTALL_DIR) $(1)/usr/lib/lua/prometheus-collectors
+	$(INSTALL_DATA) ./files/usr/lib/lua/prometheus-collectors/dhcp-leases.lua $(1)/usr/lib/lua/prometheus-collectors/
 endef
 
 define Package/prometheus-node-exporter-lua-filesystem
@@ -320,6 +331,7 @@ endef
 $(eval $(call BuildPackage,prometheus-node-exporter-lua))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-bmx7))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-dawn))
+$(eval $(call BuildPackage,prometheus-node-exporter-lua-dhcp-leases))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-filesystem))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-hostapd_stations))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-hostapd_ubus_stations))

--- a/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/dhcp-leases.lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/dhcp-leases.lua
@@ -1,0 +1,29 @@
+local ubus = require("ubus")
+
+local function get_vendor(conn, mac)
+  local ok, result = pcall(conn.call, conn, "fingerprint", "fingerprint", {macaddr = mac})
+  if ok and result and result.vendor then
+    return result.vendor
+  end
+  return ""
+end
+
+local function scrape()
+  local dhcp_client = metric("dhcp_client", "gauge")
+  local conn = ubus.connect()
+  local f = io.open("/tmp/dhcp.leases", "r")
+  if f then
+    for line in f:lines() do
+      local mac, ip, hostname = line:match("%S+ (%S+) (%S+) (%S+)")
+      if mac then
+        if hostname == "*" then hostname = "" end
+        local vendor = conn and get_vendor(conn, mac) or ""
+        dhcp_client({mac=mac:upper(), ip=ip, hostname=hostname, vendor=vendor}, 1)
+      end
+    end
+    f:close()
+  end
+  if conn then conn:close() end
+end
+
+return { scrape = scrape }


### PR DESCRIPTION
Add a new collector to expose DHCP leases. It optionally depends on
ufp-neigh to expose device type.

Signed-off-by: Stephen Finucane <stephen@that.guru>

## 📦 Package Details

**Maintainer:** @champtar
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
Add new collector for the DHCP leases. This is useful for a system status dashboard.

---

## 🧪 Run Testing Details

- **OpenWrt Version:**  25.12.5
- **OpenWrt Target/Subtarget:** x86_64
- **OpenWrt Device:** Generic N100 mini PC/switch

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
