### PR TITLE
lpac: backport MBIM UICC compatibility fixes

### DIFF
--- a/utils/lpac/Makefile
+++ b/utils/lpac/Makefile
@@ -4,7 +4,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lpac
 PKG_VERSION:=2.3.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/estkme-group/lpac/tar.gz/refs/tags/v$(PKG_VERSION)?

--- a/utils/lpac/files/lpac.sh
+++ b/utils/lpac/files/lpac.sh
@@ -33,8 +33,10 @@ elif [ "$APDU_BACKEND" = "uqmi" ]; then
 elif [ "$APDU_BACKEND" = "mbim" ]; then
     MBIM_DEVICE="$(uci_get lpac mbim device /dev/cdc-wdm0)"
     MBIM_PROXY="$(uci_get lpac mbim proxy 1)"
+    MBIM_SKIP_SLOT_MAPPING="$(uci_get lpac mbim skip_slot_mapping 0)"
     export LPAC_APDU_MBIM_DEVICE="$MBIM_DEVICE"
     export LPAC_APDU_MBIM_USE_PROXY="$MBIM_PROXY"
+    export LPAC_APDU_MBIM_SKIP_SLOT_MAPPING="$MBIM_SKIP_SLOT_MAPPING"
 fi
 
 export LPAC_CUSTOM_ISD_R_AID="$CUSTOM_ISD_R_AID"

--- a/utils/lpac/files/lpac.uci
+++ b/utils/lpac/files/lpac.uci
@@ -16,3 +16,4 @@ config uqmi uqmi
 config mbim mbim
 	option		device		'/dev/cdc-wdm0'
 	option		proxy		'1'
+	option		skip_slot_mapping	'0'

--- a/utils/lpac/patches/0002-fix-utils-improve-getenv-helpers.patch
+++ b/utils/lpac/patches/0002-fix-utils-improve-getenv-helpers.patch
@@ -1,0 +1,96 @@
+From 977ea5db70433b680cf841b7cd7d32935637324e Mon Sep 17 00:00:00 2001
+From: septs <github@septs.pw>
+Date: Sun, 31 Aug 2025 20:58:20 +0800
+Subject: [PATCH] fix(utils): improve getenv helpers (#308)
+
+---
+ docs/ENVVARS.md    | 20 +++++++++++++++++---
+ utils/lpac/utils.c | 29 ++++++++++++-----------------
+ 2 files changed, 29 insertions(+), 20 deletions(-)
+
+--- a/docs/ENVVARS.md
++++ b/docs/ENVVARS.md
+@@ -25,12 +25,26 @@
+ * `LPAC_APDU_QMI_UIM_SLOT`: specify which UIM slot will be used by QMI APDU backend. (default: 1, slot number starts from 1)
+ * `LPAC_APDU_QMI_DEVICE`: specify which QMI device will be used by QMI APDU backend.
+ * `LPAC_APDU_MBIM_UIM_SLOT`: specify which UIM slot will be used by MBIM APDU backend. (default: 1, slot number starts from 1)
+-* `LPAC_APDU_MBIM_USE_PROXY`: tell the MBIM APDU backend to use the mbim-proxy. (boolean)
++* `LPAC_APDU_MBIM_USE_PROXY`: tell the MBIM APDU backend to use the mbim-proxy. ([boolean])
+ * `LPAC_APDU_MBIM_DEVICE`: specify which MBIM device will be used by MBIM APDU backend. (default: `/dev/cdc-wdm0`)
+ 
+ ## Debug
+ 
+ * `LIBEUICC_DEBUG_APDU`: enable debug output for APDU.
+ * `LIBEUICC_DEBUG_HTTP`: enable debug output for HTTP.
+-* `LPAC_APDU_AT_DEBUG`: enable debug output for AT APDU backend. (boolean)
+-* `LPAC_APDU_GBINDER_DEBUG`: enable debug output for GBinder APDU backend. (boolean)
++* `LPAC_APDU_AT_DEBUG`: enable debug output for AT APDU backend. ([boolean])
++* `LPAC_APDU_GBINDER_DEBUG`: enable debug output for GBinder APDU backend. ([boolean])
++
++## Data Types
++
++[boolean]: #boolean-type
++
++### Boolean Type
++
++A boolean type environment variable can be set to enable or disable a feature.
++
++The following values are recognized as **enabled** (case-insensitive): `1`, `y`, `on`, `yes`, `true`
++
++The following values are recognized as **disabled** (case-insensitive): `0`, `n`, `off`, `no`, `false`
++
++Any other value will result in the default being used.
+--- a/utils/lpac/utils.c
++++ b/utils/lpac/utils.c
+@@ -7,31 +7,26 @@
+ #include <stdlib.h>
+ #include <string.h>
+ 
+-static bool is_numeric(const char *value) {
+-    if (value == NULL)
+-        return false;
+-    for (size_t i = strlen(value); i > 0; --i) {
+-        if (isdigit(value[i]))
+-            continue;
+-        return false;
+-    }
+-    return true;
+-}
+-
+ const char *getenv_str_or_default(const char *name, const char *default_value) {
+     const char *value = getenv(name);
+-    if (value == NULL)
++    if (value == NULL || strlen(value) == 0)
+         return default_value;
+     return value;
+ }
+ 
+ bool getenv_bool_or_default(const char *name, const bool default_value) {
+     const char *value = getenv(name);
+-    if (value == NULL)
++    if (value == NULL || strlen(value) == 0)
+         return default_value;
+-    if (is_numeric(value))
+-        return strcmp(value, "0") != 0;
+-    return strcasecmp(value, "y") == 0 || strcasecmp(value, "yes") == 0 || strcasecmp(value, "true") == 0;
++    if (strcasecmp(value, "1") == 0 || strcasecmp(value, "y") == 0 || strcasecmp(value, "on") == 0
++        || strcasecmp(value, "yes") == 0 || strcasecmp(value, "true") == 0)
++        return true;
++    if (strcasecmp(value, "0") == 0 || strcasecmp(value, "n") == 0 || strcasecmp(value, "off") == 0
++        || strcasecmp(value, "no") == 0 || strcasecmp(value, "false") == 0)
++        return false;
++    fprintf(stderr, "WARNING: Invalid value '%s' for environment variable '%s', falling back to default (%s)\n", value,
++            name, default_value ? "true" : "false");
++    return default_value;
+ }
+ 
+ int getenv_int_or_default(const char *name, const int default_value) {
+@@ -40,7 +35,7 @@ int getenv_int_or_default(const char *na
+ 
+ long getenv_long_or_default(const char *name, const long default_value) {
+     const char *value = getenv(name);
+-    if (value == NULL)
++    if (value == NULL || strlen(value) == 0)
+         return default_value;
+     return strtol(value, NULL, 10);
+ }

--- a/utils/lpac/patches/0003-mbim-improve-UICC-low-level-access-compatibility.patch
+++ b/utils/lpac/patches/0003-mbim-improve-UICC-low-level-access-compatibility.patch
@@ -1,0 +1,92 @@
+From 79fcec9d89a247f1a1995f7b4560ea819bfe654f Mon Sep 17 00:00:00 2001
+From: Coelacanthus <uwu@coelacanthus.name>
+Date: Fri, 17 Jul 2026 14:56:20 +0000
+Subject: [PATCH] mbim: improve UICC low-level access compatibility (#438)
+
+Improve compatibility with MBIM devices that expose eSIM access through the
+Microsoft UICC low-level access service.
+
+Some WWAN modules do not work with lpac's default MBIM APDU parameters. Add an
+opt-in environment variable to skip MBIM device slot mapping, use the extended
+class byte type for APDU transport, open the logical channel with select P2 set
+to 0x0c, and append Le=00 to case-4 ENVELOPE APDUs that omit it.
+
+The upstream documentation file changed by this commit is not present in the
+v2.3.0 release archive, so this backport contains the runtime change only.
+
+Runtime validation covered a Fibocom L850-GL with removable eUICC, a Foxconn
+T99W175, and a Dell DW5821e. The MBIM backend was also built against
+libmbim-glib 1.31.2.
+
+Signed-off-by: As Tsaqib <0xfiqks@gmail.com>
+Co-authored-by: As Tsaqib <0xfiqks@gmail.com>
+---
+ driver/apdu/mbim.c | 36 ++++++++++++++++++++++++++++++++----
+ 1 file changed, 32 insertions(+), 4 deletions(-)
+
+--- a/driver/apdu/mbim.c
++++ b/driver/apdu/mbim.c
+@@ -15,6 +15,16 @@
+ #define ENV_UIM_SLOT APDU_ENV_NAME(MBIM, UIM_SLOT)
+ #define ENV_USE_PROXY APDU_ENV_NAME(MBIM, USE_PROXY)
+ #define ENV_DEVICE APDU_ENV_NAME(MBIM, DEVICE)
++#define ENV_SKIP_SLOT_MAPPING APDU_ENV_NAME(MBIM, SKIP_SLOT_MAPPING)
++
++/*
++ * https://learn.microsoft.com/en-us/windows-hardware/drivers/network/mb-low-level-uicc-access
++ * SelectP2Arg maps to the P2 byte of the ISO/IEC 7816-4 SELECT command.
++ * ETSI TS 102 221 V18.0.0, section 11.1.1.2, table 11.2 defines 0x0c as
++ * "No data returned":
++ * https://www.etsi.org/deliver/etsi_ts/102200_102299/102221/18.00.00_60/ts_102221v180000p.pdf
++ */
++#define LPAC_MBIM_UICC_SELECT_P2_NO_RESPONSE 0x0c
+ 
+ struct mbim_data {
+     const char *device_path;
+@@ -134,6 +144,11 @@ static int apdu_interface_connect(struct
+         return -1;
+     }
+ 
++    if (getenv_bool_or_default(ENV_SKIP_SLOT_MAPPING, false)) {
++        fprintf(stderr, "info: skipping MBIM device slot mapping\n");
++        return 0;
++    }
++
+     return select_sim_slot(mbim_priv);
+ }
+ 
+@@ -161,9 +176,21 @@ static int mbim_apdu_interface_transmit(
+     struct mbim_data *mbim_priv = ctx->apdu.interface->userdata;
+     g_autoptr(GError) error = NULL;
+ 
+-    MbimMessage *request = mbim_message_ms_uicc_low_level_access_apdu_set_new(
+-        mbim_priv->last_channel_id, MBIM_UICC_SECURE_MESSAGING_NONE, MBIM_UICC_CLASS_BYTE_TYPE_INTER_INDUSTRY, tx_len,
+-        tx, &error);
++    const guint8 *apdu = tx;
++    guint32 apdu_len = tx_len;
++    g_autofree guint8 *apdu_with_le = NULL;
++
++    if (tx_len >= 5 && tx[1] == 0xe2 && tx_len == (guint32)tx[4] + 5) {
++        apdu_with_le = g_malloc(tx_len + 1);
++        memcpy(apdu_with_le, tx, tx_len);
++        apdu_with_le[tx_len] = 0x00;
++        apdu = apdu_with_le;
++        apdu_len = tx_len + 1;
++    }
++
++    MbimMessage *request =
++        mbim_message_ms_uicc_low_level_access_apdu_set_new(mbim_priv->last_channel_id, MBIM_UICC_SECURE_MESSAGING_NONE,
++                                                           MBIM_UICC_CLASS_BYTE_TYPE_EXTENDED, apdu_len, apdu, &error);
+     if (!request) {
+         fprintf(stderr, "error: creating apdu message failed: %s\n", error->message);
+         return -1;
+@@ -193,7 +220,8 @@ static int mbim_apdu_interface_logic_cha
+     g_autoptr(GError) error = NULL;
+     guint8 channel_id;
+ 
+-    MbimMessage *request = mbim_message_ms_uicc_low_level_access_open_channel_set_new(aid_len, aid, 0, 1, &error);
++    MbimMessage *request = mbim_message_ms_uicc_low_level_access_open_channel_set_new(
++        aid_len, aid, LPAC_MBIM_UICC_SELECT_P2_NO_RESPONSE, 1, &error);
+     if (!request) {
+         fprintf(stderr, "error: creating channel message failed: %s\n", error->message);
+         return -1;


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @blocktrron

**Description:**

Backport two changes already merged by lpac upstream:

- [`977ea5db7043`](https://github.com/estkme-group/lpac/commit/977ea5db70433b680cf841b7cd7d32935637324e) fixes the environment boolean parser.
- [`79fcec9d89a2`](https://github.com/estkme-group/lpac/commit/79fcec9d89a247f1a1995f7b4560ea819bfe654f) improves Microsoft UICC low-level access compatibility and adds the opt-in MBIM slot-mapping bypass.

lpac v2.3.0 starts its numeric scan at the terminating NUL byte, so UCI values such as `1` are otherwise parsed as false. The first backport is therefore required for the new option and also makes the existing `mbim.proxy=1` setting work as intended.

Expose the bypass as `lpac.mbim.skip_slot_mapping` and export `LPAC_APDU_MBIM_SKIP_SLOT_MAPPING` from the OpenWrt wrapper. Keep it disabled by default, matching upstream behavior and avoiding unintended eUICC selection on multi-slot hardware. The default APDU backend remains `uqmi`.

The latest upstream release is still v2.3.0, so this keeps the immutable release archive and carries only accepted upstream backports.

### Compile testing

Exact commit `9df1dcf4967a69b970db4c960b7e7af5d3e2aa1b` was built successfully for:

- OpenWrt snapshot: `x86_64`
- OpenWrt snapshot: `aarch64_generic`
- OpenWrt 24.10.7: `arm_cortex-a7_neon-vfpv4`
- OpenWrt 25.12.5: `x86_64`
- OpenWrt 25.12.5: `arm_cortex-a7_neon-vfpv4`

Preflight runs:

- https://github.com/As-tsaqib/packages/actions/runs/29615968026
- https://github.com/As-tsaqib/packages/actions/runs/29616656159

Package checks, source hash verification, and patch refresh checks passed. Patches 0001, 0002, and 0003 were unchanged after refresh, and the MBIM source was compiled on the target builds.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12.5 r33051-f5dae5ece4
- **OpenWrt Target/Subtarget:** ipq40xx/generic (`arm_cortex-a7_neon-vfpv4`)
- **OpenWrt Device:** Linksys EA6350 v3 with a Fibocom L850-GL and removable eUICC

Installed the exact CI artifact `lpac-2.3.0-r3.apk` with SHA-256 `943de667858caf8c9c8fd547519741ca7011663b2f9e98f139ce7b84b61347e3`.

With the existing router configuration set to MBIM, proxy enabled, and skip-slot-mapping enabled:

- three consecutive `lpac chip info` calls succeeded;
- each call reported `info: skipping MBIM device slot mapping`;
- driver discovery included MBIM, PC/SC, AT, uqmi, and stdio;
- ModemManager remained running;
- the WWAN carrier and network interface remained up;
- no recent ModemManager crash or critical lpac error was logged.

No profile, notification, or eUICC state mutation was performed during testing.

The existing v2.3.0 version-reporting issue remains out of scope. Its upstream fix is already merged separately and can be backported in a follow-up package change. A follow-up update to [openwrt/luci#8836](https://github.com/openwrt/luci/pull/8836) can expose this UCI option after the package backend is available.

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using `make package/<your-package>/refresh V=s`
- [x] It is structured in a way that it is potentially upstreamable

Both new patches are backports of changes already merged upstream.