### PR TITLE
lpac: QMI APDU support + LPAC_VERSION fix

### DIFF
--- a/utils/lpac/Config.in
+++ b/utils/lpac/Config.in
@@ -23,4 +23,10 @@ config LPAC_WITH_MBIM
 	default y
 	help
 	  Compile LPAC with APDU MBIM Backend support.
+
+config LPAC_WITH_QMI
+	bool "Include APDU QMI Backend support"
+	default y
+	help
+	  Compile LPAC with APDU QMI Backend support.
 endmenu

--- a/utils/lpac/Makefile
+++ b/utils/lpac/Makefile
@@ -4,7 +4,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lpac
 PKG_VERSION:=2.3.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/estkme-group/lpac/tar.gz/refs/tags/v$(PKG_VERSION)?
@@ -27,6 +27,7 @@ define Package/lpac
     +LPAC_WITH_PCSC:libpcsclite \
     +LPAC_WITH_PCSC:pcscd \
     +LPAC_WITH_MBIM:libmbim \
+    +LPAC_WITH_QMI:libqmi \
     +LPAC_WITH_UQMI:uqmi
   URL:=https://github.com/estkme-group/lpac
 endef
@@ -53,6 +54,7 @@ CMAKE_OPTIONS += \
   -DLPAC_WITH_APDU_AT=$(if $(CONFIG_LPAC_WITH_AT),ON,OFF) \
   -DLPAC_WITH_APDU_UQMI=$(if $(CONFIG_LPAC_WITH_UQMI),ON,OFF) \
   -DLPAC_WITH_APDU_MBIM=$(if $(CONFIG_LPAC_WITH_MBIM),ON,OFF) \
+  -DLPAC_WITH_APDU_QMI=$(if $(CONFIG_LPAC_WITH_QMI),ON,OFF) \
   -DLPAC_WITH_APDU_QMI_QRTR=OFF
 
 define Package/lpac/install

--- a/utils/lpac/files/lpac.sh
+++ b/utils/lpac/files/lpac.sh
@@ -35,6 +35,9 @@ elif [ "$APDU_BACKEND" = "mbim" ]; then
     MBIM_PROXY="$(uci_get lpac mbim proxy 1)"
     export LPAC_APDU_MBIM_DEVICE="$MBIM_DEVICE"
     export LPAC_APDU_MBIM_USE_PROXY="$MBIM_PROXY"
+elif [ "$APDU_BACKEND" = "qmi" ]; then
+    QMI_DEV="$(uci_get lpac qmi device /dev/cdc-wdm0)"
+    export LPAC_APDU_QMI_DEVICE="$QMI_DEV"
 fi
 
 export LPAC_CUSTOM_ISD_R_AID="$CUSTOM_ISD_R_AID"

--- a/utils/lpac/files/lpac.uci
+++ b/utils/lpac/files/lpac.uci
@@ -16,3 +16,6 @@ config uqmi uqmi
 config mbim mbim
 	option		device		'/dev/cdc-wdm0'
 	option		proxy		'1'
+
+config qmi qmi
+	option		device		'/dev/cdc-wdm0'

--- a/utils/lpac/patches/0002-refactor-new-LPAC_VERSION-handling.patch
+++ b/utils/lpac/patches/0002-refactor-new-LPAC_VERSION-handling.patch
@@ -1,0 +1,108 @@
+From 957955d0a93361519bb1ce1ef777dba7c1830ed1 Mon Sep 17 00:00:00 2001
+From: Coelacanthus <uwu@coelacanthus.name>
+Date: Sun, 24 Aug 2025 22:41:48 +0800
+Subject: [PATCH] refactor: new LPAC_VERSION handling (#310)
+
+* When git and .git directory is available, it append revision and
+  commit id of HEAD to version string.
+* Otherwise, it use version string defined in project() command.
+* Use target_compile_definitions() instead of configure header file,
+  avoid common header name conflict.
+
+Signed-off-by: Coelacanthus <uwu@coelacanthus.name>
+---
+ cmake/git-version.cmake | 43 ++++++++++++++++++-----------------------
+ src/CMakeLists.txt      | 15 ++++++--------
+ src/applet/version.h    |  2 --
+ src/version.h.in        |  4 ----
+ 4 files changed, 25 insertions(+), 39 deletions(-)
+ delete mode 100644 src/version.h.in
+
+--- a/cmake/git-version.cmake
++++ b/cmake/git-version.cmake
+@@ -1,25 +1,20 @@
+-# from https://github.com/nocnokneo/cmake-git-versioning-example
+-
+-if(GIT_EXECUTABLE)
+-  get_filename_component(SRC_DIR ${SRC} DIRECTORY)
+-  # Generate a git-describe version string from Git repository tags
+-  execute_process(
+-    COMMAND ${GIT_EXECUTABLE} describe --always --tags --dirty --match "v*"
+-    WORKING_DIRECTORY ${SRC_DIR}
+-    OUTPUT_VARIABLE GIT_DESCRIBE_VERSION
+-    RESULT_VARIABLE GIT_DESCRIBE_ERROR_CODE
+-    OUTPUT_STRIP_TRAILING_WHITESPACE
+-  )
+-  if(NOT GIT_DESCRIBE_ERROR_CODE)
+-    set(LPAC_VERSION ${GIT_DESCRIBE_VERSION})
+-  endif()
++find_package(Git)
++if(GIT_EXECUTABLE AND IS_DIRECTORY ${CMAKE_SOURCE_DIR}/.git)
++    execute_process(
++        COMMAND ${GIT_EXECUTABLE} rev-list --count HEAD
++        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
++        OUTPUT_VARIABLE GIT_REVISION
++        RESULT_VARIABLE GIT_REVISION_ERROR_CODE
++        OUTPUT_STRIP_TRAILING_WHITESPACE
++    )
++    execute_process(
++        COMMAND ${GIT_EXECUTABLE} rev-parse --short=12 HEAD
++        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
++        OUTPUT_VARIABLE GIT_COMMIT_ID
++        RESULT_VARIABLE GIT_COMMIT_ID_ERROR_CODE
++        OUTPUT_STRIP_TRAILING_WHITESPACE
++    )
++    if(NOT GIT_REVISION_ERROR_CODE AND NOT GIT_COMMIT_ID_ERROR_CODE)
++        set(LPAC_VERSION ${CMAKE_PROJECT_VERSION}.r${GIT_REVISION}.${GIT_COMMIT_ID})
++    endif()
+ endif()
+-
+-# Final fallback: Just use a bogus version string that is semantically older
+-# than anything else and spit out a warning to the developer.
+-if(NOT DEFINED LPAC_VERSION)
+-  set(LPAC_VERSION v0.0.0-unknown)
+-  message(WARNING "Failed to determine LPAC_VERSION from Git tags. Using default version \"${LPAC_VERSION}\".")
+-endif()
+-
+-configure_file(${SRC} ${DST} @ONLY)
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -15,15 +15,12 @@ add_executable(lpac ${DIR_LPAC_SRCS})
+ target_link_libraries(lpac euicc-drivers lpac-utils)
+ target_include_directories(lpac PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
+ 
+-find_package(Git)
+-add_custom_target(version
+-    ${CMAKE_COMMAND}
+-    -D SRC=${CMAKE_CURRENT_SOURCE_DIR}/version.h.in
+-    -D DST=${CMAKE_CURRENT_SOURCE_DIR}/version.h
+-    -D GIT_EXECUTABLE=${GIT_EXECUTABLE}
+-    -P ${LPAC_CMAKE_MODULE_PATH}/git-version.cmake
+-)
+-add_dependencies(lpac version)
++include(${CMAKE_SOURCE_DIR}/cmake/git-version.cmake)
++if(NOT DEFINED LPAC_VERSION)
++    set(LPAC_VERSION ${CMAKE_PROJECT_VERSION})
++endif()
++target_compile_definitions(lpac PRIVATE LPAC_VERSION="${LPAC_VERSION}")
++
+ set_target_properties(lpac PROPERTIES
+     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/output"
+     BUILD_RPATH "${RPATH_BINARY_PATH}"
+--- a/src/applet/version.h
++++ b/src/applet/version.h
+@@ -1,7 +1,5 @@
+ #pragma once
+ 
+-#include "version.h"
+-
+ #include <applet.h>
+ 
+ extern struct applet_entry applet_version;
+--- a/src/version.h.in
++++ /dev/null
+@@ -1,4 +0,0 @@
+-#ifndef LPAC_VERSION_H_
+-#define LPAC_VERSION_H_
+-#define LPAC_VERSION "@LPAC_VERSION@"
+-#endif /* LPAC_VERSION_H_ */


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @blocktrron 

**Description:**
Let's add libqmi support to be able to use lpac together with modemmanager for QMI based modems.

Tested with Quectel RM520N-GL.

This also fixes the output of the lpac version.

Before this patch 'lpac version' showed this output:

`{"type":"lpa","payload":{"code":0,"message":"success","data":"v0.0.0-unknown"}}`

After applying the patch we will get the real version:

`{"type":"lpa","payload":{"code":0,"message":"success","data":"2.3.0"}}`

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** BPI-R4

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [x] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
