### PR TITLE
syncthing: bump to 2.1.2

### DIFF
--- a/utils/syncthing/Makefile
+++ b/utils/syncthing/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=syncthing
-PKG_VERSION:=2.1.1
+PKG_VERSION:=2.1.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=syncthing-source-v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/syncthing/syncthing/releases/download/v$(PKG_VERSION)
-PKG_HASH:=418a99452f484abf30e403b769d0cf914a038142cd1a7e10be85b68f45d9f42a
+PKG_HASH:=584261eb7c705b9a2c4b624ba10bff8521de8c288bb7e2facffc7558291f678e
 
 PKG_BUILD_DIR=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)/$(PKG_NAME)
 


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me

**Description:**

Bump Syncthing to 2.1.2.

Changes: https://github.com/syncthing/syncthing/releases/tag/v2.1.2

---

## 🧪 Run Testing Details
- **OpenWrt Version:** SNAPSHOT, r35362-9e43544bc6
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** QEMU/Vadas

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.