### PR TITLE
syslog-ng: bind localhost source with ip-freebind

### DIFF
--- a/admin/syslog-ng/Makefile
+++ b/admin/syslog-ng/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=syslog-ng
 PKG_VERSION:=4.11.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=LGPL-2.1-or-later GPL-2.0-or-later

--- a/admin/syslog-ng/Makefile
+++ b/admin/syslog-ng/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=syslog-ng
 PKG_VERSION:=4.12.0
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=LGPL-2.1-or-later GPL-2.0-or-later

--- a/admin/syslog-ng/files/scl/network_localhost/detect.sh
+++ b/admin/syslog-ng/files/scl/network_localhost/detect.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 if [ "$(sysctl -n net.ipv6.conf.lo.disable_ipv6)" = "0" ]; then
-	echo 'network(ip("::1") port(514) transport(udp) ip-protocol(6) )'
+	echo 'network(ip("::1") port(514) transport(udp) ip-protocol(6) ip-freebind(yes) )'
 else
-	echo 'network(ip("127.0.0.1") port(514) transport(udp) ip-protocol(4) )'
+	echo 'network(ip("127.0.0.1") port(514) transport(udp) ip-protocol(4) ip-freebind(yes) )'
 fi


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @BKPepe 
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

The network_localhost source binds ::1 or 127.0.0.1 on port 514... but this bind fails with EADDRNOTAVAIL when syslog-ng starts early in boot before netifd has brought lo up and assigned its addresses. This results in the entire syslog-ng instance exiting out with code 2 so no logging.

Add ip-freebind(yes) so the socket can bind before the loopback address exists and starts receiving once it appears. This change only affects the early-boot race, once lo is up, the behavior is unchanged.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** x86/64-glibc
- **OpenWrt Device:** N150

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
