### PR TITLE
[25.12] wget: rank wget-nossl below uclient-fetch for the wget alternative

### DIFF
--- a/net/wget/Makefile
+++ b/net/wget/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wget
 PKG_VERSION:=1.25.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@GNU/$(PKG_NAME)
@@ -61,7 +61,7 @@ define Package/wget-nossl
 $(call Package/wget/Default)
   TITLE+= (without SSL support)
   VARIANT:=nossl
-  ALTERNATIVES:=300:/usr/bin/wget:/usr/libexec/wget-nossl
+  ALTERNATIVES:=100:/usr/bin/wget:/usr/libexec/wget-nossl
 endef
 
 define Package/wget-nossl/description


### PR DESCRIPTION


## 📦 Package Details

**Maintainer:** me


**Description:**

apk uses whatever /usr/bin/wget resolves to for HTTPS index downloads.
wget-nossl's alternative was ranked 300, above the HTTPS-capable
uclient-fetch (200), so pulling it in transitively silently broke
apk update. Lower it to 100 so uclient-fetch keeps the default while
wget-nossl stays selectable. wget-ssl is unchanged.

Fixes: https://github.com/openwrt/openwrt/issues/24270


---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [ ] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
