### PR TITLE
nut: manage logging

### DIFF
--- a/net/nut/Makefile
+++ b/net/nut/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nut
 PKG_VERSION:=2.8.5
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.networkupstools.org/source/2.8/

--- a/net/nut/files/add_nut_httpd_conf.default
+++ b/net/nut/files/add_nut_httpd_conf.default
@@ -22,7 +22,7 @@ grep -q '^/cgi-bin/nut' /etc/httpd.conf 2>/dev/null || {
 	# shellcheck disable=SC2016
 	echo '/cgi-bin/nut:root:$p$root' >>/etc/httpd.conf
 	if ! /etc/init.d/uhttpd restart; then
-		logger -s -t nut-cgi "Failed to restart uhttpd after http.conf update"
+		logger -t nut-cgi "Failed to restart uhttpd after http.conf update"
 		exit 1
 	fi
 }

--- a/net/nut/files/libhid-ups.hotplug
+++ b/net/nut/files/libhid-ups.hotplug
@@ -58,7 +58,7 @@ start_stop_driver() {
 	add)
 		# Skip hotplug if it is disabled or NUT is shutting down
 		if ! allow_hotplug_restart; then
-			logger -s -t nut-usb-hotplug "Hotplug restart disabled starting '$ups' when processing '$ACTION' for '$DEVNAME'"
+			log_msg "Hotplug restart disabled starting '$ups' when processing '$ACTION' for '$DEVNAME'" "libhid-ups" nut-usb-hotplug info
 			# This is a configuration not an error
 			return 0
 		fi
@@ -66,7 +66,7 @@ start_stop_driver() {
 		# Set permissions to allow the UPS device to start
 		# In some cases this may be enough for the UPS to start working
 		if ! ensure_usb_ups_access "$ups" "$known_devname"; then
-			logger -s -t nut-usb-hotplug "Unable to enable access to '$ups' when processing '$ACTION' for '$DEVNAME'"
+			log_error "Unable to enable access to '$ups' when processing '$ACTION' for '$DEVNAME'" "libhid-ups" nut-usb-hotplug
 			return 0
 		fi
 
@@ -77,11 +77,11 @@ start_stop_driver() {
 		# our last check.
 		if /etc/init.d/nut-server enabled; then
 			if ! /etc/init.d/nut-server start "$ups"; then
-				logger -s -t nut-usb-hotplug "Failed to start '$ups' processing '$ACTION' for '$DEVNAME'"
+				log_error "Failed to start '$ups' processing '$ACTION' for '$DEVNAME'" "libhid-ups" nut-usb-hotplug
 				return 0
 			fi
 		else
-			logger -s -t nut-usb-hotplug "Hotplug became disabled while processing '$ACTION' for '$DEVNAME'."
+			log_error "Hotplug became disabled while processing '$ACTION' for '$DEVNAME'." "libhid-ups" nut-usb-hotplug
 			return 0
 		fi
 		;;
@@ -90,7 +90,7 @@ start_stop_driver() {
 		# We stop only the removed UPS as we want the NUT service and other
 		# UPS (if any) to remain up.
 		/etc/init.d/nut-server stop "$ups" || {
-			logger -s -t nut-usb-hotplug "Failed to stop nut-driver instance (UPS) '$ups'."
+			log_error "Failed to stop nut-driver instance (UPS) '$ups'." "libhid-ups" nut-usb-hotplug
 			return 0
 		}
 		;;
@@ -116,7 +116,7 @@ nut_driver_config() {
 	# we keep going as we will restart this UPS with no match.
 	config_get cfg_vendorid "$ups" vendorid
 	if [ -n "$cfg_vendorid" ] && ! check_valid_hex_number "${cfg_vendorid/0x/}"; then
-		logger -s -t nut-usb-hotplug "Configured vendorid for '$ups' is not valid"
+		log_error "Configured vendorid for '$ups' is not valid" "libhid-ups" nut-usb-hotplug
 		nd_driver_config_error=true
 		return 0
 	fi
@@ -138,7 +138,7 @@ nut_driver_config() {
 	# we keep going as we will restart this UPS with no match.
 	config_get cfg_productid "$ups" productid
 	if [ -n "$cfg_productid" ] && ! check_valid_hex_number "${cfg_productid/0x/}"; then
-		logger -s -t nut-usb-hotplug "Configured productid for '$ups' is not valid"
+		log_error "Configured productid for '$ups' is not valid" "libhid-ups" nut-usb-hotplug
 		nd_driver_config_error=true
 		return 0
 	fi
@@ -163,7 +163,7 @@ nut_driver_config() {
 	if [ "$try_match" = "no" ]; then
 		if [ "$ACTION" = "add" ]; then
 			if ! allow_hotplug_restart; then
-				logger -s -t nut-usb-hotplug "Hotplug restart disabled starting '$ups' when processing '$ACTION' for '$DEVNAME'"
+				log_msg "Hotplug restart disabled starting '$ups' when processing '$ACTION' for '$DEVNAME'" "libhid-ups" nut-usb-hotplug notice
 				return 0
 			fi
 			# We check enabled again here, in case of a race condition since
@@ -173,14 +173,14 @@ nut_driver_config() {
 				# than restart of '$ups'. The nut-server initscript will do a
 				# start if the reload fails.
 				/etc/init.d/nut-server reload "$ups" || {
-					log_error "Failed to reload unmatched driver instance (UPS) '$ups' in nut_driver_config" libhid-ups nut-usb-hotplug
+					log_msg "Failed to reload unmatched driver instance (UPS) '$ups' in nut_driver_config" libhid-ups nut-usb-hotplug notice
 					nd_driver_config_error=true
 					return 0
 				}
 			else
 				# Initscript should have its own logging, and we do not exit with
 				# error as that would abort processing other devices
-				logger -s -t nut-usb-hotplug "NUT server disabled when processing '$ACTION' for '$DEVNAME'."
+				log_msg "NUT server disabled when processing '$ACTION' for '$DEVNAME'." "libhid-ups" nut-usb-hotplug notice
 				return 0
 			fi
 		else
@@ -192,12 +192,12 @@ nut_driver_config() {
 		fi
 	elif [ -n "$cfg_vendorid" ] && [ -n "$cfg_productid" ] && [ -n "$pvendid" ] && [ -n "$pprodid" ]; then
 		if ! check_valid_hex_number "$pvendid"; then
-			logger -s -t nut-usb-hotplug "Hotplug vendor id for '$ups' is not valid"
+			log_error "Hotplug vendor id for '$ups' is not valid" "libhid-ups" nut-usb-hotplug
 			nd_driver_config_error=true
 			return 0
 		fi
 		if ! check_valid_hex_number "$pprodid"; then
-			logger -s -t nut-usb-hotplug "Hotplug product id for '$ups' is not valid"
+			log_error "Hotplug product id for '$ups' is not valid" "libhid-ups" nut-usb-hotplug
 			nd_driver_config_error=true
 			return 0
 		fi
@@ -230,12 +230,12 @@ perform_libhid_action() {
 	# Only find statepath and runas once per event
 	# defines STATEPATH
 	find_statepath "upsd" "nut_server" || {
-		logger -s -t nut-usb-hotplug "Failed to set STATEPATH"
+		log_error "Failed to set STATEPATH" "libhid-ups" nut-usb-hotplug
 		return 1
 	}
 	# sets RUNAS
 	find_runas "upsd" "nut_server" || {
-		logger -s -t nut-usb-hotplug "Failed to set RUNAS"
+		log_error "Failed to set RUNAS" "libhid-ups" nut-usb-hotplug
 		return 1
 	}
 
@@ -284,7 +284,7 @@ perform_libhid_action() {
 	# and not already stopped, will be stopped. This is preferable to doing
 	# nothing on removals.
 	if ! allow_hotplug_restart; then
-		logger -s -t nut-usb-hotplug "Hotplug restart disabled when processing '$ACTION' for '$DEVNAME'"
+		log_msg "Hotplug restart disabled when processing '$ACTION' for '$DEVNAME'" "libhid-ups" nut-usb-hotplug notice
 		return 0
 	fi
 	# We check enabled again here, in case of a race condition since
@@ -296,7 +296,7 @@ perform_libhid_action() {
 		fi
 		return 0
 	else
-		logger -s -t nut-usb-hotplug "NUT server disabled when processing '$ACTION' for '$DEVNAME'."
+		log_msg "NUT server disabled when processing '$ACTION' for '$DEVNAME'." "libhid-ups" nut-usb-hotplug notice
 		return 0
 	fi
 	# We do not return 0 here as it is unnecessary (all if branches have a
@@ -324,13 +324,13 @@ case "$PRODUCT" in
 	# NUT_DISABLE_HOTPLUG_PATH is an external sentinel used to indicate NUT
 	# hotplug is disabled.
 	if ! allow_hotplug_restart; then
-		logger -s -t nut-usb-hotplug "Hotplug restart disabled when processing '$ACTION' for '$DEVNAME'"
+		log_msg "Hotplug restart disabled when processing '$ACTION' for '$DEVNAME'" "libhid-ups" nut-usb-hotplug notice
 		exit 0
 	fi
 	# We check enabled again here, in case of a race condition since
 	# our last check.
 	if ! /etc/init.d/nut-server enabled; then
-		logger -s -t nut-usb-hotplug "NUT server disabled when processing '$ACTION' for '$DEVNAME'."
+		log_msg "NUT server disabled when processing '$ACTION' for '$DEVNAME'." "libhid-ups" nut-usb-hotplug notice
 		exit 0
 	fi
 	if ! perform_libhid_action; then

--- a/net/nut/files/libhid-ups.hotplug
+++ b/net/nut/files/libhid-ups.hotplug
@@ -16,7 +16,7 @@
 # shellcheck source=net/nut/files/functions.sh.functions
 . "${IPKG_INSTROOT}"/lib/functions.sh || {
 	# Before our sourcing error logging definitions are sourced
-	logger -s -t nut-usb-hotplug "Unable to source 'functions.sh' in 'libhid-ups' hotplug. Bailing"
+	logger -t nut-usb-hotplug "Unable to source 'functions.sh' in 'libhid-ups' hotplug. Bailing"
 	exit 1
 }
 
@@ -26,7 +26,7 @@
 # shellcheck source=net/nut/files/nut-common.sh.functions
 . "${IPKG_INSTROOT}"/lib/functions/nut/nut-common.sh || {
 	# Before our sourcing error logging definitions are sourced
-	logger -s -t nut-usb-hotplug "Unable to source 'nut-common.sh' in 'libhid-ups' hotplug. Bailing"
+	logger -t nut-usb-hotplug "Unable to source 'nut-common.sh' in 'libhid-ups' hotplug. Bailing"
 	exit 1
 }
 

--- a/net/nut/files/libhid-ups.hotplug
+++ b/net/nut/files/libhid-ups.hotplug
@@ -16,7 +16,7 @@
 # shellcheck source=net/nut/files/functions.sh.functions
 . "${IPKG_INSTROOT}"/lib/functions.sh || {
 	# Before our sourcing error logging definitions are sourced
-	logger -t nut-usb-hotplug "Unable to source 'functions.sh' in 'libhid-ups' hotplug. Bailing"
+	logger -t nut-usb-hotplug[$$] "Unable to source 'functions.sh' in 'libhid-ups' hotplug. Bailing"
 	exit 1
 }
 
@@ -26,7 +26,7 @@
 # shellcheck source=net/nut/files/nut-common.sh.functions
 . "${IPKG_INSTROOT}"/lib/functions/nut/nut-common.sh || {
 	# Before our sourcing error logging definitions are sourced
-	logger -t nut-usb-hotplug "Unable to source 'nut-common.sh' in 'libhid-ups' hotplug. Bailing"
+	logger -t nut-usb-hotplug[$$] "Unable to source 'nut-common.sh' in 'libhid-ups' hotplug. Bailing"
 	exit 1
 }
 

--- a/net/nut/files/nut-cgi.init
+++ b/net/nut/files/nut-cgi.init
@@ -280,7 +280,7 @@ service_reload() {
 			return 1
 		fi
 		# Empty hosts is not necessarily an error, but we log for information
-		logger -s -t nut-cgi "No configured hosts"
+		log_msg "No configured hosts" nut-cgi nut-cgi info
 	fi
 
 	# NUT CGI host file configuration is independent of upsset configuration

--- a/net/nut/files/nut-cgi.init
+++ b/net/nut/files/nut-cgi.init
@@ -35,7 +35,7 @@ UPSCGI_HOSTS_CONF="${UPSCGI_CONF_DIR}/hosts.conf"
 # shellcheck source=net/nut/files/functions.sh.functions
 . "${IPKG_INSTROOT}"/lib/functions.sh || {
 	# Before our sourcing error logging definitions are sourced
-	logger -s -t nut-cgi "Unable to source 'functions.sh'"
+	logger -t nut-cgi "Unable to source 'functions.sh'"
 	exit 1
 }
 
@@ -45,7 +45,7 @@ UPSCGI_HOSTS_CONF="${UPSCGI_CONF_DIR}/hosts.conf"
 # shellcheck source=net/nut/files/nut-common.sh.functions
 . "${IPKG_INSTROOT}"/lib/functions/nut/nut-common.sh || {
 	# Before our sourcing error logging definitions are sourced
-	logger -s -t nut-cgi "Failed to load nut-common.sh"
+	logger -t nut-cgi "Failed to load nut-common.sh"
 	exit 1
 }
 

--- a/net/nut/files/nut-cgi.init
+++ b/net/nut/files/nut-cgi.init
@@ -35,7 +35,7 @@ UPSCGI_HOSTS_CONF="${UPSCGI_CONF_DIR}/hosts.conf"
 # shellcheck source=net/nut/files/functions.sh.functions
 . "${IPKG_INSTROOT}"/lib/functions.sh || {
 	# Before our sourcing error logging definitions are sourced
-	logger -t nut-cgi "Unable to source 'functions.sh'"
+	logger -t nut-cgi[$$] "Unable to source 'functions.sh'"
 	exit 1
 }
 
@@ -45,7 +45,7 @@ UPSCGI_HOSTS_CONF="${UPSCGI_CONF_DIR}/hosts.conf"
 # shellcheck source=net/nut/files/nut-common.sh.functions
 . "${IPKG_INSTROOT}"/lib/functions/nut/nut-common.sh || {
 	# Before our sourcing error logging definitions are sourced
-	logger -t nut-cgi "Failed to load nut-common.sh"
+	logger -t nut-cgi[$$] "Failed to load nut-common.sh"
 	exit 1
 }
 

--- a/net/nut/files/nut-common.sh.functions
+++ b/net/nut/files/nut-common.sh.functions
@@ -185,7 +185,7 @@ log_msg() {
 	local level="${4:-notice}"
 	local facility="${5:-daemon}"
 
-	logger -t "$syslog_id" -p "${facility}.${level}" "'$reason' in '$current_script'" || {
+	logger -t "${syslog_id}[$$]" -p "${facility}.${level}" "'$reason' in '$current_script'" || {
 		# We use 'tr' as changing case via variable parameter substitution is not available in ash on OpenWrt
 		# shellcheck disable=SC2018,SC2019
 		level="$(echo "$level" | tr 'a-z' 'A-Z')"

--- a/net/nut/files/nut-common.sh.functions
+++ b/net/nut/files/nut-common.sh.functions
@@ -185,7 +185,7 @@ log_msg() {
 	local level="${4:-notice}"
 	local facility="${5:-daemon}"
 
-	logger -s -t "$syslog_id" -p "${facility}.${level}" "'$reason' in '$current_script'" || {
+	logger -t "$syslog_id" -p "${facility}.${level}" "'$reason' in '$current_script'" || {
 		# We use 'tr' as changing case via variable parameter substitution is not available in ash on OpenWrt
 		# shellcheck disable=SC2018,SC2019
 		level="$(echo "$level" | tr 'a-z' 'A-Z')"

--- a/net/nut/files/nut-monitor.init
+++ b/net/nut/files/nut-monitor.init
@@ -18,7 +18,7 @@ USE_PROCD=1
 # shellcheck source=net/nut/files/functions.sh.functions
 . "${IPKG_INSTROOT}"/lib/functions.sh || {
 	# Before our sourcing error logging definitions are sourced
-	logger -s -t nut-monitor "Unable to source 'functions.sh' in 'nut-monitor'. Bailing"
+	logger -t nut-monitor "Unable to source 'functions.sh' in 'nut-monitor'. Bailing"
 	exit 1
 }
 
@@ -28,7 +28,7 @@ USE_PROCD=1
 # shellcheck source=net/nut/files/nut-common.sh.functions
 . "${IPKG_INSTROOT}"/lib/functions/nut/nut-common.sh || {
 	# Before our sourcing error logging definitions are sourced
-	logger -s -t nut-monitor "Unable to source 'nut-common.sh' in 'nut-monitor'. Bailing"
+	logger -t nut-monitor "Unable to source 'nut-common.sh' in 'nut-monitor'. Bailing"
 	exit 1
 }
 
@@ -104,9 +104,10 @@ service_preconditions() {
 start_monitor_instance() {
 	procd_open_instance upsmon
 	procd_set_param respawn
-	procd_set_param stderr 0 # stderr is just a dup of stdout + logger (with -s)
+	procd_set_param stderr 1
 	procd_set_param stdout 1
 	procd_set_param env NUT_QUIET_INIT_UPSNOTIFY=true
+	procd_set_param env NUT_DEBUG_SYSLOG="stderr"
 	procd_set_param reload_signal HUP
 	procd_set_param command /usr/sbin/upsmon
 	procd_append_param command -FF

--- a/net/nut/files/nut-monitor.init
+++ b/net/nut/files/nut-monitor.init
@@ -18,7 +18,7 @@ USE_PROCD=1
 # shellcheck source=net/nut/files/functions.sh.functions
 . "${IPKG_INSTROOT}"/lib/functions.sh || {
 	# Before our sourcing error logging definitions are sourced
-	logger -t nut-monitor "Unable to source 'functions.sh' in 'nut-monitor'. Bailing"
+	logger -t nut-monitor[$$] "Unable to source 'functions.sh' in 'nut-monitor'. Bailing"
 	exit 1
 }
 
@@ -28,7 +28,7 @@ USE_PROCD=1
 # shellcheck source=net/nut/files/nut-common.sh.functions
 . "${IPKG_INSTROOT}"/lib/functions/nut/nut-common.sh || {
 	# Before our sourcing error logging definitions are sourced
-	logger -t nut-monitor "Unable to source 'nut-common.sh' in 'nut-monitor'. Bailing"
+	logger -t nut-monitor[$$] "Unable to source 'nut-common.sh' in 'nut-monitor'. Bailing"
 	exit 1
 }
 

--- a/net/nut/files/nut-notify-exec.default
+++ b/net/nut/files/nut-notify-exec.default
@@ -26,7 +26,7 @@
 
 # shellcheck source=net/nut/files/functions.sh.functions
 . /lib/functions.sh || {
-	logger -s -t nut-notify-exec "FATAL: Unable to source 'functions.sh'." || true
+	logger -t nut-notify-exec "FATAL: Unable to source 'functions.sh'." || true
 	exit 1
 }
 
@@ -35,7 +35,7 @@ DEFAULTNOTIFY_IS_IGNORE="false"
 
 # Load and process nut_monitor (upsmon) configuration
 config_load nut_monitor || {
-	logger -s -t nut-notify-exec "FATAL: Loading 'nut_monitor' failed" || true
+	logger -t nut-notify-exec "FATAL: Loading 'nut_monitor' failed" || true
 	exit 1
 }
 
@@ -48,7 +48,7 @@ else
 	# needed, doing nothing if a upsmon type section named 'upsmon' already
 	# exists).
 	uci set "nut_monitor.upsmon=upsmon" || {
-		logger -s -t nut-notify-exec "Failed to ensure an upsmon section named upsmon exists" || true
+		logger -t nut-notify-exec "Failed to ensure an upsmon section named upsmon exists" || true
 		exit 1
 	}
 fi
@@ -65,13 +65,13 @@ else
 fi
 
 uci set "nut_monitor.upsmon.defaultnotify"="$defaultnotify" || {
-	logger -s -t nut-notify-exec "FATAL: Failed to set 'defaultnotify' for 'upsmon'" || true
+	logger -t nut-notify-exec "FATAL: Failed to set 'defaultnotify' for 'upsmon'" || true
 	uci revert nut_monitor || true
 	exit 1
 }
 
 uci commit nut_monitor || {
-	logger -s -t nut-notify-exec "ERROR: Failed to commit changes to nut_monitor" || true
+	logger -t nut-notify-exec "ERROR: Failed to commit changes to nut_monitor" || true
 	exit 1
 }
 

--- a/net/nut/files/nut-sched.default
+++ b/net/nut/files/nut-sched.default
@@ -27,7 +27,7 @@
 
 # shellcheck source=net/nut/files/functions.sh.functions
 . /lib/functions.sh || {
-	logger -s -t nut-sched "FATAL: Unable to source 'functions.sh'" || true
+	logger -t nut-sched "FATAL: Unable to source 'functions.sh'" || true
 	exit 1
 }
 
@@ -36,7 +36,7 @@ SKIP_ADD_NOTIFYCMD="false"
 
 # Load and process nut_monitor (upsmon) configuration
 config_load nut_monitor || {
-	logger -s -t nut-sched "FATAL: loading 'nut_monitor' failed" || true
+	logger -t nut-sched "FATAL: loading 'nut_monitor' failed" || true
 	exit 1
 }
 
@@ -50,18 +50,18 @@ fi
 if [ "${SKIP_ADD_NOTIFYCMD}" = "false" ]; then
 	# Ensure upsmon type section with the name upsmon exists
 	uci set "nut_monitor.upsmon=upsmon" || {
-		logger -s -t nut-sched "Failed to ensure an upsmon section named upsmon exists" || true
+		logger -t nut-sched "Failed to ensure an upsmon section named upsmon exists" || true
 		exit 1
 	}
 
 	uci set "nut_monitor.upsmon.notifycmd=/usr/sbin/upssched" || {
-		logger -s -t nut-sched "Failed to set notifycmd to upssched" || true
+		logger -t nut-sched "Failed to set notifycmd to upssched" || true
 		uci revert nut_monitor || true
 		exit 1
 	}
 
 	uci commit nut_monitor || {
-		logger -s -t nut-sched "Failed to commit changes to nut_monitor" || true
+		logger -t nut-sched "Failed to commit changes to nut_monitor" || true
 		exit 1
 	}
 fi

--- a/net/nut/files/nut-sendmail-notify
+++ b/net/nut/files/nut-sendmail-notify
@@ -15,7 +15,7 @@
 
 # shellcheck source=net/nut/files/functions.sh.functions
 . "${IPKG_INSTROOT}"/lib/functions.sh || {
-	logger -t nut-sendmail-notify "Unable to source 'functions.sh' in 'nut-sendmail-notify'. Bailing"
+	logger -t nut-sendmail-notify[$$] "Unable to source 'functions.sh' in 'nut-sendmail-notify'. Bailing"
 	exit 1
 }
 
@@ -24,7 +24,7 @@
 # shellcheck disable=SC1094
 # shellcheck source=net/nut/files/nut-common.sh.functions
 . "${IPKG_INSTROOT}"/lib/functions/nut/nut-common.sh || {
-	logger -t nut-sendmail-notify "Unable to source 'nut-common.sh' in 'nut-sendmail-notify'. Bailing"
+	logger -t nut-sendmail-notify[$$] "Unable to source 'nut-common.sh' in 'nut-sendmail-notify'. Bailing"
 	exit 1
 }
 
@@ -33,7 +33,7 @@ log_send_failure_and_exit() {
 	local reason="$1"
 	local syslog_id="nut-sendmail-notify"
 	local message_prefix="Message was not sent"
-	logger -t "$syslog_id" "${message_prefix}: $reason" || {
+	logger -t "${syslog_id}[$$]" "${message_prefix}: $reason" || {
 		printf "%s: %s: %s, and logging failed\n" "$syslog_id" "$message_prefix" "$reason" >&2
 	}
 	exit 1

--- a/net/nut/files/nut-sendmail-notify
+++ b/net/nut/files/nut-sendmail-notify
@@ -15,7 +15,7 @@
 
 # shellcheck source=net/nut/files/functions.sh.functions
 . "${IPKG_INSTROOT}"/lib/functions.sh || {
-	logger -s -t nut-sendmail-notify "Unable to source 'functions.sh' in 'nut-sendmail-notify'. Bailing"
+	logger -t nut-sendmail-notify "Unable to source 'functions.sh' in 'nut-sendmail-notify'. Bailing"
 	exit 1
 }
 
@@ -24,7 +24,7 @@
 # shellcheck disable=SC1094
 # shellcheck source=net/nut/files/nut-common.sh.functions
 . "${IPKG_INSTROOT}"/lib/functions/nut/nut-common.sh || {
-	logger -s -t nut-sendmail-notify "Unable to source 'nut-common.sh' in 'nut-sendmail-notify'. Bailing"
+	logger -t nut-sendmail-notify "Unable to source 'nut-common.sh' in 'nut-sendmail-notify'. Bailing"
 	exit 1
 }
 
@@ -33,7 +33,7 @@ log_send_failure_and_exit() {
 	local reason="$1"
 	local syslog_id="nut-sendmail-notify"
 	local message_prefix="Message was not sent"
-	logger -s -t "$syslog_id" "${message_prefix}: $reason" || {
+	logger -t "$syslog_id" "${message_prefix}: $reason" || {
 		printf "%s: %s: %s, and logging failed\n" "$syslog_id" "$message_prefix" "$reason" >&2
 	}
 	exit 1

--- a/net/nut/files/nut-sendmail-notify.default
+++ b/net/nut/files/nut-sendmail-notify.default
@@ -27,7 +27,7 @@
 
 # shellcheck source=net/nut/files/functions.sh.functions
 . /lib/functions.sh || {
-	logger -s -t nut-sendmail-notify "FATAL: Unable to source 'functions.sh'" || true
+	logger -t nut-sendmail-notify "FATAL: Unable to source 'functions.sh'" || true
 	exit 1
 }
 
@@ -36,7 +36,7 @@ SKIP_ADD_NOTIFYCMD="false"
 
 # Load and process nut_monitor (upsmon) configuration
 config_load nut_monitor || {
-	logger -s -t nut-sendmail-notify "FATAL: Loading 'nut_monitor' failed." || true
+	logger -t nut-sendmail-notify "FATAL: Loading 'nut_monitor' failed." || true
 	exit 1
 }
 
@@ -50,7 +50,7 @@ fi
 if [ "${SKIP_ADD_NOTIFYCMD}" = "false" ]; then
 	# Ensure upsmon type section with the name upsmon exists
 	uci set "nut_monitor.upsmon=upsmon" || {
-		logger -s -t nut-sendmail-notify "Failed to ensure an upsmon section named upsmon exists" || true
+		logger -t nut-sendmail-notify "Failed to ensure an upsmon section named upsmon exists" || true
 		exit 1
 	}
 
@@ -61,14 +61,14 @@ if [ "${SKIP_ADD_NOTIFYCMD}" = "false" ]; then
 		# never be reached. This is intentional. upssched takes precedence over
 		# nut-sendmail-notify, unless the user writes a script that supports both.
 		uci set "nut_monitor.upsmon.notifycmd=/usr/bin/nut-sendmail-notify" || {
-			logger -s -t nut-sendmail-notify "Failed to set notifycmd to be nut-sendmail-notify" || true
+			logger -t nut-sendmail-notify "Failed to set notifycmd to be nut-sendmail-notify" || true
 			uci revert nut_monitor || true
 			exit 1
 		}
 	fi
 
 	uci commit nut_monitor || {
-		logger -s -t nut-sendmail-notify "Failed to commit changes to nut_monitor" || true
+		logger -t nut-sendmail-notify "Failed to commit changes to nut_monitor" || true
 		exit 1
 	}
 fi

--- a/net/nut/files/nut-serial.hotplug
+++ b/net/nut/files/nut-serial.hotplug
@@ -16,7 +16,7 @@
 # shellcheck source=net/nut/files/functions.sh.functions
 . "${IPKG_INSTROOT}"/lib/functions.sh || {
 	# Before our sourcing error logging definitions are sourced
-	logger -t nut-serial-hotplug "Unable to source 'functions.sh' in 'nut-serial' hotplug. Bailing"
+	logger -t nut-serial-hotplug[$$] "Unable to source 'functions.sh' in 'nut-serial' hotplug. Bailing"
 	exit 1
 }
 
@@ -26,7 +26,7 @@
 # shellcheck source=net/nut/files/nut-common.sh.functions
 . "${IPKG_INSTROOT}"/lib/functions/nut/nut-common.sh || {
 	# Before our sourcing error logging definitions are sourced
-	logger -t nut-serial-hotplug "Unable to source 'nut-common.sh' in 'nut-serial' hotplug. Bailing"
+	logger -t nut-serial-hotplug[$$] "Unable to source 'nut-common.sh' in 'nut-serial' hotplug. Bailing"
 	exit 1
 }
 

--- a/net/nut/files/nut-serial.hotplug
+++ b/net/nut/files/nut-serial.hotplug
@@ -16,7 +16,7 @@
 # shellcheck source=net/nut/files/functions.sh.functions
 . "${IPKG_INSTROOT}"/lib/functions.sh || {
 	# Before our sourcing error logging definitions are sourced
-	logger -s -t nut-serial-hotplug "Unable to source 'functions.sh' in 'nut-serial' hotplug. Bailing"
+	logger -t nut-serial-hotplug "Unable to source 'functions.sh' in 'nut-serial' hotplug. Bailing"
 	exit 1
 }
 
@@ -26,7 +26,7 @@
 # shellcheck source=net/nut/files/nut-common.sh.functions
 . "${IPKG_INSTROOT}"/lib/functions/nut/nut-common.sh || {
 	# Before our sourcing error logging definitions are sourced
-	logger -s -t nut-serial-hotplug "Unable to source 'nut-common.sh' in 'nut-serial' hotplug. Bailing"
+	logger -t nut-serial-hotplug "Unable to source 'nut-common.sh' in 'nut-serial' hotplug. Bailing"
 	exit 1
 }
 

--- a/net/nut/files/nut-serial.hotplug
+++ b/net/nut/files/nut-serial.hotplug
@@ -139,7 +139,7 @@ nut_on_hotplug_add() {
 	# attempt to reload the driver and/or server
 	if [ "$did_set_perms" = "true" ]; then
 		# Informational and not an error
-		logger -t nut-serial-hotplug "Successfully set permissions for serial device(s)"
+		log_msg "Successfully set permissions for serial device(s)" nut-serial nut-serial-hotplug info
 		# We shouldn't get here if hotplug is disabled (race condition if we do), so log it as an error
 		if ! allow_hotplug_restart; then
 			log_error "Did not restart NUT after setting permissions as hotplug restart is disabled" nut-serial nut-serial-hotplug
@@ -163,7 +163,7 @@ nut_on_hotplug_add() {
 # for information
 if ! allow_hotplug_restart; then
 	# Informational and not an error
-	logger -t nut-serial-hotplug "Did not set permissions on serial port hotplug as NUT hotplug is disabled"
+	log_msg "Did not set permissions on serial port hotplug as NUT hotplug is disabled" nut-serial nut-serial-hotplug notice
 	exit 0
 fi
 

--- a/net/nut/files/nut-server.init
+++ b/net/nut/files/nut-server.init
@@ -397,7 +397,7 @@ reload_ups_driver() {
 
 stop_service_if_no_instances() {
 	if service_active_no_instances "nut-server"; then
-		logger -t "nut-server" "nut-server active with no instances"
+		log_msg "nut-server active with no instances" nut-server "nut-server" notice
 		# If "nut-server" is active with no instances
 		# We don't care about the exit code of procd_kill, and logging its
 		# stderr can aid debugging.

--- a/net/nut/files/nut-server.init
+++ b/net/nut/files/nut-server.init
@@ -29,7 +29,7 @@ USE_PROCD=1
 # shellcheck source=net/nut/files/functions.sh.functions
 . "${IPKG_INSTROOT}"/lib/functions.sh || {
 	# Before our sourcing error logging definitions are sourced
-	logger -s -t "nut-server" "FATAL: Unable to source 'functions.sh' in 'nut-server'"
+	logger -t "nut-server" "FATAL: Unable to source 'functions.sh' in 'nut-server'"
 	exit 1
 }
 
@@ -39,7 +39,7 @@ USE_PROCD=1
 # shellcheck source=net/nut/files/nut-common.sh.functions
 . "${IPKG_INSTROOT}"/lib/functions/nut/nut-common.sh || {
 	# Before our sourcing error logging definitions are sourced
-	logger -s -t "nut-server" "FATAL: Unable to source 'nut-common.sh' in 'nut-server'"
+	logger -t "nut-server" "FATAL: Unable to source 'nut-common.sh' in 'nut-server'"
 	exit 1
 }
 
@@ -101,8 +101,9 @@ start_ups_driver() {
 
 	procd_open_instance "$ups"
 	procd_set_param respawn
-	procd_set_param stderr 0 # stderr is just a dup of stdout + logger (with -s)
+	procd_set_param stderr 1
 	procd_set_param stdout 1
+	procd_set_param env NUT_DEBUG_SYSLOG="stderr"
 	procd_set_param env NUT_QUIET_INIT_UPSNOTIFY=true
 	procd_set_param env NUT_STATEPATH="${STATEPATH}"
 	procd_set_param command "/usr/libexec/nut/${driver}"
@@ -183,7 +184,7 @@ stop_no_longer_configured_instances() {
 		config_get driver "$instance" driver
 		# Only stop not configured but running instances
 		if [ -z "$driver" ] && [ -n "$instance" ] && procd_running "nut-server" "$instance" >/dev/null 2>&1; then
-			procd_kill "nut-server" "$instance" 2>&1 | logger -s -t nut-server
+			procd_kill "nut-server" "$instance" 2>&1 | logger -t nut-server
 		fi
 	done
 	set +f
@@ -312,8 +313,9 @@ start_server_instance() {
 
 	procd_open_instance upsd
 	procd_set_param respawn
-	procd_set_param stderr 0 # stderr is just a dup of stdout + logger (with -s)
+	procd_set_param stderr 1
 	procd_set_param stdout 1
+	procd_set_param env NUT_DEBUG_SYSLOG="stderr"
 	procd_set_param env NUT_QUIET_INIT_UPSNOTIFY=true
 	procd_set_param env NUT_STATEPATH="$STATEPATH"
 	procd_set_param command /usr/sbin/upsd
@@ -399,7 +401,7 @@ stop_service_if_no_instances() {
 		# If "nut-server" is active with no instances
 		# We don't care about the exit code of procd_kill, and logging its
 		# stderr can aid debugging.
-		procd_kill "nut-server" 2>&1 | logger -s -t "nut-server"
+		procd_kill "nut-server" 2>&1 | logger -t "nut-server"
 	fi
 }
 

--- a/net/nut/files/nut-server.init
+++ b/net/nut/files/nut-server.init
@@ -29,7 +29,7 @@ USE_PROCD=1
 # shellcheck source=net/nut/files/functions.sh.functions
 . "${IPKG_INSTROOT}"/lib/functions.sh || {
 	# Before our sourcing error logging definitions are sourced
-	logger -t "nut-server" "FATAL: Unable to source 'functions.sh' in 'nut-server'"
+	logger -t "nut-server[$$]" "FATAL: Unable to source 'functions.sh' in 'nut-server'"
 	exit 1
 }
 
@@ -39,7 +39,7 @@ USE_PROCD=1
 # shellcheck source=net/nut/files/nut-common.sh.functions
 . "${IPKG_INSTROOT}"/lib/functions/nut/nut-common.sh || {
 	# Before our sourcing error logging definitions are sourced
-	logger -t "nut-server" "FATAL: Unable to source 'nut-common.sh' in 'nut-server'"
+	logger -t "nut-server[$$]" "FATAL: Unable to source 'nut-common.sh' in 'nut-server'"
 	exit 1
 }
 
@@ -397,7 +397,7 @@ reload_ups_driver() {
 
 stop_service_if_no_instances() {
 	if service_active_no_instances "nut-server"; then
-		logger -s -t "nut-server" "nut-server active with no instances"
+		logger -t "nut-server" "nut-server active with no instances"
 		# If "nut-server" is active with no instances
 		# We don't care about the exit code of procd_kill, and logging its
 		# stderr can aid debugging.

--- a/net/nut/files/nut-service.sh.functions
+++ b/net/nut/files/nut-service.sh.functions
@@ -67,7 +67,7 @@ list_running_instances() {
 	if [ -n "$running_instances" ]; then
 		json_init
 		json_load "$running_instances" || {
-			logger -s -t nut-service "json_load failed in list_running_instances"
+			log_error "json_load failed in list_running_instances" nut-service.sh nut-service
 			return 1
 		}
 		json_get_keys instance_names
@@ -139,7 +139,7 @@ signal_instance() {
 	# We only want to issue secondary command if the primary command fails
 	if [ "$ret" = "1" ] && [ -n "$secondary_command" ] && procd_running "$service_name" "$instance_name"; then
 		# Informational log message, not error
-		logger -s -t "$service_name" "Performing '$secondary_command' $* for '$instance_name'"
+		log_msg "Performing '$secondary_command' $* for '$instance_name'" nut-service.sh "$service_name" info
 		set -f
 		"$secondary_command" "$@" 2>&1 | logger -t "$service_name"
 		set +f

--- a/net/nut/files/nut-service.sh.functions
+++ b/net/nut/files/nut-service.sh.functions
@@ -141,7 +141,7 @@ signal_instance() {
 		# Informational log message, not error
 		logger -s -t "$service_name" "Performing '$secondary_command' $* for '$instance_name'"
 		set -f
-		"$secondary_command" "$@" 2>&1 | logger -s -t "$service_name"
+		"$secondary_command" "$@" 2>&1 | logger -t "$service_name"
 		set +f
 	fi
 	# No signal sent is a valid possibility. Also, if sending a signal fails

--- a/net/nut/files/nutshutdown
+++ b/net/nut/files/nutshutdown
@@ -53,7 +53,7 @@ stop_nut_server_instance() {
 	# We're in an emergency shutdown; best effort shutdown and don't block
 	if [ -z "$1" ]; then
 		echo "$MISSING_UPS_INSTANCE_SKIP_MESSAGE" >&2
-		logger -s -t nut-shutdown "$MISSING_UPS_INSTANCE_SKIP_MESSAGE" || true
+		logger -t nut-shutdown "$MISSING_UPS_INSTANCE_SKIP_MESSAGE" || true
 		return 1
 	fi
 	"$NUT_SERVER_INIT" stop "$1" || true
@@ -76,7 +76,7 @@ shutdown_actual_ups() {
 	# with a proper UCI name (should never happen, hence skipping if it does)
 	if ! check_safe_name "$ups"; then
 		echo "$UNSAFE_UPS_INSTANCE_NAME_SKIP_MESSAGE" >&2
-		logger -s -t nut-shutdown "$UNSAFE_UPS_INSTANCE_NAME_SKIP_MESSAGE" || true
+		logger -t nut-shutdown "$UNSAFE_UPS_INSTANCE_NAME_SKIP_MESSAGE" || true
 		return 1
 	fi
 
@@ -138,7 +138,7 @@ do_forced_shutdown() {
 if [ -n "${IPKG_INSTROOT}" ]; then
 	echo "$NOT_A_LIVE_SYSTEM_BAIL_MESSAGE" >&2
 	# Improbable logging will work
-	logger -s -t nut-shutdown "$NOT_A_LIVE_SYSTEM_BAIL_MESSAGE" || true
+	logger -t nut-shutdown "$NOT_A_LIVE_SYSTEM_BAIL_MESSAGE" || true
 	exit 1
 fi
 
@@ -148,7 +148,7 @@ fi
 	# live system) bail with an error.
 	# Logging probably won't work if /lib/functions.sh is not available but try
 	echo "$MISSING_LIB_FUNCTIONS_SH_BAIL_MESSAGE" >&2
-	logger -s -t nut-shutdown "$MISSING_LIB_FUNCTIONS_SH_BAIL_MESSAGE" || true
+	logger -t nut-shutdown "$MISSING_LIB_FUNCTIONS_SH_BAIL_MESSAGE" || true
 	exit 1
 }
 
@@ -184,7 +184,7 @@ elif [ -f "$NUT_KILLPOWER" ]; then
 	DO_KILLPOWER="1"
 	disable_hotplug || true
 	echo "$MISSING_CONFIG_BAIL_MESSAGE" >&2 || true
-	logger -s -t nut-shutdown "$MISSING_CONFIG_BAIL_MESSAGE" || true
+	logger -t nut-shutdown "$MISSING_CONFIG_BAIL_MESSAGE" || true
 
 	remount_filesystems_as_readonly || true
 fi


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @danielfdickinson 
**Also notify:** @drujd @BKPepe 

**Description:**

NUT (upstream) logging has changed. With the introduction of
NUT_DEBUG_SYSLOG we can set it to "stderr" and have NUT's messages
go to stderr only.

This avoid most duplicate messages when procd sends stderr to syslog.

The reverse (syslog only from NUT) is not a current configuration
option. See the section for NUT_DEBUG_SYSLOG at
https://networkupstools.org/docs/man/nut.conf.html#_directives

This is needed because we use '-FF' so that the daemons remain in the
foreground, which is required for procd to manage them. When using
'-FF' logging behaves differently in NUT than when backgrounded.

Unfortunately, there is still some work to be done upstream to
completely eliminate duplicate messages, so some message continue to
appear twice, though not neccessarily with the same facility.priority.

See also
https://github.com/jimklimov/nut/blob/0c3eed09b89cce1e5c0c65ca03d05b4612371cb8/UPGRADING.adoc#changes-from-282-to-283
and
https://github.com/openwrt/packages/pull/29896#issuecomment-5012737643

Conversely, the log messages the initscripts emit are now configured to
emit only to syslog and not to stderr. This avoids duplicates messages
caused by procd's automatic (not configurable) behaviour of sending
the initscript's stderr to syslog, while preserving the syslogid,
facility and priority we want.

Also: Show the PID beside the syslog_id to aid debugging.

And: Where possible prefer the log wrappers to direct logger calls.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** OpenWrt SNAPSHOT r35431-4f2dc5cc64
- **OpenWrt Target/Subtarget:** bcm27xx/bcm2709
- **OpenWrt Device:** Raspberry Pi 2 Model B Rev 1.1
- **UPS Model:** Trip-Lite ECO550UPS

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
