### PR TITLE
sshtunnel: explicitly set $HOME to `/root` in init script

### DIFF
--- a/net/sshtunnel/files/sshtunnel.init
+++ b/net/sshtunnel/files/sshtunnel.init
@@ -193,6 +193,7 @@ load_server() {
 	"
 
 	procd_open_instance "$server"
+        procd_set_param env HOME="/root"
 	procd_set_param command "$PROG" $ARGS
 	# ProxyCommand must be quoted
 	[ -n "$ProxyCommand" ] && procd_append_param command -o "ProxyCommand=$ProxyCommand"

--- a/net/sshtunnel/files/sshtunnel.init
+++ b/net/sshtunnel/files/sshtunnel.init
@@ -193,7 +193,7 @@ load_server() {
 	"
 
 	procd_open_instance "$server"
-        procd_set_param env HOME="/root"
+	procd_set_param env HOME="/root"
 	procd_set_param command "$PROG" $ARGS
 	# ProxyCommand must be quoted
 	[ -n "$ProxyCommand" ] && procd_append_param command -o "ProxyCommand=$ProxyCommand"


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @nunojpg 

## Description

When dropbear is used as ssh client, it looks for `known_hosts` at `$HOME/.ssh/known_hosts`. If $HOME is not set, `known_hosts` cannot be found and if `StrictHostKeyChecking` is enabled, connection fails. This happened before #5559
I created new issue to track (#30050)

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12.4
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** xiaomi ax3000t

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable