### PR TITLE
procs: bump to 0.14.12

### DIFF
--- a/utils/procs/Makefile
+++ b/utils/procs/Makefile
@@ -1,16 +1,16 @@
 # SPDX-License-Identifier: GPL-3.0-only
 #
-# Copyright (C) 2023 Facundo Acevedo
+# Copyright (C) 2026 Facundo Acevedo
 
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=procs
-PKG_VERSION:=0.14.3
+PKG_VERSION:=0.14.12
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/dalance/procs/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=a3012bba984faddcf8da2a72d21eb9a7e9be8d5d86a387d321987743b0080a8c
+PKG_HASH:=f2fab583fe98a9ae9505c5eecf4f3d9d4ad9bcb5d478a8222d52c87aa1ac602e
 
 PKG_MAINTAINER:=Facundo Acevedo <facevedo@disroot.org>
 PKG_LICENSE:=MIT
@@ -26,13 +26,13 @@ define Package/procs
   SECTION:=utils
   CATEGORY:=Utilities
   TITLE:=Procs is feature-rich alternative to the 'ps'
-  DEPENDS:=$(RUST_ARCH_DEPENDS) 
+  DEPENDS:=$(RUST_ARCH_DEPENDS)
   URL:=https://github.com/dalance/procs/
 endef
 
 define Package/procs/description
-  Procs is a 'ps' command replacement written in Rust, offering 
-  enhanced usability and information display. 
+  Procs is a 'ps' command replacement written in Rust, offering
+  enhanced usability and information display.
   Features include color-coded output, theme auto-detection, advanced
   search, and extended process details
   (TCP/UDP ports, Docker names, I/O throughput).

--- a/utils/procs/files/etc/procs/procs.toml
+++ b/utils/procs/files/etc/procs/procs.toml
@@ -48,13 +48,6 @@ nonnumeric_search = false
 align = "Left"
 
 [[columns]]
-kind = "MultiSlot"
-style = "ByUnit"
-numeric_search = false
-nonnumeric_search = false
-align = "Right"
-
-[[columns]]
 kind = "Separator"
 style = "White|BrightBlack"
 numeric_search = false
@@ -103,16 +96,9 @@ color_x = "BrightBlue|Blue"
 numeric_search = "Exact"
 nonnumeric_search = "Partial"
 logic = "And"
-case = "Smart"
 
 [display]
 show_self = false
-show_thread = false
-show_thread_in_tree = true
-show_parent_in_tree = true
-show_children_in_tree = true
-show_header = true
-show_footer = false
 cut_to_terminal = true
 cut_to_pager = false
 cut_to_pipe = false
@@ -122,7 +108,6 @@ ascending = "▲"
 descending = "▼"
 tree_symbols = ["│", "─", "┬", "├", "└"]
 abbr_sid = true
-theme = "Auto"
 
 [sort]
 column = 0
@@ -132,7 +117,4 @@ order = "Ascending"
 path = "unix:///var/run/docker.sock"
 
 [pager]
-mode = "Disable" # OpenWrt's less doen't support the flags '-SR', if needed install the full less pacakge
-detect_width = false
-use_builtin = false
-
+mode = "Disable" # Install the full "less" package before enabling this flag.


### PR DESCRIPTION
Updated procs package to 0.14.12

## 📦 Package Details

**Maintainer:** @FacundoAcevedo
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
Updates packages to v0.14.12

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
