### PR TITLE
fluent-bit: add init script

### DIFF
--- a/admin/fluent-bit/Makefile
+++ b/admin/fluent-bit/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fluent-bit
 PKG_VERSION:=5.0.8
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/fluent/fluent-bit.git
@@ -59,6 +59,9 @@ define Package/fluent-bit/install
 
 	$(INSTALL_DIR) $(1)/etc/fluent-bit
 	$(INSTALL_CONF) $(PKG_BUILD_DIR)/conf/parsers.conf $(1)/etc/fluent-bit/parsers.conf
+
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/fluent-bit.init $(1)/etc/init.d/fluent-bit
 endef
 
 $(eval $(call BuildPackage,fluent-bit))

--- a/admin/fluent-bit/files/fluent-bit.init
+++ b/admin/fluent-bit/files/fluent-bit.init
@@ -1,0 +1,12 @@
+#!/bin/sh /etc/rc.common
+START=99
+
+USE_PROCD=1
+
+start_service() {
+	procd_open_instance
+	procd_set_param command fluent-bit --supervisor -c /etc/fluent-bit/fluent-bit.yaml
+	procd_set_param file /etc/fluent-bit/fluent-bit.yaml
+	procd_set_param respawn
+	procd_close_instance
+}


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @commodo

**Description:**
This PR adds an init script for fluent-bit so it can run as a system service.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12.5
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** x86_64 device

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.