### PR TITLE
[25.12] adblock-fast: update to 1.2.4-4

### DIFF
--- a/net/adblock-fast/Makefile
+++ b/net/adblock-fast/Makefile
@@ -5,7 +5,8 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock-fast
 PKG_VERSION:=1.2.4
-PKG_RELEASE:=2
+PKG_RELEASE:=4
+PKG_CPE_ID:=cpe:/a:mossdef:adblock-fast
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
 PKG_LICENSE:=AGPL-3.0-or-later
 

--- a/net/adblock-fast/files/lib/adblock-fast/adblock-fast.uc
+++ b/net/adblock-fast/files/lib/adblock-fast/adblock-fast.uc
@@ -2224,8 +2224,8 @@ function _build_procd_data() {
 	result.outputFile = dns_output.file;
 	result.outputCache = dns_output.cache;
 
-	let gzip_path = cfg.compressed_cache_dir
-		? cfg.compressed_cache_dir + '/' + dns_output.gzip
+	let gzip_path = cfg.compressed_cache
+		? dns_output.gzip
 		: '';
 	result.outputGzip = gzip_path;
 
@@ -2935,8 +2935,8 @@ function get_init_status(name) {
 
 	// Gzip path (for live file-existence checks)
 	let gzip_path = svc_data?.outputGzip || '';
-	if (!gzip_path && cfg.compressed_cache_dir)
-		gzip_path = cfg.compressed_cache_dir + '/' + dns_output.gzip;
+	if (!gzip_path && cfg.compressed_cache)
+		gzip_path = dns_output.gzip;
 
 	let result = {};
 	result[name] = {


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Dell EMC Edge620, OpenWrt 25.12.4
Run tested: x86_64, Dell EMC Edge620, OpenWrt 25.12.4

Description:
Maintainer: me
Compile tested: x86_64, Dell EMC Edge620, OpenWrt 25.12.4
Run tested: x86_64, Dell EMC Edge620, OpenWrt 25.12.4

Description:
Update to PKG_RELEASE 4

  - Bump PKG_RELEASE from 2 to 4.
  - Add PKG_CPE_ID.

files/lib/adblock-fast/adblock-fast.uc:
  - Adjust logic for determining the gzip cache path to align with
    the new 'compressed_cache' option.
  - Remove dependency on 'compressed_cache_dir' for gzip path
    construction.
  - Update gzip path calculation in 'get_init_status' to use the new
    'compressed_cache' option.

Signed-off-by: Stan Grishin <stangri@melmac.ca>
(cherry picked from commit bde6e9a5a0d22d1f471eb2a055f063d01008c69c)