### PR TITLE
nut: improve rpcd acl / luci-app-acl effectiveness

### DIFF
--- a/net/nut/Makefile
+++ b/net/nut/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nut
 PKG_VERSION:=2.8.5
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.networkupstools.org/source/2.8/
@@ -78,6 +78,7 @@ define Package/nut-server/install
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/share/nut/cmdvartab $(1)/usr/share/nut/
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_CONF) ./files/nut_server $(1)/etc/config/nut_server
+	$(INSTALL_CONF) ./files/nut_server_root $(1)/etc/config/nut_server_root
 	ln -sf ../../var/etc/nut/upsd.users  $(1)/etc/nut/upsd.users
 	ln -sf ../../var/etc/nut/upsd.conf $(1)/etc/nut/upsd.conf
 	# Driver common portion
@@ -145,6 +146,7 @@ endef
 
 define Package/nut-server/conffiles
 /etc/config/nut_server
+/etc/config/nut_server_root
 /etc/nut/upsd.conf
 /etc/nut/upsd.users
 /etc/nut/ups.conf
@@ -169,6 +171,7 @@ endef
 
 define Package/nut-upsmon/conffiles
 /etc/config/nut_monitor
+/etc/config/nut_monitor_root
 /etc/nut/upsmon.conf
 endef
 
@@ -185,6 +188,7 @@ define Package/nut-upsmon/install
 	$(INSTALL_DATA) ./files/nut-monitor-migrate.default $(1)/etc/uci-defaults/80-nut-monitor-migrate
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_CONF) ./files/nut_monitor $(1)/etc/config/nut_monitor
+	$(INSTALL_CONF) ./files/nut_monitor_root $(1)/etc/config/nut_monitor_root
 	ln -sf /var/etc/nut/upsmon.conf $(1)/etc/nut/upsmon.conf
 endef
 
@@ -342,6 +346,7 @@ define Package/nut-web-cgi/conffiles
 /etc/nut/upsstats.html
 /etc/nut/upsstats-single.html
 /etc/config/nut_cgi
+/etc/config/nut_cgi_root
 /etc/httpd.conf
 endef
 
@@ -356,6 +361,7 @@ define Package/nut-web-cgi/install
 	$(INSTALL_CONF) $(PKG_INSTALL_DIR)/etc/nut/upsstats-single.html.sample $(1)/etc/nut/upsstats-single.html
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_CONF) ./files/nut_cgi $(1)/etc/config/nut_cgi
+	$(INSTALL_CONF) ./files/nut_cgi_root $(1)/etc/config/nut_cgi_root
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/nut-cgi.init $(1)/etc/init.d/nut-cgi
 	ln -sf /var/etc/nut/hosts.conf $(1)/etc/nut/hosts.conf

--- a/net/nut/Makefile
+++ b/net/nut/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nut
 PKG_VERSION:=2.8.5
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.networkupstools.org/source/2.8/
@@ -80,6 +80,7 @@ define Package/nut-server/install
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/share/nut/cmdvartab $(1)/usr/share/nut/
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_CONF) ./files/nut_server $(1)/etc/config/nut_server
+	$(INSTALL_CONF) ./files/nut_server_root $(1)/etc/config/nut_server_root
 	ln -sf ../../var/etc/nut/upsd.users  $(1)/etc/nut/upsd.users
 	ln -sf ../../var/etc/nut/upsd.conf $(1)/etc/nut/upsd.conf
 	# Driver common portion
@@ -100,6 +101,7 @@ define Package/nut-server/install
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/30-libhid-ups $(1)/etc/hotplug.d/usb/30-libhid-ups
 	$(INSTALL_DIR) $(1)/etc/uci-defaults
 	$(INSTALL_DATA) ./files/nut-server.default $(1)/etc/uci-defaults/90_nut-server
+	$(INSTALL_DATA) ./files/nut-server-migrate-root.default $(1)/etc/uci-defaults/81-nut-server-migrate-root
 endef
 
 define Package/nut-common
@@ -160,6 +162,7 @@ endef
 
 define Package/nut-server/conffiles
 /etc/config/nut_server
+/etc/config/nut_server_root
 /etc/nut/upsd.conf
 /etc/nut/upsd.users
 /etc/nut/ups.conf
@@ -185,6 +188,7 @@ endef
 
 define Package/nut-upsmon/conffiles
 /etc/config/nut_monitor
+/etc/config/nut_monitor_root
 /etc/nut/upsmon.conf
 endef
 
@@ -199,8 +203,10 @@ define Package/nut-upsmon/install
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/upsmon $(1)/usr/sbin/
 	$(INSTALL_BIN) ./files/nutshutdown $(1)/usr/sbin/nutshutdown
 	$(INSTALL_DATA) ./files/nut-monitor-migrate.default $(1)/etc/uci-defaults/80-nut-monitor-migrate
+	$(INSTALL_DATA) ./files/nut-monitor-migrate-root.default $(1)/etc/uci-defaults/81-nut-monitor-migrate-root
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_CONF) ./files/nut_monitor $(1)/etc/config/nut_monitor
+	$(INSTALL_CONF) ./files/nut_monitor_root $(1)/etc/config/nut_monitor_root
 	ln -sf /var/etc/nut/upsmon.conf $(1)/etc/nut/upsmon.conf
 	$(INSTALL_DATA) ./files/nut-upsmon.default $(1)/etc/uci-defaults/90_nut-upsmon
 endef
@@ -359,6 +365,7 @@ define Package/nut-web-cgi/conffiles
 /etc/nut/upsstats.html
 /etc/nut/upsstats-single.html
 /etc/config/nut_cgi
+/etc/config/nut_cgi_root
 /etc/httpd.conf
 endef
 
@@ -373,10 +380,12 @@ define Package/nut-web-cgi/install
 	$(INSTALL_CONF) $(PKG_INSTALL_DIR)/etc/nut/upsstats-single.html.sample $(1)/etc/nut/upsstats-single.html
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_CONF) ./files/nut_cgi $(1)/etc/config/nut_cgi
+	$(INSTALL_CONF) ./files/nut_cgi_root $(1)/etc/config/nut_cgi_root
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/nut-cgi.init $(1)/etc/init.d/nut-cgi
 	ln -sf /var/etc/nut/hosts.conf $(1)/etc/nut/hosts.conf
 	ln -sf /var/etc/nut/upsset.conf $(1)/etc/nut/upsset.conf
+	$(INSTALL_DATA) ./files/nut-cgi-migrate-root.default $(1)/etc/uci-defaults/81-nut-cgi-migrate-root
 endef
 
 define Package/nut-avahi-service

--- a/net/nut/files/libhid-ups.hotplug
+++ b/net/nut/files/libhid-ups.hotplug
@@ -110,11 +110,12 @@ start_stop_driver() {
 nut_driver_config() {
 	local ups="$1"
 	local try_match="$2"
-	local cfg_vendorid cfg_productid
+	local cfg_vendorid cfg_productid val
 
 	# Configuration might not have a vendorid. This is allowed, and in that case
 	# we keep going as we will restart this UPS with no match.
-	config_get cfg_vendorid "$ups" vendorid
+	config_get_single "$ups" vendorid
+	cfg_vendorid="$val"
 	if [ -n "$cfg_vendorid" ] && ! check_valid_hex_number "${cfg_vendorid/0x/}"; then
 		log_error "Configured vendorid for '$ups' is not valid" "libhid-ups" nut-usb-hotplug
 		nd_driver_config_error=true
@@ -136,7 +137,9 @@ nut_driver_config() {
 
 	# Configuration might not have a productid. This is allowed, and in that case
 	# we keep going as we will restart this UPS with no match.
-	config_get cfg_productid "$ups" productid
+	config_get_single "$ups" productid
+	cfg_productid="$val"
+
 	if [ -n "$cfg_productid" ] && ! check_valid_hex_number "${cfg_productid/0x/}"; then
 		log_error "Configured productid for '$ups' is not valid" "libhid-ups" nut-usb-hotplug
 		nd_driver_config_error=true

--- a/net/nut/files/libhid-ups.hotplug
+++ b/net/nut/files/libhid-ups.hotplug
@@ -93,6 +93,7 @@ start_stop_driver() {
 			log_error "Failed to stop nut-driver instance (UPS) '$ups'." "libhid-ups" nut-usb-hotplug
 			return 0
 		}
+		return 0
 		;;
 	*)
 		# Ignore all other hotplug ACTION types
@@ -110,11 +111,12 @@ start_stop_driver() {
 nut_driver_config() {
 	local ups="$1"
 	local try_match="$2"
-	local cfg_vendorid cfg_productid
+	local cfg_vendorid cfg_productid val
 
 	# Configuration might not have a vendorid. This is allowed, and in that case
 	# we keep going as we will restart this UPS with no match.
-	config_get cfg_vendorid "$ups" vendorid
+	config_get_single "$ups" vendorid
+	cfg_vendorid="$val"
 	if [ -n "$cfg_vendorid" ] && ! check_valid_hex_number "${cfg_vendorid/0x/}"; then
 		log_error "Configured vendorid for '$ups' is not valid" "libhid-ups" nut-usb-hotplug
 		nd_driver_config_error=true
@@ -136,7 +138,9 @@ nut_driver_config() {
 
 	# Configuration might not have a productid. This is allowed, and in that case
 	# we keep going as we will restart this UPS with no match.
-	config_get cfg_productid "$ups" productid
+	config_get_single "$ups" productid
+	cfg_productid="$val"
+
 	if [ -n "$cfg_productid" ] && ! check_valid_hex_number "${cfg_productid/0x/}"; then
 		log_error "Configured productid for '$ups' is not valid" "libhid-ups" nut-usb-hotplug
 		nd_driver_config_error=true
@@ -225,19 +229,28 @@ perform_libhid_action() {
 	# Variable to indicate NUT driver instance (UPS) section found
 	local nd_found=false
 	local nd_driver_config_error=false
+	local pvendid pprodid ret
+
 	local pvendid pprodid
 
 	# Only find statepath and runas once per event
 	# defines STATEPATH
-	find_statepath "upsd" "nut_server" || {
+	STATEPATH="$(find_statepath "upsd_root" "nut_server_root")"
+	ret=$?
+
+	if [ "$ret" -ne 0 ] || [ -z "$STATEPATH" ]; then
+
 		log_error "Failed to set STATEPATH" "libhid-ups" nut-usb-hotplug
 		return 1
-	}
+	fi
 	# sets RUNAS
-	find_runas "upsd" "nut_server" || {
+	RUNAS="$(find_runas "upsd_root" "nut_server_root")"
+	ret=$?
+
+	if [ "$ret" -ne 0 ] || [ -z "$RUNAS" ]; then
 		log_error "Failed to set RUNAS" "libhid-ups" nut-usb-hotplug
 		return 1
-	}
+	fi
 
 	# PRODUCT comes from the calling hotplug event, and
 	# is of the form vendorid/productid/other
@@ -309,15 +322,15 @@ perform_libhid_action() {
 # This is an incomplete script which gets filled by libhid-ups.parsed-usermap.
 # This confuses shellcheck and reviewers, hence the disables below.
 # shellcheck disable=SC1073,SC1072
-case "$PRODUCT" in
-### insert libhid-ups.parsed-usermap content here ###
 # The result is cases of the form
-# "vendorid/productid/other" ) | \
+# "vendorid/productid/other" | \
 # to be matched against the PRODUCT from the calling hotplug event
-# and does NOT use ';;' (so falls through to code below).
 # The empty string matches when PRODUCT is empty, but does not match
 # when PRODUCT is neither empty nor one of the case targets, above
 
+# shellcheck disable=SC1073,SC1072
+case "$PRODUCT" in
+### insert libhid-ups.parsed-usermap content here ###
 "")
 	# Skip hotplug actions if NUT hotplug is disabled
 	# Uses NUT_DISABLE_HOTPLUG_PATH,  defined in nut-service.sh and sourced

--- a/net/nut/files/libhid-ups.hotplug
+++ b/net/nut/files/libhid-ups.hotplug
@@ -175,6 +175,8 @@ nut_driver_config() {
 			# We check enabled again here, in case of a race condition since
 			# our last check.
 			if /etc/init.d/nut-server enabled; then
+				# Reduce bouncing with multiple hotplug events in quick succession
+				sleep 1
 				# If we don't have a specific match, attempt a reload rather
 				# than restart of '$ups'. The nut-server initscript will do a
 				# start if the reload fails.
@@ -208,7 +210,8 @@ nut_driver_config() {
 			return 0
 		fi
 		if [ "$(printf "%04x" 0x"$pvendid")" = "$cfg_vendorid" ] &&
-			[ "$(printf "%04x" 0x"$pprodid")" = "$cfg_productid" ]; then
+			[ "$(printf "%04x" 0x"$pprodid")" = "$cfg_productid" ] &&
+			[ -n "$DEVNAME" ] && [ -n "$ups" ]; then
 			# Round 1: If we have a match for hotplug event and the UCI config
 			# start this UPS and record that fact, otherwise skip this UCI UPS
 			# for this round
@@ -254,6 +257,9 @@ perform_libhid_action() {
 		log_error "Failed to set RUNAS" "libhid-ups" nut-usb-hotplug
 		return 1
 	fi
+
+	# Reduce bouncing with multiple hotplug events in quick succession
+	sleep 2
 
 	# PRODUCT comes from the calling hotplug event, and
 	# is of the form vendorid/productid/other

--- a/net/nut/files/libhid-ups.hotplug
+++ b/net/nut/files/libhid-ups.hotplug
@@ -161,6 +161,8 @@ nut_driver_config() {
 
 	# ACTION and DEVNAME come from the calling hotplug event
 
+	[ -n "$DEVNAME" ] || return 0
+
 	# If we could not match a device in the previous round, or the configuration
 	# for the UPS does not have a vendorid and productid, start this UPS
 	# without checking for a match
@@ -212,7 +214,7 @@ nut_driver_config() {
 			# for this round
 			# Initscript should have its own logging
 			if ! start_stop_driver "$ups" "/dev/$DEVNAME"; then
-				log_error "Error starting matched driver instance (UPS) in nut_driver_config" libhid-ups nut-usb-hotplug
+				log_error "Error starting/stopping matched driver instance (UPS) in nut_driver_config" libhid-ups nut-usb-hotplug
 				nd_driver_config_error=true
 				return 0
 			fi
@@ -231,7 +233,8 @@ perform_libhid_action() {
 	local nd_driver_config_error=false
 	local pvendid pprodid ret
 
-	local pvendid pprodid
+	[ -n "$DEVNAME" ] || return 0
+	[ -n "$ACTION" ] || return 0
 
 	# Only find statepath and runas once per event
 	# defines STATEPATH
@@ -281,6 +284,7 @@ perform_libhid_action() {
 	config_foreach nut_driver_config driver yes
 
 	[ "$nd_driver_config_error" = "false" ] || return 1
+	[ "$ACTION" = "add" ] || return 0
 	# Only if we cannot find a matching UPS (driver instance) configuration
 	# do we try again, this time restarting all UPS (driver) instances
 	# This is for the event the device matching configuration for NUT does

--- a/net/nut/files/nut-cgi-migrate-root.default
+++ b/net/nut/files/nut-cgi-migrate-root.default
@@ -1,0 +1,112 @@
+#!/bin/sh
+# Script is sourced not executed, but shebang helps tools recognize this as
+# a shell script.
+
+# In recent (relevant) versions of shellcheck busybox is a valid shell type
+# shellcheck shell=busybox
+
+# uci-defaults script to migrate old uci config into new separate regular and
+# admin configs. Applied during install or on first boot after install, if
+# setting on install fails
+
+# IPKG_INSTROOT is intentionally only set when building an image and
+# is intentionally empty on a live OpenWrt device
+
+# Only run this uci-defaults script on a live OpenWrt device
+[ -z "${IPKG_INSTROOT}" ] || exit 0
+
+# Loads needed OpenWrt functions
+# shellcheck source=net/nut/files/functions.sh.functions
+. /lib/functions.sh || {
+	# As the uci-defaults environment in which this runs does not have logging
+	# available, nor is stderr captured or displayed on the console, these messages
+	# exist only to assist when debugging manual runs of the script.
+	printf "'%s': ERROR: '%s'\n" nut-cgi-migrate "Unable to source 'functions.sh' in 'nut-cgi-migrate' uci-default script. Bailing"
+	exit 1
+}
+
+# As the uci-defaults environment in which this runs does not have logging
+# available, nor is stderr captured or displayed on the console, these messages
+# exist only to assist when debugging manual runs of the script.
+# shellcheck disable=SC2329,SC2317
+log_migration_error() {
+	local reason="$1"
+
+	printf "'%s': ERROR: '%s'\n" "nut-cgi-migrate" "$reason" >&2
+}
+
+# If there is more than one upsset section, the only the last is used, so only
+# migrate the last section found (and remove the rest).
+
+# We use a subshell so nut_cgi and nut_cgi_root do not become mixed together in
+# the environment
+upsset_enable="$(
+	upsset_enable_val=""
+
+	# shellcheck disable=SC2329
+	upsset_get_enable_val() {
+		local cfg="$1"
+		local enable
+
+		config_get_bool enable "$cfg" enable 0
+
+		if [ -n "$enable" ]; then
+			# config_foreach uses eval and for loops so upsset_enable_value will
+			# keep the last value set once config_foreach is done
+			upsset_enable_val="$enable"
+		fi
+
+		uci_remove nut_cgi "$cfg" || {
+			log_migration_error "Failed to remove upsset section '$cfg' from nut_cgi"
+		}
+		return 0
+	}
+
+	if ! config_load nut_cgi; then
+		log_migration_error "Missing nut_config_root"
+		exit 1
+	fi
+
+	config_foreach upsset_get_enable_val upsset
+
+	echo "$upsset_enable_val"
+)"
+ret=$?
+
+[ $ret -eq 0 ] || exit 1
+
+uci_load nut_cgi_root || {
+	log_migration_error "Failed to load 'nut_cgi_root'"
+	exit 1
+}
+
+last_upsset_section=""
+
+# shellcheck disable=SC2329
+upsset_get_last_section() {
+	local cfg="$1"
+	last_upsset_section="$cfg"
+}
+
+config_foreach upsset_get_last_section upsset
+
+if [ -z "$last_upsset_section" ]; then
+	uci_add nut_cgi_root upsset upsset
+	if [ -z "$CONFIG_SECTION" ]; then
+		log_migration_error "Failed to add upsset section to 'nut_cgi_root'"
+		exit 1
+	else
+		last_upsset_section="$CONFIG_SECTION"
+	fi
+fi
+
+uci_set nut_cgi_root "$last_upsset_section" enable "$upsset_enable" || {
+	log_migration_error "Failed to set nut_cgi_root.$last_upsset_section.enable"
+	exit 1
+}
+
+if ! uci_commit nut_cgi && uci_commit nut_cgi_root; then
+	log_migration_error "Failed to commit changes"
+fi
+
+exit 0

--- a/net/nut/files/nut-cgi.init
+++ b/net/nut/files/nut-cgi.init
@@ -202,12 +202,16 @@ validate_host() {
 # Must be called from service_reload
 nut_upscgi_add_host() {
 	local ups="$1"
-	local upsname hostname port system displayname
+	local upsname hostname port system displayname val
 
-	config_get upsname "$ups" upsname "$ups"
-	config_get hostname "$ups" hostname localhost
-	config_get port "$ups" port
-	config_get displayname "$ups" displayname "$ups"
+	config_get_single "$ups" upsname "$ups"
+	upsname="$val"
+	config_get_single "$ups" hostname localhost
+	hostname="$val"
+	config_get_single "$ups" port
+	port="$val"
+	config_get_single "$ups" displayname "$ups"
+	displayname="$val"
 
 	# We do not error exit as that would abort processing of other hosts
 	validate_host "$ups" "$upsname" "$hostname" "$port" "$displayname" || return
@@ -239,11 +243,6 @@ service_reload() {
 	local upscgi_hosts_exists="false"
 	local upscgi_upsset_failed="false"
 
-	config_load nut_cgi || {
-		log_config_load_error "nut_cgi" "nut-cgi" "nut-cgi"
-		exit 1
-	}
-
 	# NUT configuration does not exist if NUT CGI cannot be configured, so
 	# stop service and bailout.
 	ensure_conf_dir_exists || {
@@ -260,35 +259,55 @@ service_reload() {
 	}
 	restore_umask
 
-	# We do not exit on error here as we do not want to block monitoring hosts
-	# with the needed configuration as a result of those that do not
-	config_foreach nut_upscgi_add_host host
+	# Execute in a subshell to avoid config_load nut_cgi
+	# and config_load nut_cgi_root becoming mixed together
+	(
+		config_load nut_cgi || {
+			log_config_load_error "nut_cgi" "nut-cgi" "nut-cgi"
+			exit 1
+		}
 
-	# If new host configuration was successfully created
-	if [ "$upscgi_hosts_exists" = "true" ] && [ -s "${UPSCGI_HOSTS_CONF}.new" ]; then
-		# Move the new configuration file to active use,
-		# removing the old configuration in the process
-		mv -f "${UPSCGI_HOSTS_CONF}.new" "${UPSCGI_HOSTS_CONF}"
-	elif [ "$upscgi_hosts_exists" = "true" ]; then
-		rm -f "${UPSCGI_HOSTS_CONF}.new"
-	else
-		# If no hosts are configured, use an empty hosts.conf (no configuration)
-		rm -f "${UPSCGI_HOSTS_CONF}"
-		rm -f "${UPSCGI_HOSTS_CONF}.new"
-		if ! touch "${UPSCGI_HOSTS_CONF}"; then
-			log_error "Failed to create empty hosts.conf" nut-cgi nut-cgi
-			return 1
+		# We do not exit on error here as we do not want to block monitoring hosts
+		# with the needed configuration as a result of those that do not
+		config_foreach nut_upscgi_add_host host
+
+		# If new host configuration was successfully created
+		if [ "$upscgi_hosts_exists" = "true" ] && [ -s "${UPSCGI_HOSTS_CONF}.new" ]; then
+			# Move the new configuration file to active use,
+			# removing the old configuration in the process
+			mv -f "${UPSCGI_HOSTS_CONF}.new" "${UPSCGI_HOSTS_CONF}"
+		elif [ "$upscgi_hosts_exists" = "true" ]; then
+			rm -f "${UPSCGI_HOSTS_CONF}.new"
+		else
+			# If no hosts are configured, use an empty hosts.conf (no configuration)
+			rm -f "${UPSCGI_HOSTS_CONF}"
+			rm -f "${UPSCGI_HOSTS_CONF}.new"
+			if ! touch "${UPSCGI_HOSTS_CONF}"; then
+				log_error "Failed to create empty hosts.conf" nut-cgi nut-cgi
+				exit 1
+			fi
+			# Empty hosts is not necessarily an error, but we log for information
+			logger -s -t nut-cgi "No configured hosts"
 		fi
-		# Empty hosts is not necessarily an error, but we log for information
-		log_msg "No configured hosts" nut-cgi nut-cgi info
-	fi
+	) || return 1
 
-	# NUT CGI host file configuration is independent of upsset configuration
-	config_foreach configure_nut_upscgi_upsset upsset
-	if [ "$upscgi_upsset_failed" = "true" ]; then
-		disable_upsset
-		return 1
-	fi
+	# Execute in a subshell to avoid config_load nut_cgi
+	# and config_load nut_cgi_root becoming mixed together
+	# not strictly necessary as config_load nut_cgi is already in a subshell
+	# but this is defensive
+	(
+		config_load nut_cgi_root || {
+			log_config_load_error "nut_cgi_root" "nut-cgi" "nut-cgi"
+			exit 1
+		}
+
+		# NUT CGI host file configuration is independent of upsset configuration
+		config_foreach configure_nut_upscgi_upsset upsset
+		if [ "$upscgi_upsset_failed" = "true" ]; then
+			disable_upsset
+			exit 1
+		fi
+	) || return 1
 	return 0
 }
 
@@ -320,5 +339,6 @@ stop_service() {
 service_triggers() {
 	# Add a reload trigger on changes to the nut_cgi UCI config
 	procd_add_reload_trigger "nut_cgi" || return 1
+	procd_add_reload_trigger "nut_cgi_root" || return 1
 	return 0
 }

--- a/net/nut/files/nut-common.sh.functions
+++ b/net/nut/files/nut-common.sh.functions
@@ -268,3 +268,47 @@ have_section_named() {
 		return $ret
 	fi
 }
+
+config_get_single() {
+	local section="$1"
+	local var="$2"
+	local def="$3"
+	local flag="$4"
+
+	# Used to pass value back to caller
+	unset val
+
+	if [ -z "$flag" ] || [ "$flag" = "0" ]; then
+		config_get val "$section" "$var" "$def"
+		# keep only printable ASCII characters (space through ~)
+		# borrowed from ser2net in this (packages) repo
+		val="$(LC_ALL=C printf '%s' "$val" | tr -cd ' -~')"
+	else
+		config_get_bool val "$section" "$var" "$def"
+	fi
+}
+
+config_get_single_unsafe() {
+	local section="$1"
+	local var="$2"
+	local def="$3"
+	local flag="$4"
+
+	# Used to pass value back to caller
+	unset val
+
+	if [ -z "$flag" ] || [ "$flag" = "0" ]; then
+		config_get val "$section" "$var" "$def"
+		case "$val" in
+		# Disallow newline. Prevents extra configuration injection.
+		*"
+"*)
+			log_error "section '$section' had an option '$var' with a disallowed newline" nut-common.sh nut-common
+			return 1
+			;;
+		esac
+	else
+		config_get_bool val "$section" "$var" "$def"
+	fi
+	return 0
+}

--- a/net/nut/files/nut-monitor-config.sh.functions
+++ b/net/nut/files/nut-monitor-config.sh.functions
@@ -23,12 +23,12 @@ append NUT_EVENT_TYPES "OTHER NOTOTHER SUSPEND_STARTING SUSPEND_FINISHED"
 
 # Upstream NUT upsmon.conf option names (in the order listed in
 # https://networkupstools.org/docs/man/upsmon.conf.html)
-# except MONITOR, NOTIFYMSG, NOTIFYFLAG, and RUN_AS_USER which are handled
-# separately
+# except MONITOR, NOTIFYCMD, NOTIFYMSG, NOTIFYFLAG, RUN_AS_USER, and SHUTDOWNCMD
+# which are handled separately
 NUT_UPSMON_OPTIONS="DEADTIME FINALDELAY HOSTSYNC MINSUPPLIES NOCOMMWARNTIME"
-append NUT_UPSMON_OPTIONS "POLLFAIL_LOG_THROTTLE_MAX NOTIFYCMD POLLFREQ"
+append NUT_UPSMON_OPTIONS "POLLFAIL_LOG_THROTTLE_MAX POLLFREQ"
 append NUT_UPSMON_OPTIONS "POLLFREQALERT POWERDOWNFLAG OFFDURATION OVERDURATION"
-append NUT_UPSMON_OPTIONS "OBLBDURATION RBWARNTIME SHUTDOWNCMD SHUTDOWNEXIT"
+append NUT_UPSMON_OPTIONS "OBLBDURATION RBWARNTIME SHUTDOWNEXIT"
 append NUT_UPSMON_OPTIONS "CERTPATH CERTFILE CERTIDENT CERTHOST DEBUG_MIN"
 
 NUT_UPSMON_BOOL_OPTIONS="ALARMCRITICAL CERTVERIFY FORCESSL"
@@ -59,14 +59,14 @@ nut_get_notifications() {
 	# is a valid NUT event type, so use it.
 	event_types=" $NUT_EVENT_TYPES "
 	if [ "${event_types#*" $event "}" != "${event_types}" ]; then
-		config_get val "$event" message
+		config_get_single "$event" message
 		if [ -n "$val" ]; then
 			if ! printf 'NOTIFYMSG %s %s\n' "$event" "$val" >>"$config_file"; then
 				log_error "upsmon section '$event' failed to write 'NOTIFYMSG' for '$event'" nut-monitor-config.sh nut-monitor-config
 				return 1
 			fi
 		fi
-		config_get val "$event" flag "$defaultnotify"
+		config_get_single "$event" flag "$defaultnotify"
 		if [ -n "$val" ]; then
 			if ! printf 'NOTIFYFLAG %s %s\n' "$event" "$val" >>"$config_file"; then
 				log_error "upsmon section '$event' failed to write 'NOTIFYFLAG' for '$event'" nut-monitor-config.sh nut-monitor-config
@@ -93,7 +93,7 @@ upsmon_conf_get_write() {
 		# Will always get a value - either 0 or 1
 		config_get_bool val "$cfg" "$uci_option" "$default"
 	else
-		config_get val "$cfg" "$uci_option" "$default"
+		config_get_single "$cfg" "$uci_option" "$default"
 	fi
 
 	if [ -n "$val" ]; then
@@ -119,115 +119,139 @@ nut_upsmon_conf() {
 	# Note that we use '-u $RUNAS' on the daemon command line in preference to
 	# the RUN_AS_USER configuration in "$config_file"
 
-	# Word-splitting is intentional here, and we know NUT_UPSMON_OPTIONS and
-	# NUT_UPSMON_BOOL_OPTIONS are safe because we define them.
-	set -f
-	for nut_option in $NUT_UPSMON_OPTIONS $NUT_UPSMON_BOOL_OPTIONS; do
-		nut_bool="false"
-		# The nut_option and corresponding uci_option are known to be
-		# pure 7-bit ASCII
-		# We use tr because ash does not support *global* replacement using
-		# parameter expansion
-		# shellcheck disable=SC2019,SC2018
-		uci_option="$(echo "$nut_option" | tr 'A-Z_' 'a-z')"
-		case "$nut_option" in
-		# integer: negative values allowed
-		POLLFAIL_LOG_THROTTLE_MAX | \
-		OFFDURATION | \
-		OVERDURATION | \
-		OBLBDURATION)
-			config_get val "$cfg" "$uci_option"
-			if ! check_signed_int "$val"; then
-				log_error "upsmon section '$cfg' bad value for '$uci_option'" nut-monitor-config.sh nut-monitor-config
-				return 1
-			elif [ -n "$val" ]; then # Ignore options with no configuration
-				if ! printf "%s %s\n" "$nut_option" "$val" >>"$config_file"; then
-					log_error "upsmon section '$cfg' failed to write '$nut_option'" nut-monitor-config.sh nut-monitor-config
-					return 1
+	# Execute in a subshell to avoid config_load nut_monitor
+	# and config_load nut_monitor_root becoming mixed together
+	(
+		config_load nut_monitor || {
+			log_config_load_error "nut_monitor" "nut-monitor" "nut-monitor"
+			exit 1
+		}
+
+		# Word-splitting is intentional here, and we know NUT_UPSMON_OPTIONS and
+		# NUT_UPSMON_BOOL_OPTIONS are safe because we define them.
+		set -f
+		for nut_option in $NUT_UPSMON_OPTIONS $NUT_UPSMON_BOOL_OPTIONS; do
+			nut_bool="false"
+			# The nut_option and corresponding uci_option are known to be
+			# pure 7-bit ASCII
+			# We use tr because ash does not support *global* replacement using
+			# parameter expansion
+			# shellcheck disable=SC2019,SC2018
+			uci_option="$(echo "$nut_option" | tr 'A-Z_' 'a-z')"
+			case "$nut_option" in
+			# integer: negative values allowed
+			POLLFAIL_LOG_THROTTLE_MAX | \
+			OFFDURATION | \
+			OVERDURATION | \
+			OBLBDURATION)
+				config_get_single "$cfg" "$uci_option"
+				if ! check_signed_int "$val"; then
+					log_error "upsmon section '$cfg' bad value for '$uci_option'" nut-monitor-config.sh nut-monitor-config
+					exit 1
+				elif [ -n "$val" ]; then # Ignore options with no configuration
+					if ! printf "%s %s\n" "$nut_option" "$val" >>"$config_file"; then
+						log_error "upsmon section '$cfg' failed to write '$nut_option'" nut-monitor-config.sh nut-monitor-config
+						exit 1
+					fi
 				fi
-			fi
-			;;
-		# integer: negative values not allowed
-		DEADTIME | \
-		DEBUG_MIN | \
-		FINALDELAY | \
-		HOSTSYNC | \
-		MINSUPPLIES | \
-		NOCOMMWARNTIME | \
-		POLLFREQ | \
-		POLLFREQALERT | \
-		RBWARNTIME)
-			config_get val "$cfg" "$uci_option"
-			if ! check_unsigned_int "$val"; then
-				log_error "upsmon section '$cfg' bad value for '$uci_option'" nut-monitor-config.sh nut-monitor-config
-				return 1
-			elif [ -n "$val" ]; then # Ignore options with no configuration
-				if ! printf "%s %s\n" "$nut_option" "$val" >>"$config_file"; then
-					log_error "upsmon section '$cfg' failed to write '$nut_option'" nut-monitor-config.sh nut-monitor-config
-					return 1
-				fi
-			fi
-			;;
-		SHUTDOWNCMD)
-			upsmon_conf_get_write "$cfg" "$config_file" "$uci_option" "$nut_option"
-			conf_ret=$?
-			case "$conf_ret" in
-			1)
-				return 1
 				;;
-			2)
-				if ! printf "%s %s\n" "$nut_option" "/usr/sbin/nutshutdown" >>"$config_file"; then
-					log_error "upsmon section '$cfg' failed to write 'SHUTDOWNCMD'" nut-monitor-config.sh nut-monitor-config
-					return 1
+			# integer: negative values not allowed
+			DEADTIME | \
+			DEBUG_MIN | \
+			FINALDELAY | \
+			HOSTSYNC | \
+			MINSUPPLIES | \
+			NOCOMMWARNTIME | \
+			POLLFREQ | \
+			POLLFREQALERT | \
+			RBWARNTIME)
+				config_get_single "$cfg" "$uci_option"
+				if ! check_unsigned_int "$val"; then
+					log_error "upsmon section '$cfg' bad value for '$uci_option'" nut-monitor-config.sh nut-monitor-config
+					exit 1
+				elif [ -n "$val" ]; then # Ignore options with no configuration
+					if ! printf "%s %s\n" "$nut_option" "$val" >>"$config_file"; then
+						log_error "upsmon section '$cfg' failed to write '$nut_option'" nut-monitor-config.sh nut-monitor-config
+						exit 1
+					fi
+				fi
+				;;
+			ALARMCRITICAL)
+				upsmon_conf_get_write "$cfg" "$config_file" "$uci_option" "$nut_option" "true" "1"
+				conf_ret=$?
+				if [ "$conf_ret" -eq 1 ]; then
+					exit 1
+				fi
+				;;
+			POWERDOWNFLAG)
+				upsmon_conf_get_write "$cfg" "$config_file" "$uci_option" "$nut_option" "false" "$NUT_KILLPOWER"
+				conf_ret=$?
+				if [ "$conf_ret" -eq 1 ]; then
+					exit 1
+				fi
+				;;
+			*)
+				if [ "${upsmon_bool_options/$nut_option/}" != "${upsmon_bool_options}" ]; then
+					nut_bool="true"
+				fi
+				upsmon_conf_get_write "$cfg" "$config_file" "$uci_option" "$nut_option" "$nut_bool"
+				conf_ret=$?
+				if [ "$conf_ret" -eq 1 ]; then
+					exit 1
 				fi
 				;;
 			esac
+		done
+		set +f
+	) || return 1
+
+	# Execute in a subshell to avoid config_load nut_monitor
+	# and config_load nut_monitor_root becoming mixed together
+	(
+		config_load nut_monitor_root || {
+			log_config_load_error "nut_monitor_root" "nut-monitor" "nut-monitor"
+			exit 1
+		}
+
+		upsmon_conf_get_write "upsmon_root" "$config_file" "shutdowncmd" "SHUTDOWNCMD"
+		conf_ret=$?
+
+		case "$conf_ret" in
+		1)
+			exit 1
 			;;
-		ALARMCRITICAL)
-			upsmon_conf_get_write "$cfg" "$config_file" "$uci_option" "$nut_option" "true" "1"
-			conf_ret=$?
-			if [ "$conf_ret" -eq 1 ]; then
-				return 1
-			fi
-			;;
-		POWERDOWNFLAG)
-			upsmon_conf_get_write "$cfg" "$config_file" "$uci_option" "$nut_option" "false" "$NUT_KILLPOWER"
-			conf_ret=$?
-			if [ "$conf_ret" -eq 1 ]; then
-				return 1
-			fi
-			;;
-		*)
-			if [ "${upsmon_bool_options/$nut_option/}" != "${upsmon_bool_options}" ]; then
-				nut_bool="true"
-			fi
-			upsmon_conf_get_write "$cfg" "$config_file" "$uci_option" "$nut_option" "$nut_bool"
-			conf_ret=$?
-			if [ "$conf_ret" -eq 1 ]; then
-				return 1
+		2)
+			if ! printf "%s %s\n" "SHUTDOWNCMD" "/usr/sbin/nutshutdown" >>"$config_file"; then
+				log_error "upsmon section 'upsmon_root' failed to write 'SHUTDOWNCMD'" nut-monitor-config.sh nut-monitor-config
+				exit 1
 			fi
 			;;
 		esac
-	done
-	set +f
 
-	event_notify_flags_not_found="$NUT_EVENT_TYPES"
-	config_get val "$cfg" defaultnotify "SYSLOG"
-	defaultnotify="$val"
-	config_foreach nut_get_notifications notifications "$val" "$config_file"
-
-	# Otherwise the default is WALL+SYSLOG
-	event_notify_flags_not_found="$(printf "%s" "$event_notify_flags_not_found" | tr -s ' ')"
-	# We intentionally word-split on event_notify_flags-not-found to iterate
-	# over event types.
-	set -f
-	for event in $event_notify_flags_not_found; do
-		if ! printf "NOTIFYFLAG %s %s\n" "$event" "$defaultnotify" >>"$config_file"; then
-			log_error "upsmon section '$cfg' failed to write 'NOTIFYFLAG' for '$event'" nut-monitor-config.sh nut-monitor-config
-			return 1
+		upsmon_conf_get_write "upsmon_root" "$config_file" "notifycmd" "NOTIFYCMD"
+		conf_ret=$?
+		if [ "$conf_ret" -eq 1 ]; then
+			exit 1
 		fi
-	done
-	set +f
+
+		event_notify_flags_not_found="$NUT_EVENT_TYPES"
+		config_get_single "upsmon_root" defaultnotify "SYSLOG"
+		defaultnotify="$val"
+		config_foreach nut_get_notifications notifications "$val" "$config_file"
+
+		# Otherwise the default is WALL+SYSLOG
+		event_notify_flags_not_found="$(printf "%s" "$event_notify_flags_not_found" | tr -s ' ')"
+		# We intentionally word-split on event_notify_flags-not-found to iterate
+		# over event types.
+		set -f
+		for event in $event_notify_flags_not_found; do
+			if ! printf "NOTIFYFLAG %s %s\n" "$event" "$defaultnotify" >>"$config_file"; then
+				log_error "upsmon section '$cfg' failed to write 'NOTIFYFLAG' for '$event'" nut-monitor-config.sh nut-monitor-config
+				exit 1
+			fi
+		done
+		set +f
+	) || return 1
 	return 0
 }
 
@@ -242,38 +266,46 @@ nut_upsmon_add() {
 	local password
 	local system
 	local type
+	local val
 
-	config_get upsname "$cfg" upsname "$cfg"
+	config_get_single "$cfg" upsname "$cfg"
+	upsname="$val"
 	if ! check_safe_uci_name "$upsname"; then
 		log_error "upsmon section '$cfg' has invalid upsname" nut-monitor-config.sh nut-monitor-config
 		upsmon_conf_fail="true"
 		# we do not error exit so as not abort processing of other sections on the config_foreach
 		return 0
 	fi
-	config_get hostname "$cfg" hostname localhost
+	config_get_single "$cfg" hostname localhost
+	hostname="$val"
 	if ! check_safe_hostname_or_ip "$hostname"; then
 		log_error "upsmon section '$cfg' has invalid hostname" nut-monitor-config.sh nut-monitor-config
 		upsmon_conf_fail="true"
 		# we do not error exit so as not abort processing of other sections on the config_foreach
 		return 0
 	fi
-	config_get port "$cfg" port
+	config_get_single "$cfg" port
+	port="$val"
 	if ! check_port "$port"; then
 		log_error "upsmon section '$cfg' has invalid port" nut-monitor-config.sh nut-monitor-config
 		upsmon_conf_fail="true"
 		# we do not error exit so as not abort processing of other sections on the config_foreach
 		return 0
 	fi
-	config_get powervalue "$cfg" powervalue 1
-	if ! check_unsigned_int "$powervalue" || [ -z "$powervalue" ]; then
+	config_get_single "$cfg" powervalue 1
+	powervalue="$val"
+	if ! check_unsigned_int "$powervalue"; then
 		log_error "upsmon section '$cfg' has invalid powervalue" nut-monitor-config.sh nut-monitor-config
 		upsmon_conf_fail="true"
 		# we do not error exit so as not abort processing of other sections on the config_foreach
 		return 0
 	fi
-	config_get username "$cfg" username
-	config_get password "$cfg" password
-	config_get type "$cfg" type secondary
+	config_get_single "$cfg" username
+	username="$val"
+	config_get_single "$cfg" password
+	password="$val"
+	config_get_single "$cfg" type secondary
+	type="$val"
 	case "$type" in
 	primary | secondary)
 		# primary or secondary are the only allowed values
@@ -332,16 +364,25 @@ build_config() {
 		printf "%s\n" "# Config file automatically generated from UCI config" >>"$UPSMON_C.new"
 
 		if nut_upsmon_conf "$UPSMON_C.new"; then
-			# upsmon_conf_fail will be set in this function's context by nut_upsmon_add, on error
-			config_foreach nut_upsmon_add monitor "$UPSMON_C.new"
-			if [ "$upsmon_conf_fail" = "true" ]; then
-				log_error "'monitor' type sections must be correctly configured" nut-monitor-config.sh nut-monitor-config
-				return 1
-			fi
-			if [ "$have_monitor_line" = "false" ]; then
-				log_msg "Must have at least one 'monitor' type section" nut-monitor-config.sh nut-monitor-config warn
-				return 1
-			fi
+			# Execute in a subshell to avoid config_load nut_monitor
+			# and config_load nut_monitor_root becoming mixed together
+			(
+				config_load nut_monitor_root || {
+					log_config_load_error "nut_monitor_root" "nut-monitor" "nut-monitor"
+					exit 1
+				}
+
+				# upsmon_conf_fail will be set in this function's context by nut_upsmon_add, on error
+				config_foreach nut_upsmon_add monitor "$UPSMON_C.new"
+				if [ "$upsmon_conf_fail" = "true" ]; then
+					log_error "'monitor' type sections must be correctly configured" nut-monitor-config.sh nut-monitor-config
+					exit 1
+				fi
+				if [ "$have_monitor_line" = "false" ]; then
+					log_msg "Must have at least one 'monitor' type section" nut-monitor-config.sh nut-monitor-config warn
+					exit 1
+				fi
+			) || return 1
 		else
 			log_error "upsmon section name 'upsmon' not correctly configured" nut-monitor-config.sh nut-monitor-config
 			return 1

--- a/net/nut/files/nut-monitor-config.sh.functions
+++ b/net/nut/files/nut-monitor-config.sh.functions
@@ -23,12 +23,12 @@ append NUT_EVENT_TYPES "OTHER NOTOTHER SUSPEND_STARTING SUSPEND_FINISHED"
 
 # Upstream NUT upsmon.conf option names (in the order listed in
 # https://networkupstools.org/docs/man/upsmon.conf.html)
-# except MONITOR, NOTIFYMSG, NOTIFYFLAG, and RUN_AS_USER which are handled
-# separately
+# except MONITOR, NOTIFYCMD, NOTIFYMSG, NOTIFYFLAG, RUN_AS_USER, and SHUTDOWNCMD
+# which are handled separately
 NUT_UPSMON_OPTIONS="DEADTIME FINALDELAY HOSTSYNC MINSUPPLIES NOCOMMWARNTIME"
-append NUT_UPSMON_OPTIONS "POLLFAIL_LOG_THROTTLE_MAX NOTIFYCMD POLLFREQ"
+append NUT_UPSMON_OPTIONS "POLLFAIL_LOG_THROTTLE_MAX POLLFREQ"
 append NUT_UPSMON_OPTIONS "POLLFREQALERT POWERDOWNFLAG OFFDURATION OVERDURATION"
-append NUT_UPSMON_OPTIONS "OBLBDURATION RBWARNTIME SHUTDOWNCMD SHUTDOWNEXIT"
+append NUT_UPSMON_OPTIONS "OBLBDURATION RBWARNTIME SHUTDOWNEXIT"
 append NUT_UPSMON_OPTIONS "CERTPATH CERTFILE CERTIDENT CERTHOST DEBUG_MIN"
 
 NUT_UPSMON_BOOL_OPTIONS="ALARMCRITICAL CERTVERIFY FORCESSL"
@@ -59,14 +59,14 @@ nut_get_notifications() {
 	# is a valid NUT event type, so use it.
 	event_types=" $NUT_EVENT_TYPES "
 	if [ "${event_types#*" $event "}" != "${event_types}" ]; then
-		config_get val "$event" message
+		config_get_single "$event" message
 		if [ -n "$val" ]; then
 			if ! printf 'NOTIFYMSG %s %s\n' "$event" "$val" >>"$config_file"; then
 				log_error "upsmon section '$event' failed to write 'NOTIFYMSG' for '$event'" nut-monitor-config.sh nut-monitor-config
 				return 1
 			fi
 		fi
-		config_get val "$event" flag "$defaultnotify"
+		config_get_single "$event" flag "$defaultnotify"
 		if [ -n "$val" ]; then
 			if ! printf 'NOTIFYFLAG %s %s\n' "$event" "$val" >>"$config_file"; then
 				log_error "upsmon section '$event' failed to write 'NOTIFYFLAG' for '$event'" nut-monitor-config.sh nut-monitor-config
@@ -93,7 +93,7 @@ upsmon_conf_get_write() {
 		# Will always get a value - either 0 or 1
 		config_get_bool val "$cfg" "$uci_option" "$default"
 	else
-		config_get val "$cfg" "$uci_option" "$default"
+		config_get_single "$cfg" "$uci_option" "$default"
 	fi
 
 	if [ -n "$val" ]; then
@@ -126,153 +126,202 @@ nut_upsmon_conf() {
 	# Note that we use '-u $RUNAS' on the daemon command line in preference to
 	# the RUN_AS_USER configuration in "$config_file"
 
-	# Word-splitting is intentional here, and we know NUT_UPSMON_OPTIONS and
-	# NUT_UPSMON_BOOL_OPTIONS are safe because we define them.
-	set -f
-	for nut_option in $NUT_UPSMON_OPTIONS $NUT_UPSMON_BOOL_OPTIONS; do
-		nut_bool="false"
-		# The nut_option and corresponding uci_option are known to be
-		# pure 7-bit ASCII
-		# We use tr because ash does not support *global* replacement using
-		# parameter expansion
-		# shellcheck disable=SC2019,SC2018
-		uci_option="$(echo "$nut_option" | tr 'A-Z_' 'a-z')"
-		case "$nut_option" in
-		# integer: negative values allowed
-		POLLFAIL_LOG_THROTTLE_MAX | \
-		OFFDURATION | \
-		OVERDURATION | \
-		OBLBDURATION)
-			config_get val "$cfg" "$uci_option"
-			if ! check_signed_int "$val"; then
-				log_error "upsmon section '$cfg' bad value for '$uci_option'" nut-monitor-config.sh nut-monitor-config
-				return 1
-			elif [ -n "$val" ]; then # Ignore options with no configuration
-				if ! printf "%s %s\n" "$nut_option" "$val" >>"$config_file"; then
-					log_error "upsmon section '$cfg' failed to write '$nut_option'" nut-monitor-config.sh nut-monitor-config
-					return 1
+	# Execute in a subshell to avoid config_load nut_monitor
+	# and config_load nut_monitor_root becoming mixed together
+	(
+		config_load nut_monitor || {
+			log_config_load_error "nut_monitor" "nut-monitor" "nut-monitor"
+			exit 1
+		}
+
+		# Word-splitting is intentional here, and we know NUT_UPSMON_OPTIONS and
+		# NUT_UPSMON_BOOL_OPTIONS are safe because we define them.
+		set -f
+		for nut_option in $NUT_UPSMON_OPTIONS $NUT_UPSMON_BOOL_OPTIONS; do
+			nut_bool="false"
+			# The nut_option and corresponding uci_option are known to be
+			# pure 7-bit ASCII
+			# We use tr because ash does not support *global* replacement using
+			# parameter expansion
+			# shellcheck disable=SC2019,SC2018
+			uci_option="$(echo "$nut_option" | tr 'A-Z_' 'a-z')"
+			case "$nut_option" in
+			# integer: negative values allowed
+			POLLFAIL_LOG_THROTTLE_MAX | \
+			OFFDURATION | \
+			OVERDURATION | \
+			OBLBDURATION)
+				config_get_single "$cfg" "$uci_option"
+				if ! check_signed_int "$val"; then
+					log_error "upsmon section '$cfg' bad value for '$uci_option'" nut-monitor-config.sh nut-monitor-config
+					exit 1
+				elif [ -n "$val" ]; then # Ignore options with no configuration
+					if ! printf "%s %s\n" "$nut_option" "$val" >>"$config_file"; then
+						log_error "upsmon section '$cfg' failed to write '$nut_option'" nut-monitor-config.sh nut-monitor-config
+						exit 1
+					fi
 				fi
-			fi
-			;;
-		# integer: negative values not allowed
-		DEADTIME | \
-		DEBUG_MIN | \
-		FINALDELAY | \
-		HOSTSYNC | \
-		MINSUPPLIES | \
-		NOCOMMWARNTIME | \
-		POLLFREQ | \
-		POLLFREQALERT | \
-		RBWARNTIME)
-			config_get val "$cfg" "$uci_option"
-			if ! check_unsigned_int "$val"; then
-				log_error "upsmon section '$cfg' bad value for '$uci_option'" nut-monitor-config.sh nut-monitor-config
-				return 1
-			elif [ -n "$val" ]; then # Ignore options with no configuration
-				if ! printf "%s %s\n" "$nut_option" "$val" >>"$config_file"; then
-					log_error "upsmon section '$cfg' failed to write '$nut_option'" nut-monitor-config.sh nut-monitor-config
-					return 1
-				fi
-			fi
-			;;
-		SHUTDOWNCMD)
-			upsmon_conf_get_write "$cfg" "$config_file" "$uci_option" "$nut_option"
-			conf_ret=$?
-			case "$conf_ret" in
-			1)
-				return 1
 				;;
-			2)
-				if ! printf "%s %s\n" "$nut_option" "/usr/sbin/nutshutdown" >>"$config_file"; then
-					log_error "upsmon section '$cfg' failed to write 'SHUTDOWNCMD'" nut-monitor-config.sh nut-monitor-config
+			# integer: negative values not allowed
+			DEADTIME | \
+			DEBUG_MIN | \
+			FINALDELAY | \
+			HOSTSYNC | \
+			MINSUPPLIES | \
+			NOCOMMWARNTIME | \
+			POLLFREQ | \
+			POLLFREQALERT | \
+			RBWARNTIME)
+				config_get_single "$cfg" "$uci_option"
+				if ! check_unsigned_int "$val"; then
+					log_error "upsmon section '$cfg' bad value for '$uci_option'" nut-monitor-config.sh nut-monitor-config
+					exit 1
+				elif [ -n "$val" ]; then # Ignore options with no configuration
+					if ! printf "%s %s\n" "$nut_option" "$val" >>"$config_file"; then
+						log_error "upsmon section '$cfg' failed to write '$nut_option'" nut-monitor-config.sh nut-monitor-config
+						exit 1
+					fi
+				fi
+				;;
+			ALARMCRITICAL)
+				upsmon_conf_get_write "$cfg" "$config_file" "$uci_option" "$nut_option" "true" "1"
+				conf_ret=$?
+				if [ "$conf_ret" -eq 1 ]; then
+					return 1
+				fi
+				;;
+			*)
+				if [ "${upsmon_bool_options/$nut_option/}" != "${upsmon_bool_options}" ]; then
+					nut_bool="true"
+				fi
+				upsmon_conf_get_write "$cfg" "$config_file" "$uci_option" "$nut_option" "$nut_bool"
+				conf_ret=$?
+				if [ "$conf_ret" -eq 1 ]; then
+					exit 1
+				fi
+				;;
+			esac
+		done
+		set +f
+	) || return 1
+
+	# Execute in a subshell to avoid config_load nut_monitor
+	# and config_load nut_monitor_root becoming mixed together
+	(
+		config_load nut_monitor_root || {
+			log_config_load_error "nut_monitor_root" "nut-monitor" "nut-monitor"
+			exit 1
+		}
+
+		upsmon_conf_get_write "upsmon_root" "$config_file" "shutdowncmd" "SHUTDOWNCMD"
+		conf_ret=$?
+
+		case "$conf_ret" in
+		1)
+			exit 1
+			;;
+		2)
+			if ! printf "%s %s\n" "SHUTDOWNCMD" "/usr/sbin/nutshutdown" >>"$config_file"; then
+				log_error "upsmon section 'upsmon_root' failed to write 'SHUTDOWNCMD'" nut-monitor-config.sh nut-monitor-config
+				exit 1
+			fi
+			;;
+		esac
+
+		# Word-splitting is intentional here, and we know NUT_UPSMON_OPTIONS and
+		# NUT_UPSMON_BOOL_OPTIONS are safe because we define them.
+		set -f
+		for nut_option in $NUT_UPSMON_OPTIONS $NUT_UPSMON_BOOL_OPTIONS; do
+			nut_bool="false"
+			# The nut_option and corresponding uci_option are known to be
+			# pure 7-bit ASCII
+			# We use tr because ash does not support *global* replacement using
+			# parameter expansion
+			# shellcheck disable=SC2019,SC2018
+			uci_option="$(echo "$nut_option" | tr 'A-Z_' 'a-z')"
+			case "$nut_option" in
+			POWERDOWNFLAG)
+				upsmon_conf_get_write "$cfg" "$config_file" "$uci_option" "$nut_option" "false" "$NUT_KILLPOWER"
+				conf_ret=$?
+				if [ "$conf_ret" -eq 1 ]; then
+					return 1
+				fi
+				;;
+			CERTPATH | CERTIDENT | CERTHOST)
+				# if not compiled with SSL (OpenSSL or NSS), then do not attempt to use
+				# SSL configuration
+				if [ "$ssl_backend" != "openssl" ] && [ "$ssl_backend" != "nss" ]; then
+					continue
+				fi
+				# If no certpath or certfile is specified, then SSL will not be used, even if
+				# other SSL config exists
+				upsmon_conf_get_write "$cfg" "$config_file" "$uci_option" "$nut_option" "false"
+				conf_ret=$?
+				if [ "$conf_ret" -eq 1 ]; then
+					return 1
+				fi
+				;;
+			CERTVERIFY | FORCESSL)
+				# if not compiled with SSL (OpenSSL or NSS), then do not attempt to use
+				# SSL configuration
+				if [ "$ssl_backend" != "openssl" ] && [ "$ssl_backend" != "nss" ]; then
+					continue
+				fi
+				upsmon_conf_get_write "$cfg" "$config_file" "$uci_option" "$nut_option" "true"
+				conf_ret=$?
+				if [ "$conf_ret" -eq 1 ]; then
+					return 1
+				fi
+				;;
+			CERTFILE)
+				# if not compiled with OpenSSL, then do not attempt to use CERTFILE (it is
+				# OpenSSL specific)
+				if [ "$ssl_backend" != "openssl" ]; then
+					continue
+				fi
+				upsmon_conf_get_write "$cfg" "$config_file" "$uci_option" "$nut_option" "false"
+				conf_ret=$?
+				if [ "$conf_ret" -eq 1 ]; then
+					return 1
+				fi
+				;;
+			*)
+				if [ "${upsmon_bool_options/$nut_option/}" != "${upsmon_bool_options}" ]; then
+					nut_bool="true"
+				fi
+				upsmon_conf_get_write "$cfg" "$config_file" "$uci_option" "$nut_option" "$nut_bool"
+				conf_ret=$?
+				if [ "$conf_ret" -eq 1 ]; then
 					return 1
 				fi
 				;;
 			esac
-			;;
-		ALARMCRITICAL)
-			upsmon_conf_get_write "$cfg" "$config_file" "$uci_option" "$nut_option" "true" "1"
-			conf_ret=$?
-			if [ "$conf_ret" -eq 1 ]; then
-				return 1
-			fi
-			;;
-		POWERDOWNFLAG)
-			upsmon_conf_get_write "$cfg" "$config_file" "$uci_option" "$nut_option" "false" "$NUT_KILLPOWER"
-			conf_ret=$?
-			if [ "$conf_ret" -eq 1 ]; then
-				return 1
-			fi
-			;;
-		CERTPATH | CERTIDENT | CERTHOST)
-			# if not compiled with SSL (OpenSSL or NSS), then do not attempt to use
-			# SSL configuration
-			if [ "$ssl_backend" != "openssl" ] && [ "$ssl_backend" != "nss" ]; then
-				continue
-			fi
-			# If no certpath or certfile is specified, then SSL will not be used, even if
-			# other SSL config exists
-			upsmon_conf_get_write "$cfg" "$config_file" "$uci_option" "$nut_option" "false"
-			conf_ret=$?
-			if [ "$conf_ret" -eq 1 ]; then
-				return 1
-			fi
-			;;
-		CERTVERIFY | FORCESSL)
-			# if not compiled with SSL (OpenSSL or NSS), then do not attempt to use
-			# SSL configuration
-			if [ "$ssl_backend" != "openssl" ] && [ "$ssl_backend" != "nss" ]; then
-				continue
-			fi
-			upsmon_conf_get_write "$cfg" "$config_file" "$uci_option" "$nut_option" "true"
-			conf_ret=$?
-			if [ "$conf_ret" -eq 1 ]; then
-				return 1
-			fi
-			;;
-		CERTFILE)
-			# if not compiled with OpenSSL, then do not attempt to use CERTFILE (it is
-			# OpenSSL specific)
-			if [ "$ssl_backend" != "openssl" ]; then
-				continue
-			fi
-			upsmon_conf_get_write "$cfg" "$config_file" "$uci_option" "$nut_option" "false"
-			conf_ret=$?
-			if [ "$conf_ret" -eq 1 ]; then
-				return 1
-			fi
-			;;
-		*)
-			if [ "${upsmon_bool_options/$nut_option/}" != "${upsmon_bool_options}" ]; then
-				nut_bool="true"
-			fi
-			upsmon_conf_get_write "$cfg" "$config_file" "$uci_option" "$nut_option" "$nut_bool"
-			conf_ret=$?
-			if [ "$conf_ret" -eq 1 ]; then
-				return 1
-			fi
-			;;
-		esac
-	done
-	set +f
+		done
 
-	event_notify_flags_not_found="$NUT_EVENT_TYPES"
-	config_get val "$cfg" defaultnotify "SYSLOG"
-	defaultnotify="$val"
-	config_foreach nut_get_notifications notifications "$val" "$config_file"
-
-	# Otherwise the default is WALL+SYSLOG
-	event_notify_flags_not_found="$(printf "%s" "$event_notify_flags_not_found" | tr -s ' ')"
-	# We intentionally word-split on event_notify_flags-not-found to iterate
-	# over event types.
-	set -f
-	for event in $event_notify_flags_not_found; do
-		if ! printf "NOTIFYFLAG %s %s\n" "$event" "$defaultnotify" >>"$config_file"; then
-			log_error "upsmon section '$cfg' failed to write 'NOTIFYFLAG' for '$event'" nut-monitor-config.sh nut-monitor-config
-			return 1
+		upsmon_conf_get_write "upsmon_root" "$config_file" "notifycmd" "NOTIFYCMD"
+		conf_ret=$?
+		if [ "$conf_ret" -eq 1 ]; then
+			exit 1
 		fi
-	done
-	set +f
+
+		event_notify_flags_not_found="$NUT_EVENT_TYPES"
+		config_get_single "upsmon_root" defaultnotify "SYSLOG"
+		defaultnotify="$val"
+		config_foreach nut_get_notifications notifications "$val" "$config_file"
+
+		# Otherwise the default is WALL+SYSLOG
+		event_notify_flags_not_found="$(printf "%s" "$event_notify_flags_not_found" | tr -s ' ')"
+		# We intentionally word-split on event_notify_flags-not-found to iterate
+		# over event types.
+		set -f
+		for event in $event_notify_flags_not_found; do
+			if ! printf "NOTIFYFLAG %s %s\n" "$event" "$defaultnotify" >>"$config_file"; then
+				log_error "upsmon section '$cfg' failed to write 'NOTIFYFLAG' for '$event'" nut-monitor-config.sh nut-monitor-config
+				exit 1
+			fi
+		done
+		set +f
+	) || return 1
 	return 0
 }
 
@@ -287,38 +336,46 @@ nut_upsmon_add() {
 	local password
 	local system
 	local type
+	local val
 
-	config_get upsname "$cfg" upsname "$cfg"
+	config_get_single "$cfg" upsname "$cfg"
+	upsname="$val"
 	if ! check_safe_uci_name "$upsname"; then
 		log_error "upsmon section '$cfg' has invalid upsname" nut-monitor-config.sh nut-monitor-config
 		upsmon_conf_fail="true"
 		# we do not error exit so as not abort processing of other sections on the config_foreach
 		return 0
 	fi
-	config_get hostname "$cfg" hostname localhost
+	config_get_single "$cfg" hostname localhost
+	hostname="$val"
 	if ! check_safe_hostname_or_ip "$hostname"; then
 		log_error "upsmon section '$cfg' has invalid hostname" nut-monitor-config.sh nut-monitor-config
 		upsmon_conf_fail="true"
 		# we do not error exit so as not abort processing of other sections on the config_foreach
 		return 0
 	fi
-	config_get port "$cfg" port
+	config_get_single "$cfg" port
+	port="$val"
 	if ! check_port "$port"; then
 		log_error "upsmon section '$cfg' has invalid port" nut-monitor-config.sh nut-monitor-config
 		upsmon_conf_fail="true"
 		# we do not error exit so as not abort processing of other sections on the config_foreach
 		return 0
 	fi
-	config_get powervalue "$cfg" powervalue 1
-	if ! check_unsigned_int "$powervalue" || [ -z "$powervalue" ]; then
+	config_get_single "$cfg" powervalue 1
+	powervalue="$val"
+	if ! check_unsigned_int "$powervalue"; then
 		log_error "upsmon section '$cfg' has invalid powervalue" nut-monitor-config.sh nut-monitor-config
 		upsmon_conf_fail="true"
 		# we do not error exit so as not abort processing of other sections on the config_foreach
 		return 0
 	fi
-	config_get username "$cfg" username
-	config_get password "$cfg" password
-	config_get type "$cfg" type secondary
+	config_get_single "$cfg" username
+	username="$val"
+	config_get_single "$cfg" password
+	password="$val"
+	config_get_single "$cfg" type secondary
+	type="$val"
 	case "$type" in
 	primary | secondary)
 		# primary or secondary are the only allowed values
@@ -377,16 +434,25 @@ build_config() {
 		printf "%s\n" "# Config file automatically generated from UCI config" >>"$UPSMON_C.new"
 
 		if nut_upsmon_conf "$UPSMON_C.new"; then
-			# upsmon_conf_fail will be set in this function's context by nut_upsmon_add, on error
-			config_foreach nut_upsmon_add monitor "$UPSMON_C.new"
-			if [ "$upsmon_conf_fail" = "true" ]; then
-				log_error "'monitor' type sections must be correctly configured" nut-monitor-config.sh nut-monitor-config
-				return 1
-			fi
-			if [ "$have_monitor_line" = "false" ]; then
-				log_msg "Must have at least one 'monitor' type section" nut-monitor-config.sh nut-monitor-config warn
-				return 1
-			fi
+			# Execute in a subshell to avoid config_load nut_monitor
+			# and config_load nut_monitor_root becoming mixed together
+			(
+				config_load nut_monitor_root || {
+					log_config_load_error "nut_monitor_root" "nut-monitor" "nut-monitor"
+					exit 1
+				}
+
+				# upsmon_conf_fail will be set in this function's context by nut_upsmon_add, on error
+				config_foreach nut_upsmon_add monitor "$UPSMON_C.new"
+				if [ "$upsmon_conf_fail" = "true" ]; then
+					log_error "'monitor' type sections must be correctly configured" nut-monitor-config.sh nut-monitor-config
+					exit 1
+				fi
+				if [ "$have_monitor_line" = "false" ]; then
+					log_msg "Must have at least one 'monitor' type section" nut-monitor-config.sh nut-monitor-config warn
+					exit 1
+				fi
+			) || return 1
 		else
 			log_error "upsmon section name 'upsmon' not correctly configured" nut-monitor-config.sh nut-monitor-config
 			return 1

--- a/net/nut/files/nut-monitor-config.sh.functions
+++ b/net/nut/files/nut-monitor-config.sh.functions
@@ -61,7 +61,7 @@ nut_get_notifications() {
 	if [ "${event_types#*" $event "}" != "${event_types}" ]; then
 		config_get_single "$event" message
 		if [ -n "$val" ]; then
-			if ! printf 'NOTIFYMSG %s %s\n' "$event" "$val" >>"$config_file"; then
+			if ! printf 'NOTIFYMSG %s "%s"\n' "$event" "$val" >>"$config_file"; then
 				log_error "upsmon section '$event' failed to write 'NOTIFYMSG' for '$event'" nut-monitor-config.sh nut-monitor-config
 				return 1
 			fi

--- a/net/nut/files/nut-monitor-migrate-root.default
+++ b/net/nut/files/nut-monitor-migrate-root.default
@@ -1,0 +1,98 @@
+#!/bin/sh
+# Script is sourced not executed, but shebang helps tools recognize this as
+# a shell script.
+
+# In recent (relevant) versions of shellcheck busybox is a valid shell type
+# shellcheck shell=busybox
+
+# uci-defaults script to migrate old uci config for notifications and monitor sections,
+# to the new. Applied during install or on first boot after install, if setting on install
+# fails
+
+# IPKG_INSTROOT is intentionally only set when building an image and
+# is intentionally empty on a live OpenWrt device
+
+# Only run this uci-defaults script on a live OpenWrt device
+[ -z "${IPKG_INSTROOT}" ] || exit 0
+
+# As the uci-defaults environment in which this runs does not have logging
+# available, nor is stderr captured or displayed on the console, these messages
+# exist only to assist when debugging manual runs of the script.
+# shellcheck disable=SC2329,SC2317
+log_migration_error() {
+	local reason="$1"
+
+	printf "'%s': ERROR: '%s'\n" "nut-monitor-migrate-root" "$reason" >&2
+}
+
+preserve_root_commented_file="false"
+preserve_regular_commented_file="false"
+
+nut_monitor_root_current_trimmed="$(mktemp)"
+
+grep -Ev "((^[#]|^$))*" /etc/config/nut_monitor_root 2>/dev/null >>"$nut_monitor_root_current_trimmed"
+
+if [ -n "$(cat "$nut_monitor_root_current_trimmed" | tr -d '\t \r\n')" ]; then
+	printf "'%s': NOTICE: '%s'\n" "nut-monitor-migrate-root" "nut_monitor_root already exists and has configuration. Skipping migration." >&2
+	rm -f "$nut_monitor_root_current_trimmed" || true
+	exit 0
+fi
+
+if grep -q "^[#]" /etc/config/nut_monitor_root 2>/dev/null; then
+	preserve_root_commented_file="true"
+fi
+
+nut_monitor_dir="$(mktemp -d /tmp/tmpXXXXXX)"
+nut_monitor_new="$(mktemp -p "$nut_monitor_dir" tmp_XXXXXX)"
+nut_monitor_new_trimmed="$(mktemp -p "$nut_monitor_dir" tmp_XXXXXX)"
+nut_monitor_root_add="$(mktemp -p "$nut_monitor_dir" tmp_XXXXXX)"
+nut_monitor_root_add_trimmed="$(mktemp -p "$nut_monitor_dir" tmp_XXXXXX)"
+
+grep -E "^#?(\t| )*(config(\t| )upsmon((\t| )+('|\")?upsmon('|\")?)?|option(\t| )+(deadtime|finaldelay|hostsync|minsupplies|nocommwarntime|pollfaillogthrottlemax|pollfreq|pollfreqalert|offduration|overduration|oblbduration|rbwarntime|alarmcritical|shutdownexit|interface_reload_delay|triggerlist))" /etc/config/nut_monitor >>"$nut_monitor_new"
+grep -Ev "^(\t )*(#|$)" "$nut_monitor_new" >>"$nut_monitor_new_trimmed"
+
+if [ -n "$(cat "$nut_monitor_new_trimmed" | tr -d '\t \r\n')" ]; then
+	if ! uci -c "$(dirname "$nut_monitor_new")" show "$(basename "$nut_monitor_new")" >/dev/null; then
+		log_migration_error "FATAL: failed to create valid non-_root only nut_monitor config"
+		exit 1
+	fi
+elif grep -q "^#" /etc/config/nut_monitor 2>/dev/null; then
+	preserve_regular_commented_file="true"
+fi
+
+grep -E "^#?(\t| )*(config(\t| )+(upsmon((\t| )+('|\")?upsmon('|\")?)?|monitor|notifications)|option(\t| )+(runas|notifycmd|shutdowncmd|defaultnotify|certfile|certpath|certident|certverify|forcessl|type|upsname|hostname|port|powervalue|username|password|message|flag))" /etc/config/nut_monitor >>"$nut_monitor_root_add"
+grep -Ev "^((\t )*(#|$)|#?(\t| )*config(\t| )+upsmon((\t| )+('|\")?upsmon('|\")?))" "$nut_monitor_root_add" >>"$nut_monitor_root_add_trimmed"
+
+if [ -n "$(cat "$nut_monitor_root_add_trimmed" | tr -d '\t \r\n')" ]; then
+	sed -i -e "s/config upsmon (|'|\")upsmon(|'|\")/config upsmon 'upsmon_root'/" "$nut_monitor_root_add" || {
+		log_migration_error "FATAL: failed to create new 'upsmon_root' to add to nut_monitor_root"
+		exit 1
+	}
+fi
+
+if [ -n "$(cat "$nut_monitor_root_add_trimmed" | tr -d '\t \r\n')" ] || [ "$preserve_root_commented_file" = "false" ]; then
+	if ! uci -c "$(dirname "$nut_monitor_root_add")" show "$(basename "$nut_monitor_root_add")" >/dev/null; then
+		log_migration_error "FATAL: failed to create valid nut_monitor_root config"
+		exit 1
+	fi
+	cat "$nut_monitor_root_add" | uci import nut_monitor_root || {
+		log_migration_error "Failed to import new nut_monitor_root configuration"
+		exit 1
+	}
+	# Ensure we remove non-root configs from regular nut_monitor config
+	preserve_regular_commented_file="false"
+fi
+
+if [ -n "$(cat "$nut_monitor_new_trimmed" | tr -d '\t \r\n')" ] || [ "$preserve_regular_commented_file" == "false" ]; then
+	cat "$nut_monitor_new" >/etc/config/nut_monitor || {
+		log_migration_error "Failed to replace nut_monitor_config with new non-_root only config"
+		exit 1
+	}
+fi
+
+rm -f "$nut_monitor_root_add_trimmed" || true
+rm -f "$nut_monitor_new_trimmed" || true
+rm -f "$nut_monitor_root_add" || true
+rm -f "$nut_monitor_new" || true
+
+exit 0

--- a/net/nut/files/nut-monitor.init
+++ b/net/nut/files/nut-monitor.init
@@ -70,28 +70,45 @@ service_preconditions() {
 
 	case "$action" in
 	start | reload)
+		unset RUNAS
+		export RUNAS
+
 		# NUT_KILLPOWER is an external sentinel that indicates a forced shutdown
 		if [ -f "$NUT_KILLPOWER" ]; then
 			return 1
 		fi
 
-		config_load nut_monitor || {
-			log_config_load_error "nut_monitor" "nut-monitor" "nut-monitor"
-			exit 1
-		}
-
-		if have_section_named "upsmon" "upsmon"; then
-			# Find the RUNAS user for upsmon
-			RUNAS="$(find_runas "upsmon" "nut_monitor" "nutmon")" || {
-				log_error_exit "Failed to determine RUNAS user" "nut-monitor" "nut-monitor"
+		# Execute in a subshell to avoid config_load nut_monitor
+		# and config_load nut_monitor_root becoming mixed together
+		RUNAS="$(
+			config_load nut_monitor_root || {
+				log_config_load_error "nut_monitor_root" "nut-monitor" "nut-monitor"
+				exit 1
 			}
-		else
-			# If we do not have a 'upsmon' section in nut_monitor, use defaults
-			log_msg "No upsmon section so no RUNAS user, falling back to nutmon" "nut-monitor" "nut-monitor" "notice"
-			RUNAS=nutmon
-		fi
+			if have_section_named "upsmon" "upsmon_root"; then
+				# Find the RUNAS user for upsmon
+				RUNAS="$(find_runas "upsmon_root" "nut_monitor_root" "nutmon")"
+				if [ -z "$RUNAS" ]; then
+					log_msg "Failed to determine RUNAS user (maybe not set in upsmon_root), falling back to nutmon" "nut-monitor" "nut-monitor" "notice"
+				fi
+			else
+				# If we do not have a 'upsmon_root' section in nut_monitor_root, use defaults
+				log_msg "No upsmon_root section so no RUNAS user, falling back to nutmon" "nut-monitor" "nut-monitor" "notice"
+				RUNAS=nutmon
+			fi
+			echo "$RUNAS"
+		)" || return 1
+
+		# RUNAS should always be set, but be defensive
+		RUNAS="${RUNAS:-nutmon}"
+		export RUNAS
 
 		build_config || return 1
+
+		config_load nut_monitor || {
+			log_config_load_error "nut_monitor" "nut-monitor" "nut-monitor"
+			return 1
+		}
 		check_interface_up "upsmon" || return 1
 		return 0
 		;;
@@ -203,14 +220,14 @@ stop_service() {
 
 service_triggers() {
 	local val interface_reload_delay
-
 	# No config, or error loading config is fatal
 	config_load nut_monitor || {
 		log_config_load_error "nut_monitor" "nut-monitor" "nut-monitor"
 		exit 1
 	}
 
-	config_get interface_reload_delay upsmon interface_reload_delay $DEFAULT_PROCD_INTERFACE_RELOAD_DELAY
+	config_get_single upsmon interface_reload_delay "$DEFAULT_PROCD_INTERFACE_RELOAD_DELAY"
+	interface_reload_delay="$val"
 	if ! check_unsigned_int "$interface_reload_delay" || [ -z "$interface_reload_delay" ]; then
 		log_msg "interface_reload_delay must be an unsigned integer" nut-monitor nut-monitor warn
 		interface_reload_delay="$DEFAULT_PROCD_INTERFACE_RELOAD_DELAY"
@@ -222,4 +239,5 @@ service_triggers() {
 		log_error "Failed to add interface triggers" nut-monitor nut-monitor
 	}
 	procd_add_reload_trigger "nut_monitor"
+	procd_add_reload_trigger "nut_monitor_root"
 }

--- a/net/nut/files/nut-monitor.init
+++ b/net/nut/files/nut-monitor.init
@@ -70,28 +70,45 @@ service_preconditions() {
 
 	case "$action" in
 	start | reload)
+		unset RUNAS
+		export RUNAS
+
 		# NUT_KILLPOWER is an external sentinel that indicates a forced shutdown
 		if [ -f "$NUT_KILLPOWER" ]; then
 			return 1
 		fi
 
-		config_load nut_monitor || {
-			log_config_load_error "nut_monitor" "nut-monitor" "nut-monitor"
-			exit 1
-		}
-
-		if have_section_named "upsmon" "upsmon"; then
-			# Find the RUNAS user for upsmon
-			RUNAS="$(find_runas "upsmon" "nut_monitor" "nutmon")" || {
-				log_error_exit "Failed to determine RUNAS user" "nut-monitor" "nut-monitor"
+		# Execute in a subshell to avoid config_load nut_monitor
+		# and config_load nut_monitor_root becoming mixed together
+		RUNAS="$(
+			config_load nut_monitor_root || {
+				log_config_load_error "nut_monitor_root" "nut-monitor" "nut-monitor"
+				exit 1
 			}
-		else
-			# If we do not have a 'upsmon' section in nut_monitor, use defaults
-			log_msg "No upsmon section so no RUNAS user, falling back to nutmon" "nut-monitor" "nut-monitor" "notice"
-			RUNAS=nutmon
-		fi
+			if have_section_named "upsmon" "upsmon_root"; then
+				# Find the RUNAS user for upsmon
+				RUNAS="$(find_runas "upsmon_root" "nut_monitor_root" "nutmon")"
+				if [ -z "$RUNAS" ]; then
+					log_msg "Failed to determine RUNAS user, falling back to nutmon" "nut-monitor" "nut-monitor" "notice"
+				fi
+			else
+				# If we do not have a 'upsmon_root' section in nut_monitor_root, use defaults
+				log_msg "No upsmon_root section so no RUNAS user, falling back to nutmon" "nut-monitor" "nut-monitor" "notice"
+				RUNAS=nutmon
+			fi
+			echo "$RUNAS"
+		)" || return 1
+
+		# RUNAS should always be set, but be defensive
+		RUNAS="${RUNAS:-nutmon}"
+		export RUNAS
 
 		build_config || return 1
+
+		config_load nut_monitor || {
+			log_config_load_error "nut_monitor" "nut-monitor" "nut-monitor"
+			return 1
+		}
 		check_interface_up "upsmon" || return 1
 		return 0
 		;;
@@ -203,14 +220,14 @@ stop_service() {
 
 service_triggers() {
 	local val interface_reload_delay
-
 	# No config, or error loading config is fatal
 	config_load nut_monitor || {
 		log_config_load_error "nut_monitor" "nut-monitor" "nut-monitor"
 		exit 1
 	}
 
-	config_get interface_reload_delay upsmon interface_reload_delay $DEFAULT_PROCD_INTERFACE_RELOAD_DELAY
+	config_get_single upsmon interface_reload_delay "$DEFAULT_PROCD_INTERFACE_RELOAD_DELAY"
+	interface_reload_delay="$val"
 	if ! check_unsigned_int "$interface_reload_delay" || [ -z "$interface_reload_delay" ]; then
 		log_msg "interface_reload_delay must be an unsigned integer" nut-monitor nut-monitor warn
 		interface_reload_delay="$DEFAULT_PROCD_INTERFACE_RELOAD_DELAY"
@@ -222,4 +239,5 @@ service_triggers() {
 		log_error "Failed to add interface triggers" nut-monitor nut-monitor
 	}
 	procd_add_reload_trigger "nut_monitor"
+	procd_add_reload_trigger "nut_monitor_root"
 }

--- a/net/nut/files/nut-serial.hotplug
+++ b/net/nut/files/nut-serial.hotplug
@@ -89,10 +89,11 @@ nut_set_serial_port_permissions() {
 # shellcheck disable=SC2317,SC2329
 nut_serial() {
 	local ups="$1" # UCI section name is also the UPS configuration name
-	local enable_usb_serial port normal_devname
+	local enable_usb_serial port normal_devname val
 
 	config_get_bool enable_usb_serial "$ups" enable_usb_serial 0
-	config_get port "$ups" port
+	config_get_single "$ups" port
+	port="$val"
 
 	[ "$enable_usb_serial" = "1" ] && {
 		# If port is specified only change tty's matching port

--- a/net/nut/files/nut-serial.hotplug
+++ b/net/nut/files/nut-serial.hotplug
@@ -163,8 +163,12 @@ nut_on_hotplug_add() {
 # Do not do any hotplug actions if hotplug is disabled. Not an error but log
 # for information
 if ! allow_hotplug_restart; then
-	# Informational and not an error
-	log_msg "Did not set permissions on serial port hotplug as NUT hotplug is disabled" nut-serial nut-serial-hotplug notice
+	# Don't spam logs on initial boot
+	# (before NUT_HOTPLUG_BOOT_COMPLETE_PATH exists)
+	if [ -f "$NUT_HOTPLUG_BOOT_COMPLETE_PATH" ]; then
+		# Informational and not an error
+		log_msg "Did not set permissions on serial port hotplug as NUT hotplug is disabled" nut-serial nut-serial-hotplug notice
+	fi
 	exit 0
 fi
 

--- a/net/nut/files/nut-server-config.sh.functions
+++ b/net/nut/files/nut-server-config.sh.functions
@@ -35,11 +35,11 @@ get_write_ups_config() {
 	local config_file="$5"
 	local val
 
+	config_get_single "$ups" "$var" "$def" "$flag"
+
 	if [ -z "$flag" ] || [ "$flag" = "0" ]; then
-		config_get val "$ups" "$var" "$def"
 		[ -n "$val" ] && printf "%s = %s\n" "$var" "$val" >>"$config_file"
 	else
-		config_get_bool val "$ups" "$var" "$def"
 		# In NUT config a flag is either present or not present
 		# present is true, not present is false. Map UCI bool to NUT flags.
 		if [ "$val" = "1" ]; then
@@ -52,10 +52,13 @@ get_write_ups_config() {
 listen_address() {
 	local srv="$1"
 	local config_file="$2"
-	local address port
+	local address port val
 
-	config_get address "$srv" address "::1"
-	config_get port "$srv" port
+	config_get_single "$srv" address "::1"
+	address="$val"
+	config_get_single "$srv" port
+	port="$val"
+
 	if [ -n "$port" ]; then
 		printf "LISTEN %s %s\n" "$address" "$port" >>"$config_file"
 	else
@@ -68,15 +71,37 @@ srv_config() {
 	local srv="$1"
 	local config_file="$2"
 	local ssl_backend
-	local maxage maxconn val certfile
+	local val certfile
+	local val
 
-	config_get maxage "$srv" maxage
-	[ -n "$maxage" ] && printf "MAXAGE %s\n" "$maxage" >>"$config_file"
+	config_get_single "$srv" maxage
+	[ -n "$val" ] && printf "MAXAGE %s\n" "$val" >>"$config_file"
 
 	[ -n "$STATEPATH" ] && printf "STATEPATH %s\n" "$STATEPATH" >>"$config_file"
 
-	config_get maxconn "$srv" maxconn
-	[ -n "$maxconn" ] && printf "MAXCONN %s\n" "$maxconn" >>"$config_file"
+	config_get_single "$srv" maxconn
+	[ -n "$val" ] && printf "MAXCONN %s\n" "$val" >>"$config_file"
+
+	# triggerlist is handled in nut_service.sh
+
+	# NOTE: certs only apply to SSL-enabled version
+	config_get val "$srv" debug_min
+	[ -n "$val" ] && printf "DEBUG_MIN %s\n" "$val" >>"$config_file"
+
+	return 0
+}
+
+# Adds sensitive upsd (NUT server) run-time configuration
+srv_config_root() {
+	local srv="$1"
+	local config_file="$2"
+	local ssl_backend
+	local val certfile
+	local val
+
+	# NOTE: certs only apply to SSL-enabled version
+	config_get_single "$srv" certfile
+	[ -n "$val" ] && printf "CERTFILE %s\n" "$val" >>"$config_file"
 
 	ssl_backend="$(cat /usr/share/nut/ssl_backend)"
 
@@ -107,15 +132,17 @@ srv_config() {
 		printf "DISABLE_WEAK_SSL %s\n" "$val" >>"$config_file"
 	fi
 
-	config_get val "$srv" debug_min
-	[ -n "$val" ] && printf "DEBUG_MIN %s\n" "$val" >>"$config_file"
-
 	return 0
 }
 
 nut_user_instcmd() {
 	local val="$1"
 	local config_file="$2"
+
+	# keep only printable ASCII characters (space through ~)
+	# borrowed from ser2net in this (packages) repo
+	val="$(LC_ALL=C printf '%s' "$val" | tr -cd ' -~')"
+
 	printf "  instcmds = %s\n" "$val" >>"$config_file"
 }
 
@@ -126,13 +153,13 @@ nut_user_add() {
 	local a
 	local val
 
-	config_get val "$user" username "$user"
+	config_get_single "$user" username "$user"
 	printf "[%s]\n" "$val" >>"$config_file"
 
-	config_get val "$user" password
+	config_get_single "$user" password
 	[ -n "$val" ] && printf "  password = %s\n" "$val" >>"$config_file"
 
-	config_get val "$user" actions
+	config_get_single "$user" actions
 	set -f
 	for a in $val; do
 		printf "  actions = %s\n" "$a" >>"$config_file"
@@ -142,7 +169,7 @@ nut_user_add() {
 	# The name instcmd is use for both the UCI option and the callback function
 	config_list_foreach "$user" instcmd nut_user_instcmd "$config_file"
 
-	config_get val "$user" upsmon
+	config_get_single "$user" upsmon
 	if [ -n "$val" ]; then
 		printf "  upsmon %s\n" "$val" >>"$config_file"
 	fi
@@ -167,16 +194,37 @@ build_server_config() {
 	echo "# Config file automatically generated from UCI config" >"$UPSD_C.new"
 	restore_umask
 
-	# For nut_user and listen_address, the section type and callback function
+	# Execute in a subshell to avoid nut_server and nut_server_root becoming
+	# mixed together
+	(
+		config_load nut_server_root || {
+			log_config_load_error "nut_server_root" "nut-server" "nut-server"
+			exit 1
+		}
+
+		# For nut_user, the section type and callback function are named the same
+		config_foreach nut_user_add user "$USERS_C.new"
+
+		if have_section_named "upsd" "upsd"; then
+			srv_config upsd "$UPSD_C.new" || return 1
+		else
+			# If config 'nut_server' does not have a 'upsd' section, use a default
+			# configuration
+			[ -n "$STATEPATH" ] && printf "STATEPATH %s\n" "$STATEPATH" >>"$UPSD_C.new"
+		fi
+	) || return 1
+
+	config_load nut_server || {
+		log_config_load_error "nut_server" "nut-server" "nut-server"
+		return 1
+	}
+
+	# For listen_address, the section type and callback function
 	# are named the same
-	config_foreach nut_user_add user "$USERS_C.new"
 	config_foreach listen_address listen_address "$UPSD_C.new"
+
 	if have_section_named "upsd" "upsd"; then
 		srv_config upsd "$UPSD_C.new" || return 1
-	else
-		# If config 'nut_server' does not have a 'upsd' section, use a default
-		# configuration
-		[ -n "$STATEPATH" ] && printf "STATEPATH %s\n" "$STATEPATH" >>"$UPSD_C.new"
 	fi
 
 	# Failure to write nut.conf is not hard-fatal although it means the NUT will
@@ -189,7 +237,7 @@ build_server_config() {
 			return 1
 		fi
 	else
-		# Otherwise if nut-monitor is already configured, make sure both
+		# Otherwise if nut.conf is already configured, make sure both
 		# nut-server (this service) and nut-monitor are started
 		if grep -q '^MODE=netclient' "$NUT_CONF"; then
 			# In modern OpenWrt 'sed -i' modifies the specified files, without backup
@@ -222,14 +270,14 @@ nut_ups_defoverride() {
 	local config_file="$3"
 	local ups="$4"
 	local overtype
-	local overval
+	local val
 
 	# tr is used as global replace in variable parameter expansion is not
 	# available in ash.
 	overtype="$(printf "%s" "$overvar" | tr '_' '.')"
 
-	config_get overval "$ups" "${defover}_${overvar}"
-	[ -n "$overval" ] && printf "%s.%s = %s\n" "${defover}" "${overtype}" "$overval" >>"$config_file"
+	config_get_single "$ups" "${defover}_${overvar}"
+	[ -n "$val" ] && printf "%s.%s = %s\n" "${defover}" "${overtype}" "$val" >>"$config_file"
 }
 
 # From documentation and fixing of nut_ups_other (previously other or do_other)
@@ -249,14 +297,22 @@ nut_ups_other() {
 	local othervarflag="$2"
 	local config_file="$3"
 	local ups="$4"
-	local otherval
+	local otherval val
 
 	if [ "$othervarflag" = "otherflag" ]; then
 		config_get_bool otherval "${ups}" "${othervarflag}_${othervar}"
 		[ "$otherval" = "1" ] && printf "%s\n" "${othervar}" >>"$config_file"
 	else
-		config_get otherval "${ups}" "${othervarflag}_${othervar}"
-		[ -n "$otherval" ] && printf "%s = %s\n" "${othervar}" "$otherval" >>"$config_file"
+		config_get_single "${ups}" "${othervarflag}_${othervar}"
+
+		case "$othervar" in
+		runas)
+			log_error "An 'other' option in '$ups' had an illegal NUT option '$othervar'" nut-server-config.sh nut-server-config
+			return 1
+			;;
+		esac
+
+		[ -n "$val" ] && printf "%s = %s\n" "${othervar}" "$val" >>"$config_file"
 	fi
 }
 
@@ -400,15 +456,23 @@ build_config() {
 		return 1
 	}
 
+	build_server_config "$conf_group" || {
+		log_msg "Failed to configure upsd. Not starting." nut-server-config.sh nut-server-config warn
+		return 1
+	}
+
+	config_load nut_server || {
+		log_config_load_error "nut_server" "nut-server" "nut-server"
+		return 1
+	}
+
 	config_foreach build_global_driver_config driver_global "$UPS_C.new"
 	config_foreach build_ups_config driver "$UPS_C.new"
 
-	if ! build_server_config "$conf_group"; then
-		log_msg "Failed to configure upsd. Not starting." nut-server-config.sh nut-server-config warn
-		return 1
-	elif [ "$haveupscfg" = "false" ]; then
+	if [ "$haveupscfg" = "false" ]; then
 		log_msg "No configured UPS. Not starting upsd." nut-server-config.sh nut-server-config warn
 		return 2
 	fi
+
 	return 0
 }

--- a/net/nut/files/nut-server-config.sh.functions
+++ b/net/nut/files/nut-server-config.sh.functions
@@ -35,11 +35,11 @@ get_write_ups_config() {
 	local config_file="$5"
 	local val
 
+	config_get_single "$ups" "$var" "$def" "$flag"
+
 	if [ -z "$flag" ] || [ "$flag" = "0" ]; then
-		config_get val "$ups" "$var" "$def"
 		[ -n "$val" ] && printf "%s = %s\n" "$var" "$val" >>"$config_file"
 	else
-		config_get_bool val "$ups" "$var" "$def"
 		# In NUT config a flag is either present or not present
 		# present is true, not present is false. Map UCI bool to NUT flags.
 		if [ "$val" = "1" ]; then
@@ -52,10 +52,13 @@ get_write_ups_config() {
 listen_address() {
 	local srv="$1"
 	local config_file="$2"
-	local address port
+	local address port val
 
-	config_get address "$srv" address "::1"
-	config_get port "$srv" port
+	config_get_single "$srv" address "::1"
+	address="$val"
+	config_get_single "$srv" port
+	port="$val"
+
 	if [ -n "$port" ]; then
 		printf "LISTEN %s %s\n" "$address" "$port" >>"$config_file"
 	else
@@ -67,24 +70,32 @@ listen_address() {
 srv_config() {
 	local srv="$1"
 	local config_file="$2"
-	local maxage maxconn certfile
+	local val
 
-	config_get maxage "$srv" maxage
-	[ -n "$maxage" ] && printf "MAXAGE %s\n" "$maxage" >>"$config_file"
+	config_get_single "$srv" maxage
+	[ -n "$val" ] && printf "MAXAGE %s\n" "$val" >>"$config_file"
 
 	[ -n "$STATEPATH" ] && printf "STATEPATH %s\n" "$STATEPATH" >>"$config_file"
 
-	config_get maxconn "$srv" maxconn
-	[ -n "$maxconn" ] && printf "MAXCONN %s\n" "$maxconn" >>"$config_file"
+	config_get_single "$srv" maxconn
+	[ -n "$val" ] && printf "MAXCONN %s\n" "$val" >>"$config_file"
 
-	#NOTE: certs only apply to SSL-enabled version
-	config_get certfile "$srv" certfile
-	[ -n "$certfile" ] && printf "CERTFILE %s\n" "$certfile" >>"$config_file"
+	# triggerlist is handled in nut_service.sh
+
+	# NOTE: certs only apply to SSL-enabled version
+	config_get_single "$srv" certfile
+	[ -n "$val" ] && printf "CERTFILE %s\n" "$val" >>"$config_file"
+
 }
 
 nut_user_instcmd() {
 	local val="$1"
 	local config_file="$2"
+
+	# keep only printable ASCII characters (space through ~)
+	# borrowed from ser2net in this (packages) repo
+	val="$(LC_ALL=C printf '%s' "$val" | tr -cd ' -~')"
+
 	printf "  instcmds = %s\n" "$val" >>"$config_file"
 }
 
@@ -95,13 +106,13 @@ nut_user_add() {
 	local a
 	local val
 
-	config_get val "$user" username "$user"
+	config_get_single "$user" username "$user"
 	printf "[%s]\n" "$val" >>"$config_file"
 
-	config_get val "$user" password
+	config_get_single "$user" password
 	[ -n "$val" ] && printf "  password = %s\n" "$val" >>"$config_file"
 
-	config_get val "$user" actions
+	config_get_single "$user" actions
 	set -f
 	for a in $val; do
 		printf "  actions = %s\n" "$a" >>"$config_file"
@@ -111,7 +122,7 @@ nut_user_add() {
 	# The name instcmd is use for both the UCI option and the callback function
 	config_list_foreach "$user" instcmd nut_user_instcmd "$config_file"
 
-	config_get val "$user" upsmon
+	config_get_single "$user" upsmon
 	if [ -n "$val" ]; then
 		printf "  upsmon %s\n" "$val" >>"$config_file"
 	fi
@@ -136,9 +147,25 @@ build_server_config() {
 	echo "# Config file automatically generated from UCI config" >"$UPSD_C.new"
 	restore_umask
 
-	# For nut_user and listen_address, the section type and callback function
+	# Execute in a subshell to avoid nut_server and nut_server_root becoming
+	# mixed together
+	(
+		config_load nut_server_root || {
+			log_config_load_error "nut_server_root" "nut-server" "nut-server"
+			exit 1
+		}
+
+		# For nut_user, the section type and callback function are named the same
+		config_foreach nut_user_add user "$USERS_C.new"
+	) || return 1
+
+	config_load nut_server || {
+		log_config_load_error "nut_server" "nut-server" "nut-server"
+		return 1
+	}
+
+	# For listen_address, the section type and callback function
 	# are named the same
-	config_foreach nut_user_add user "$USERS_C.new"
 	config_foreach listen_address listen_address "$UPSD_C.new"
 	if have_section_named "upsd" "upsd"; then
 		srv_config upsd "$UPSD_C.new"
@@ -158,7 +185,7 @@ build_server_config() {
 			return 1
 		fi
 	else
-		# Otherwise if nut-monitor is already configured, make sure both
+		# Otherwise if nut.conf is already configured, make sure both
 		# nut-server (this service) and nut-monitor are started
 		if grep -q '^MODE=netclient' "$NUT_CONF"; then
 			# In modern OpenWrt 'sed -i' modifies the specified files, without backup
@@ -191,14 +218,14 @@ nut_ups_defoverride() {
 	local config_file="$3"
 	local ups="$4"
 	local overtype
-	local overval
+	local val
 
 	# tr is used as global replace in variable parameter expansion is not
 	# available in ash.
 	overtype="$(printf "%s" "$overvar" | tr '_' '.')"
 
-	config_get overval "$ups" "${defover}_${overvar}"
-	[ -n "$overval" ] && printf "%s.%s = %s\n" "${defover}" "${overtype}" "$overval" >>"$config_file"
+	config_get_single "$ups" "${defover}_${overvar}"
+	[ -n "$val" ] && printf "%s.%s = %s\n" "${defover}" "${overtype}" "$val" >>"$config_file"
 }
 
 # From documentation and fixing of nut_ups_other (previously other or do_other)
@@ -218,14 +245,22 @@ nut_ups_other() {
 	local othervarflag="$2"
 	local config_file="$3"
 	local ups="$4"
-	local otherval
+	local otherval val
 
 	if [ "$othervarflag" = "otherflag" ]; then
 		config_get_bool otherval "${ups}" "${othervarflag}_${othervar}"
 		[ "$otherval" = "1" ] && printf "%s\n" "${othervar}" >>"$config_file"
 	else
-		config_get otherval "${ups}" "${othervarflag}_${othervar}"
-		[ -n "$otherval" ] && printf "%s = %s\n" "${othervar}" "$otherval" >>"$config_file"
+		config_get_single "${ups}" "${othervarflag}_${othervar}"
+
+		case "$othervar" in
+		runas)
+			log_error "An 'other' option in '$ups' had an illegal NUT option '$othervar'" nut-server-config.sh nut-server-config
+			return 1
+			;;
+		esac
+
+		[ -n "$val" ] && printf "%s = %s\n" "${othervar}" "$val" >>"$config_file"
 	fi
 }
 
@@ -369,15 +404,23 @@ build_config() {
 		return 1
 	}
 
+	build_server_config "$conf_group" || {
+		log_msg "Failed to configure upsd. Not starting." nut-server-config.sh nut-server-config warn
+		return 1
+	}
+
+	config_load nut_server || {
+		log_config_load_error "nut_server" "nut-server" "nut-server"
+		return 1
+	}
+
 	config_foreach build_global_driver_config driver_global "$UPS_C.new"
 	config_foreach build_ups_config driver "$UPS_C.new"
 
-	if ! build_server_config "$conf_group"; then
-		log_msg "Failed to configure upsd. Not starting." nut-server-config.sh nut-server-config warn
-		return 1
-	elif [ "$haveupscfg" = "false" ]; then
+	if [ "$haveupscfg" = "false" ]; then
 		log_msg "No configured UPS. Not starting upsd." nut-server-config.sh nut-server-config warn
 		return 2
 	fi
+
 	return 0
 }

--- a/net/nut/files/nut-server-migrate-root.default
+++ b/net/nut/files/nut-server-migrate-root.default
@@ -1,0 +1,99 @@
+#!/bin/sh
+# Script is sourced not executed, but shebang helps tools recognize this as
+# a shell script.
+
+# In recent (relevant) versions of shellcheck busybox is a valid shell type
+# shellcheck shell=busybox
+
+# uci-defaults script to migrate old uci config for server and driver sections,
+# to the new. Applied during install or on first boot after install, if setting on install
+# fails
+
+# IPKG_INSTROOT is intentionally only set when building an image and
+# is intentionally empty on a live OpenWrt device
+
+# Only run this uci-defaults script on a live OpenWrt device
+[ -z "${IPKG_INSTROOT}" ] || exit 0
+
+# As the uci-defaults environment in which this runs does not have logging
+# available, nor is stderr captured or displayed on the console, these messages
+# exist only to assist when debugging manual runs of the script.
+# shellcheck disable=SC2329,SC2317
+log_migration_error() {
+	local reason="$1"
+
+	printf "'%s': ERROR: '%s'\n" "nut-server-migrate-root" "$reason" >&2
+}
+
+preserve_root_commented_file="false"
+preserve_regular_commented_file="false"
+
+nut_server_root_current_trimmed="$(mktemp)"
+
+grep -Ev "((^[#]|^$))*" /etc/config/nut_server_root 2>/dev/null >>"$nut_server_root_current_trimmed"
+
+if [ -n "$(cat "$nut_server_root_current_trimmed" | tr -d '\t \r\n')" ]; then
+	printf "'%s': NOTICE: '%s'\n" "nut-server-migrate-root" "nut_server_root already exists and has configuration. Skipping migration." >&2
+	rm -f "$nut_server_root_current_trimmed" || true
+	exit 0
+fi
+
+if grep -q "^[#]" /etc/config/nut_server_root 2>/dev/null; then
+	preserve_root_commented_file="true"
+fi
+
+nut_server_dir="$(mktemp -d /tmp/tmpXXXXXX)"
+nut_server_new="$(mktemp -p "$nut_server_dir" tmp_XXXXXX)"
+nut_server_new_trimmed="$(mktemp -p "$nut_server_dir" tmp_XXXXXX)"
+nut_server_root_add="$(mktemp -p "$nut_server_dir" tmp_XXXXXX)"
+nut_server_root_add_trimmed="$(mktemp -p "$nut_server_dir" tmp_XXXXXX)"
+
+# NetXML drivers are a special case we don't handle
+grep -E "^#?(\t| )*(config(\t| )+(upsd((\t| )+('|\")?upsd('|\")?)?|driver_global|driver|listen_address)|option(\t| )+(bus|cable|community|desc|driver|ignorelb|interruptonly|interruptsize|maxreport|maxstartdelay|mfr|model|nolock|notransferoids|offdelay|ondelay|pollfreq|port|product|productid|retrydelay|sdorder|sdtime|serial|shutdown_delay|snmp_version|snmp_retries|snmp_timeout|synchronous|usd|vendor|vendorid|enable_usb_serial|address|port|maxage|maxconn|interface_reload_delay|triggerlist|chroot|maxstartdelay|maxretry|retrydelay|pollinterval|synchronous))" /etc/config/nut_server >>"$nut_server_new"
+grep -Ev "^(\t )*(#|$)" "$nut_server_new" >>"$nut_server_new_trimmed"
+
+if [ -n "$(cat "$nut_server_new_trimmed" | tr -d '\t \r\n')" ]; then
+	if ! uci -c "$(dirname "$nut_server_new")" show "$(basename "$nut_server_new")" >/dev/null; then
+		log_migration_error "FATAL: failed to create valid non-_root only nut_server config"
+		exit 1
+	fi
+elif grep -q "^#" /etc/config/nut_server 2>/dev/null; then
+	preserve_regular_commented_file="true"
+fi
+
+grep -E "^#?(\t| )*(config(\t| )+(upsd((\t| )+('|\")?upsd('|\")?)?|user)|option(\t| )+(statepath|runas|certfile|triggerlist|debug_min|certpath|certident|certrequest|disable_weak|ssl|username|password|actions|upsmon)|list instcmd)" /etc/config/nut_server >>"$nut_server_root_add"
+grep -Ev "^((\t )*(#|$)|#?(\t| )*config(\t| )+upsd((\t| )+('|\")?upsd('|\")?))" "$nut_server_root_add" >>"$nut_server_root_add_trimmed"
+
+if [ -n "$(cat "$nut_server_root_add_trimmed" | tr -d '\t \r\n')" ]; then
+	sed -i -e "s/config upsd (|'|\")upsd(|'|\")/config upsd 'upsd_root'/" "$nut_server_root_add" || {
+		log_migration_error "FATAL: failed to create new 'upsd_root' to add to nut_server_root"
+		exit 1
+	}
+fi
+
+if [ -n "$(cat "$nut_server_root_add_trimmed" | tr -d '\t \r\n')" ] || [ "$preserve_root_commented_file" = "false" ]; then
+	if ! uci -c "$(dirname "$nut_server_root_add")" show "$(basename "$nut_server_root_add")" >/dev/null; then
+		log_migration_error "FATAL: failed to create valid nut_server_root config"
+		exit 1
+	fi
+	cat "$nut_server_root_add" | uci import nut_server_root || {
+		log_migration_error "Failed to import new nut_server_root configuration"
+		exit 1
+	}
+	# Ensure we remove non-root configs from regular nut_server config
+	preserve_regular_commented_file="false"
+fi
+
+if [ -n "$(cat "$nut_server_new_trimmed" | tr -d '\t \r\n')" ] || [ "$preserve_regular_commented_file" == "false" ]; then
+	cat "$nut_server_new" >/etc/config/nut_server || {
+		log_migration_error "Failed to replace nut_server_config with new non-_root only config"
+		exit 1
+	}
+fi
+
+rm -f "$nut_server_root_add_trimmed" || true
+rm -f "$nut_server_new_trimmed" || true
+rm -f "$nut_server_root_add" || true
+rm -f "$nut_server_new" || true
+
+exit 0

--- a/net/nut/files/nut-server-service.sh.functions
+++ b/net/nut/files/nut-server-service.sh.functions
@@ -18,6 +18,22 @@
 # run by nut-server initscript prior to calling
 # ensure_usb_ups_access.
 
+config_get_ups_value() {
+	local ups="$1"
+	local option="$2"
+
+	# Execute in a subshell to avoid nut_server and nut_server_root becoming
+	# mixed together
+	(
+		config_load nut_server || {
+			log_config_load_error "nut_server" "nut-server" "nut-server"
+			exit 1
+		}
+		config_get_single "$ups" "$option"
+		printf "%s" "$val"
+	) || return 1
+}
+
 # Ensure the RUNAS user has access to the USB UPS device
 ensure_usb_ups_access() {
 	local ups="$1"
@@ -34,6 +50,7 @@ ensure_usb_ups_access() {
 	local sysfs_vendorid
 	local sysfs_productid
 	local serial
+	local val
 	# When no USB bus or USB device is found, the value returned in each case,
 	# after printf,	will be '000', which is not a valid USB bus or USB device
 	# number (i.e. it is a missing data indicator).
@@ -50,7 +67,8 @@ ensure_usb_ups_access() {
 		return 1
 	}
 
-	config_get cfg_vendorid "$ups" vendorid
+	cfg_vendorid="$(config_get_ups_value "$ups" "vendorid")" || return 1
+
 	# replacement in variable parameter expansion is supported by ash in OpenWrt
 	# since at least OpenWrt-24.10 (the previous stable release, which two
 	# versions older than the targetted next release of OpenWrt (after
@@ -73,7 +91,8 @@ ensure_usb_ups_access() {
 		;;
 	esac
 
-	config_get cfg_productid "$ups" productid
+	cfg_productid="$(config_get_ups_value "$ups" "productid")" || return 1
+
 	if [ -n "$cfg_productid" ] && ! check_valid_hex_number "${cfg_productid/0x/}"; then
 		log_error "Configured productid for '$ups' is not valid" nut-server-service.sh nut-server-service
 		return 1
@@ -92,7 +111,7 @@ ensure_usb_ups_access() {
 		;;
 	esac
 
-	config_get serial "$ups" serial
+	serial="$(config_get_ups_value "$ups" "serial")" || return 1
 
 	# $'\x' syntax is supported by ash in OpenWrt since at least OpenWrt-24.10
 	# (the previous stable release, which two versions older than the targetted

--- a/net/nut/files/nut-server.init
+++ b/net/nut/files/nut-server.init
@@ -80,6 +80,7 @@ start_ups_driver() {
 	local ups="$1"
 	local requested="$2"
 	local driver=""
+	local val
 
 	# If wanting a specific instance, only start that instance
 	if [ -n "$requested" ] && [ "$requested" != "$ups" ]; then
@@ -91,12 +92,15 @@ start_ups_driver() {
 	# driver instance (UPS) match a USB device in sysfs, set the permissions
 	# on the USB device node in /dev/bus/usb/... to allow NUT to access and
 	# control the device.
-	ensure_usb_ups_access "$ups" || return 1
-	config_get driver "$ups" driver
+	# no error exit code so we that we do not prevent other drivers from starting
+	ensure_usb_ups_access "$ups" || return 0
+	config_get_single "$ups" driver
+	driver="$val"
 
 	[ -n "$driver" ] || {
 		log_error "Missing driver when starting UPS '$ups'" "nut-server" "nut-server"
-		return 1
+		# no error exit code so we that we do not prevent other drivers from starting
+		return 0
 	}
 
 	procd_open_instance "$ups"
@@ -128,33 +132,47 @@ add_ups_driver() {
 	rc_procd start_ups_driver "$ups" "$requested"
 }
 
-have_upsd_section() {
-	have_upsd_section="true"
-}
-
 common_preconditions() {
 	local ret
 
-	# No config, or error loading config is fatal
-	config_load nut_server || {
-		log_config_load_error "nut_server" "nut-server" "nut-server"
-		exit 1
-	}
+	# We use these nearly identical code block because we need to retrieve the
+	# value of a two different variables and are avoiding use of eval
 
-	# Only find statepath and runas once per service start or reload
-	if have_section_named "upsd" "upsd"; then
-		STATEPATH="$(find_statepath "upsd" "nut_server")" || {
-			log_error_exit "Failed to determine STATEPATH" "nut-server" "nut-server"
+	# Execute in a subshell to avoid nut_server and nut_server_root becoming
+	# mixed together
+	STATEPATH="$(
+		config_load nut_server_root || {
+			log_config_load_error "nut_server_root" "nut-server" "nut-server"
+			exit 1
 		}
-		RUNAS="$(find_runas "upsd" "nut_server")" || {
-			log_error_exit "Failed to determine RUNAS" "nut-server" "nut-server"
+
+		if have_section_named "upsd" "upsd_root"; then
+			# Only find statepath once per service start or reload
+			# prints STATEPATH
+			find_statepath "upsd_root" "nut_server_root" || {
+				log_error_exit "Failed to determine STATEPATH" "nut-server" "nut-server"
+			}
+		fi
+	)" || return 1
+	STATEPATH="${STATEPATH:-/var/run/nut}"
+
+	# Execute in a subshell to avoid nut_server and nut_server_root becoming
+	# mixed together
+	RUNAS="$(
+		config_load nut_server_root || {
+			log_config_load_error "nut_server_root" "nut-server" "nut-server"
+			exit 1
 		}
-	else
-		# If there is no 'upsd' section in the nut_server config file, use
-		# default settings
-		STATEPATH=/var/run/nut
-		RUNAS=nut
-	fi
+
+		if have_section_named "upsd" "upsd_root"; then
+			# Only find runas once per service start or reload
+			# prints RUNAS
+			find_runas "upsd_root" "nut_server_root" || {
+				log_error_exit "Failed to determine RUNAS" "nut-server" "nut-server"
+			}
+		fi
+	)" || return 1
+	RUNAS="${RUNAS:-nut}"
 
 	# NUT_KILLPOWER is an external sentinel that indicates a forced shutdown
 	if [ -f "$NUT_KILLPOWER" ]; then
@@ -171,6 +189,7 @@ stop_no_longer_configured_instances() {
 	local have_driver_instance=false
 	local have_upsd_instance=false
 	local instance instances
+	local driver val
 
 	# Stop any driver instances which are no longer configured
 	# We can only reliably do this for instances managed by procd
@@ -181,7 +200,8 @@ stop_no_longer_configured_instances() {
 		if [ "$instance" = "upsd" ]; then
 			continue
 		fi
-		config_get driver "$instance" driver
+		config_get_single "$instance" driver
+		driver="$val"
 		# Only stop not configured but running instances
 		if [ -z "$driver" ] && [ -n "$instance" ] && procd_running "nut-server" "$instance" >/dev/null 2>&1; then
 			procd_kill "nut-server" "$instance" 2>&1 | logger -t nut-server
@@ -217,7 +237,7 @@ stop_no_longer_configured_instances() {
 }
 
 stop_all_instances() {
-	local instance instances
+	local instance instances driver val
 
 	set -f
 	instances="$(list_running_instances "nut-server")"
@@ -227,7 +247,8 @@ stop_all_instances() {
 		if [ "$instance" = "upsd" ]; then
 			continue
 		fi
-		config_get driver "$instance" driver
+		config_get_single "$instance" driver
+		driver="$val"
 		[ -n "$driver" ] || continue
 
 		signal_instance "$instance" "/usr/libexec/nut/${driver}" "stop" "TERM" \
@@ -252,6 +273,12 @@ service_preconditions() {
 
 		case $ret in
 		0)
+			# No config, or error loading config is fatal
+			config_load nut_server || {
+				log_config_load_error "nut_server" "nut-server" "nut-server"
+				return 1
+			}
+
 			check_interface_up "upsd" || should_start_srv=false
 			;;
 		*)
@@ -265,6 +292,12 @@ service_preconditions() {
 
 		case $ret in
 		0 | 2)
+			# No config, or error loading config is fatal
+			config_load nut_server || {
+				log_config_load_error "nut_server" "nut-server" "nut-server"
+				return 1
+			}
+
 			check_interface_up "upsd" || should_stop_srv=true
 			;;
 		*)
@@ -287,6 +320,12 @@ service_preconditions() {
 
 	# Stop all instances, remove config, and exit with error, if should_stop_srv is true
 	if [ "$should_stop_srv" = "true" ]; then
+		# No config, or error loading config is fatal
+		config_load nut_server || {
+			log_config_load_error "nut_server" "nut-server" "nut-server"
+			exit 1
+		}
+
 		stop_all_instances || true
 		remove_var_config
 		return $ret
@@ -337,14 +376,15 @@ remove_var_config() {
 stop_ups_driver() {
 	local ups="$1" # The ups (driver instance)
 	local requested="$2"
-	local driver
+	local driver val
 
 	# If wanting a specific instance, only stop it
 	if [ -n "$requested" ] && [ "$requested" != "$ups" ]; then
 		return 0
 	fi
 
-	config_get driver "$ups" driver
+	config_get_single "$ups" driver
+	driver="$val"
 
 	if [ -z "$driver" ]; then
 		log_error "No driver specified for UPS '$ups'. Attempting procd_kill." "nut-server" "nut-server"
@@ -365,7 +405,7 @@ stop_ups_driver() {
 reload_ups_driver() {
 	local ups="$1"
 	local requested="$2"
-	local driver
+	local driver val
 
 	# If wanting a specific instance, only reload that instance
 	if [ -n "$requested" ] && [ "$requested" != "$ups" ]; then
@@ -377,7 +417,8 @@ reload_ups_driver() {
 		return 0
 	fi
 
-	config_get driver "$ups" driver
+	config_get_single "$ups" driver
+	driver="$val"
 
 	# Try to reload, otherwise exit politely
 	if procd_running "nut-server" "$ups"; then
@@ -405,13 +446,26 @@ stop_service_if_no_instances() {
 	fi
 }
 
+loop_through_drivers() {
+	local action="$1"
+	shift || true
+
+	config_load nut_server || {
+		log_config_load_error "nut_server" "nut-server" "nut-server"
+		return 1
+	}
+
+	config_foreach "$action" driver "$@" || return 1
+}
+
 # Stop or reload active instances
 manage_instances() {
 	local action="$1"
+	local ret
 
 	case "$action" in
 	start)
-		config_foreach start_ups_driver driver
+		loop_through_drivers start_ups_driver || return 1
 		;;
 	reload)
 		if service_active_no_instances "nut-server"; then
@@ -420,15 +474,34 @@ manage_instances() {
 		if procd_running "nut-server" upsd >/dev/null 2>&1; then
 			signal_instance "upsd" "upsd" "reload" "HUP" "${STATEPATH}/upsd.pid" "" "nut-server" "procd_kill" "nut-server" "upsd"
 		fi
-		config_foreach reload_ups_driver driver
+		loop_through_drivers reload_ups_driver
+		ret=$?
+
+		# No config, or error loading config is fatal
+		config_load nut_server || {
+			log_config_load_error "nut_server" "nut-server" "nut-server"
+			return 1
+		}
+
 		stop_no_longer_configured_instances
+		if [ $ret != "0" ]; then
+			return 1
+		fi
 		;;
 	stop)
+		config_load nut_server || {
+			log_config_load_error "nut_server" "nut-server" "nut-server"
+			return 1
+		}
 		stop_all_instances
 		stop_service_if_no_instances
 		remove_var_config
 		;;
 	stop-instances)
+		config_load nut_server || {
+			log_config_load_error "nut_server" "nut-server" "nut-server"
+			return 1
+		}
 		stop_all_instances
 		remove_var_config
 		;;
@@ -452,10 +525,14 @@ manage_service() {
 			service_preconditions "$action"
 			ret=$?
 
+			config_load nut_server || {
+				log_config_load_error "nut_server" "nut-server" "nut-server"
+				return 1
+			}
 			stop_no_longer_configured_instances
 
 			if [ "$ret" = "0" ]; then
-				manage_instances start
+				manage_instances start || return 1
 			else
 				return 1
 			fi
@@ -467,6 +544,11 @@ manage_service() {
 			if [ "$ret" = "0" ]; then
 				start_server_instance
 			fi
+
+			config_load nut_server || {
+				log_config_load_error "nut_server" "nut-server" "nut-server"
+				return 1
+			}
 			stop_no_longer_configured_instances
 
 			return $ret
@@ -476,10 +558,13 @@ manage_service() {
 			service_preconditions "$action"
 			ret=$?
 			if [ "$ret" = "0" ]; then
-				config_foreach start_ups_driver driver "$instance"
+				loop_through_drivers start_ups_driver driver "$instance"
 			fi
+			config_load nut_server || {
+				log_config_load_error "nut_server" "nut-server" "nut-server"
+				return 1
+			}
 			stop_no_longer_configured_instances
-
 			return $ret
 			;;
 		esac
@@ -490,8 +575,13 @@ manage_service() {
 
 		if [ "$ret" != "1" ]; then
 			manage_instances reload
+			ret=$?
 		fi
 
+		config_load nut_server || {
+			log_config_load_error "nut_server" "nut-server" "nut-server"
+			return 1
+		}
 		stop_no_longer_configured_instances
 
 		if [ "$ret" = "1" ]; then
@@ -511,7 +601,7 @@ manage_service() {
 			;;
 		*)
 			# We only handle the first parameter, so do not pass in all parameters
-			config_foreach stop_ups_driver driver "$instance"
+			loop_through_drivers stop_ups_driver driver "$instance"
 			stop_service_if_no_instances
 			;;
 		esac
@@ -528,7 +618,7 @@ manage_service() {
 			;;
 		*)
 			# We only handle the first parameter, so do not pass in all parameters
-			config_foreach stop_ups_driver driver "$instance"
+			loop_through_drivers stop_ups_driver driver "$instance"
 			;;
 		esac
 		;;
@@ -551,13 +641,15 @@ stop_service() {
 }
 
 service_triggers() {
+	local interface_reload_delay val
 	# No config, or error loading config is fatal
 	config_load nut_server || {
 		log_config_load_error "nut_server" "nut-server" "nut-server"
 		exit 1
 	}
 
-	config_get interface_reload_delay upsd interface_reload_delay $DEFAULT_PROCD_INTERFACE_RELOAD_DELAY
+	config_get_single upsd interface_reload_delay "$DEFAULT_PROCD_INTERFACE_RELOAD_DELAY"
+	interface_reload_delay="$val"
 	if ! check_unsigned_int "$interface_reload_delay" || [ -z "$interface_reload_delay" ]; then
 		log_msg "interface_reload_delay must be an unsigned integer" nut-server nut-server warn
 		interface_reload_delay="$DEFAULT_PROCD_INTERFACE_RELOAD_DELAY"
@@ -567,4 +659,5 @@ service_triggers() {
 		log_error "Failed to add interface triggers" nut-server nut-server
 	}
 	procd_add_reload_trigger "nut_server"
+	procd_add_reload_trigger "nut_server_root"
 }

--- a/net/nut/files/nut-server.init
+++ b/net/nut/files/nut-server.init
@@ -80,6 +80,7 @@ start_ups_driver() {
 	local ups="$1"
 	local requested="$2"
 	local driver=""
+	local val
 
 	# If wanting a specific instance, only start that instance
 	if [ -n "$requested" ] && [ "$requested" != "$ups" ]; then
@@ -91,12 +92,15 @@ start_ups_driver() {
 	# driver instance (UPS) match a USB device in sysfs, set the permissions
 	# on the USB device node in /dev/bus/usb/... to allow NUT to access and
 	# control the device.
-	ensure_usb_ups_access "$ups" || return 1
-	config_get driver "$ups" driver
+	# no error exit code so we that we do not prevent other drivers from starting
+	ensure_usb_ups_access "$ups" || return 0
+	config_get_single "$ups" driver
+	driver="$val"
 
 	[ -n "$driver" ] || {
 		log_error "Missing driver when starting UPS '$ups'" "nut-server" "nut-server"
-		return 1
+		# no error exit code so we that we do not prevent other drivers from starting
+		return 0
 	}
 
 	procd_open_instance "$ups"
@@ -128,33 +132,37 @@ add_ups_driver() {
 	rc_procd start_ups_driver "$ups" "$requested"
 }
 
-have_upsd_section() {
-	have_upsd_section="true"
-}
-
 common_preconditions() {
 	local ret
 
-	# No config, or error loading config is fatal
-	config_load nut_server || {
-		log_config_load_error "nut_server" "nut-server" "nut-server"
-		exit 1
-	}
+	# We use these nearly identical code block because we need to retrieve the
+	# value of a two different variables and are avoiding use of eval
 
-	# Only find statepath and runas once per service start or reload
-	if have_section_named "upsd" "upsd"; then
-		STATEPATH="$(find_statepath "upsd" "nut_server")" || {
-			log_error_exit "Failed to determine STATEPATH" "nut-server" "nut-server"
-		}
-		RUNAS="$(find_runas "upsd" "nut_server")" || {
-			log_error_exit "Failed to determine RUNAS" "nut-server" "nut-server"
-		}
-	else
-		# If there is no 'upsd' section in the nut_server config file, use
-		# default settings
-		STATEPATH=/var/run/nut
-		RUNAS=nut
+	# Execute in a subshell to avoid nut_server and nut_server_root becoming
+	# mixed together
+	# Only find statepath once per service start or reload
+	STATEPATH="$(find_statepath "upsd_root" "nut_server_root")"
+	ret=$?
+
+	if [ "$ret" -ne 0 ] || [ -z "$STATEPATH" ]; then
+		log_error_exit "Failed to determine STATEPATH" "nut-server" "nut-server"
+		return 1
 	fi
+
+	export STATEPATH
+
+	# Execute in a subshell to avoid nut_server and nut_server_root becoming
+	# mixed together
+	# Only find runas once per service start or reload
+	RUNAS="$(find_runas "upsd_root" "nut_server_root")"
+	ret=$?
+
+	if [ "$ret" -ne 0 ] || [ -z "$RUNAS" ]; then
+		log_error_exit "Failed to determine RUNAS" "nut-server" "nut-server"
+		return 1
+	fi
+
+	export RUNAS
 
 	# NUT_KILLPOWER is an external sentinel that indicates a forced shutdown
 	if [ -f "$NUT_KILLPOWER" ]; then
@@ -171,6 +179,7 @@ stop_no_longer_configured_instances() {
 	local have_driver_instance=false
 	local have_upsd_instance=false
 	local instance instances
+	local driver val
 
 	# Stop any driver instances which are no longer configured
 	# We can only reliably do this for instances managed by procd
@@ -181,7 +190,8 @@ stop_no_longer_configured_instances() {
 		if [ "$instance" = "upsd" ]; then
 			continue
 		fi
-		config_get driver "$instance" driver
+		config_get_single "$instance" driver
+		driver="$val"
 		# Only stop not configured but running instances
 		if [ -z "$driver" ] && [ -n "$instance" ] && procd_running "nut-server" "$instance" >/dev/null 2>&1; then
 			procd_kill "nut-server" "$instance" 2>&1 | logger -t nut-server
@@ -217,7 +227,7 @@ stop_no_longer_configured_instances() {
 }
 
 stop_all_instances() {
-	local instance instances
+	local instance instances driver val
 
 	set -f
 	instances="$(list_running_instances "nut-server")"
@@ -227,7 +237,8 @@ stop_all_instances() {
 		if [ "$instance" = "upsd" ]; then
 			continue
 		fi
-		config_get driver "$instance" driver
+		config_get_single "$instance" driver
+		driver="$val"
 		[ -n "$driver" ] || continue
 
 		signal_instance "$instance" "/usr/libexec/nut/${driver}" "stop" "TERM" \
@@ -252,6 +263,12 @@ service_preconditions() {
 
 		case $ret in
 		0)
+			# No config, or error loading config is fatal
+			config_load nut_server || {
+				log_config_load_error "nut_server" "nut-server" "nut-server"
+				return 1
+			}
+
 			check_interface_up "upsd" || should_start_srv=false
 			;;
 		*)
@@ -265,6 +282,12 @@ service_preconditions() {
 
 		case $ret in
 		0 | 2)
+			# No config, or error loading config is fatal
+			config_load nut_server || {
+				log_config_load_error "nut_server" "nut-server" "nut-server"
+				return 1
+			}
+
 			check_interface_up "upsd" || should_stop_srv=true
 			;;
 		*)
@@ -287,6 +310,12 @@ service_preconditions() {
 
 	# Stop all instances, remove config, and exit with error, if should_stop_srv is true
 	if [ "$should_stop_srv" = "true" ]; then
+		# No config, or error loading config is fatal
+		config_load nut_server || {
+			log_config_load_error "nut_server" "nut-server" "nut-server"
+			exit 1
+		}
+
 		stop_all_instances || true
 		remove_var_config
 		return $ret
@@ -337,14 +366,15 @@ remove_var_config() {
 stop_ups_driver() {
 	local ups="$1" # The ups (driver instance)
 	local requested="$2"
-	local driver
+	local driver val
 
 	# If wanting a specific instance, only stop it
 	if [ -n "$requested" ] && [ "$requested" != "$ups" ]; then
 		return 0
 	fi
 
-	config_get driver "$ups" driver
+	config_get_single "$ups" driver
+	driver="$val"
 
 	if [ -z "$driver" ]; then
 		log_error "No driver specified for UPS '$ups'. Attempting procd_kill." "nut-server" "nut-server"
@@ -365,7 +395,7 @@ stop_ups_driver() {
 reload_ups_driver() {
 	local ups="$1"
 	local requested="$2"
-	local driver
+	local driver val
 
 	# If wanting a specific instance, only reload that instance
 	if [ -n "$requested" ] && [ "$requested" != "$ups" ]; then
@@ -377,7 +407,8 @@ reload_ups_driver() {
 		return 0
 	fi
 
-	config_get driver "$ups" driver
+	config_get_single "$ups" driver
+	driver="$val"
 
 	# Try to reload, otherwise exit politely
 	if procd_running "nut-server" "$ups"; then
@@ -405,13 +436,26 @@ stop_service_if_no_instances() {
 	fi
 }
 
+loop_through_drivers() {
+	local action="$1"
+	shift || true
+
+	config_load nut_server || {
+		log_config_load_error "nut_server" "nut-server" "nut-server"
+		return 1
+	}
+
+	config_foreach "$action" driver "$@" || return 1
+}
+
 # Stop or reload active instances
 manage_instances() {
 	local action="$1"
+	local ret
 
 	case "$action" in
 	start)
-		config_foreach start_ups_driver driver
+		loop_through_drivers start_ups_driver || return 1
 		;;
 	reload)
 		if service_active_no_instances "nut-server"; then
@@ -420,15 +464,34 @@ manage_instances() {
 		if procd_running "nut-server" upsd >/dev/null 2>&1; then
 			signal_instance "upsd" "upsd" "reload" "HUP" "${STATEPATH}/upsd.pid" "" "nut-server" "procd_kill" "nut-server" "upsd"
 		fi
-		config_foreach reload_ups_driver driver
+		loop_through_drivers reload_ups_driver
+		ret=$?
+
+		# No config, or error loading config is fatal
+		config_load nut_server || {
+			log_config_load_error "nut_server" "nut-server" "nut-server"
+			return 1
+		}
+
 		stop_no_longer_configured_instances
+		if [ $ret != "0" ]; then
+			return 1
+		fi
 		;;
 	stop)
+		config_load nut_server || {
+			log_config_load_error "nut_server" "nut-server" "nut-server"
+			return 1
+		}
 		stop_all_instances
 		stop_service_if_no_instances
 		remove_var_config
 		;;
 	stop-instances)
+		config_load nut_server || {
+			log_config_load_error "nut_server" "nut-server" "nut-server"
+			return 1
+		}
 		stop_all_instances
 		remove_var_config
 		;;
@@ -452,10 +515,14 @@ manage_service() {
 			service_preconditions "$action"
 			ret=$?
 
+			config_load nut_server || {
+				log_config_load_error "nut_server" "nut-server" "nut-server"
+				return 1
+			}
 			stop_no_longer_configured_instances
 
 			if [ "$ret" = "0" ]; then
-				manage_instances start
+				manage_instances start || return 1
 			else
 				return 1
 			fi
@@ -467,6 +534,11 @@ manage_service() {
 			if [ "$ret" = "0" ]; then
 				start_server_instance
 			fi
+
+			config_load nut_server || {
+				log_config_load_error "nut_server" "nut-server" "nut-server"
+				return 1
+			}
 			stop_no_longer_configured_instances
 
 			return $ret
@@ -476,10 +548,13 @@ manage_service() {
 			service_preconditions "$action"
 			ret=$?
 			if [ "$ret" = "0" ]; then
-				config_foreach start_ups_driver driver "$instance"
+				loop_through_drivers start_ups_driver "$instance"
 			fi
+			config_load nut_server || {
+				log_config_load_error "nut_server" "nut-server" "nut-server"
+				return 1
+			}
 			stop_no_longer_configured_instances
-
 			return $ret
 			;;
 		esac
@@ -490,8 +565,13 @@ manage_service() {
 
 		if [ "$ret" != "1" ]; then
 			manage_instances reload
+			ret=$?
 		fi
 
+		config_load nut_server || {
+			log_config_load_error "nut_server" "nut-server" "nut-server"
+			return 1
+		}
 		stop_no_longer_configured_instances
 
 		if [ "$ret" = "1" ]; then
@@ -511,7 +591,7 @@ manage_service() {
 			;;
 		*)
 			# We only handle the first parameter, so do not pass in all parameters
-			config_foreach stop_ups_driver driver "$instance"
+			loop_through_drivers stop_ups_driver driver "$instance"
 			stop_service_if_no_instances
 			;;
 		esac
@@ -528,7 +608,7 @@ manage_service() {
 			;;
 		*)
 			# We only handle the first parameter, so do not pass in all parameters
-			config_foreach stop_ups_driver driver "$instance"
+			loop_through_drivers stop_ups_driver "$instance"
 			;;
 		esac
 		;;
@@ -551,13 +631,15 @@ stop_service() {
 }
 
 service_triggers() {
+	local interface_reload_delay val
 	# No config, or error loading config is fatal
 	config_load nut_server || {
 		log_config_load_error "nut_server" "nut-server" "nut-server"
 		exit 1
 	}
 
-	config_get interface_reload_delay upsd interface_reload_delay $DEFAULT_PROCD_INTERFACE_RELOAD_DELAY
+	config_get_single upsd interface_reload_delay "$DEFAULT_PROCD_INTERFACE_RELOAD_DELAY"
+	interface_reload_delay="$val"
 	if ! check_unsigned_int "$interface_reload_delay" || [ -z "$interface_reload_delay" ]; then
 		log_msg "interface_reload_delay must be an unsigned integer" nut-server nut-server warn
 		interface_reload_delay="$DEFAULT_PROCD_INTERFACE_RELOAD_DELAY"
@@ -567,4 +649,5 @@ service_triggers() {
 		log_error "Failed to add interface triggers" nut-server nut-server
 	}
 	procd_add_reload_trigger "nut_server"
+	procd_add_reload_trigger "nut_server_root"
 }

--- a/net/nut/files/nut-server.init
+++ b/net/nut/files/nut-server.init
@@ -75,6 +75,77 @@ USE_PROCD=1
 
 restore_umask_on_exit
 
+rc_procd_service() {
+	if ! procd_running "nut-server"; then
+		method="set"
+	else
+		method="add"
+	fi
+	procd_open_service nut-server
+	"$@"
+	procd_close_service "$method"
+}
+
+has_running_driver() {
+	set -f
+	instances="$(list_running_instances "nut-server")"
+	[ -n "$instances" ] || return 0
+	for instance in $instances; do
+		if [ "$instance" = "upsd" ]; then
+			have_upsd_instance="true"
+			continue
+		fi
+		have_driver_instance="true"
+		break
+	done
+	set +f
+}
+
+start_server_service() {
+	procd_open_instance upsd
+	procd_set_param respawn
+	procd_set_param stderr 1
+	procd_set_param stdout 1
+	procd_set_param env NUT_DEBUG_SYSLOG="stderr"
+	procd_set_param env NUT_QUIET_INIT_UPSNOTIFY=true
+	procd_set_param env NUT_STATEPATH="$STATEPATH"
+	procd_set_param command /usr/sbin/upsd
+	procd_append_param command -FF
+	procd_append_param command -u "$RUNAS"
+	procd_close_instance
+}
+
+# Start upsd instance
+start_server_instance() {
+	if [ -f "$NUT_KILLPOWER" ]; then
+		return 1
+	fi
+
+	local have_driver_instance="false"
+	local have_upsd_instance="false"
+	has_running_driver
+
+	# upsd will crash if started with no available UPS, so only start if
+	# we have one, and we do not already have a upsd instance
+	if [ "$have_driver_instance" = "true" ] && [ "$have_upsd_instance" = "false" ]; then
+		rc_procd_service start_server_service
+	fi
+}
+
+start_ups_service() {
+	procd_open_instance "$ups"
+	procd_set_param respawn
+	procd_set_param stderr 1
+	procd_set_param stdout 1
+	procd_set_param env NUT_DEBUG_SYSLOG="stderr"
+	procd_set_param env NUT_QUIET_INIT_UPSNOTIFY=true
+	procd_set_param env NUT_STATEPATH="${STATEPATH}"
+	procd_set_param command "/usr/libexec/nut/${driver}"
+	procd_append_param command -FF -a "$ups"
+	procd_append_param command -u "$RUNAS"
+	procd_close_instance
+}
+
 # Start a ups driver instance
 start_ups_driver() {
 	local ups="$1"
@@ -93,7 +164,11 @@ start_ups_driver() {
 	# on the USB device node in /dev/bus/usb/... to allow NUT to access and
 	# control the device.
 	# no error exit code so we that we do not prevent other drivers from starting
-	ensure_usb_ups_access "$ups" || return 0
+	ensure_usb_ups_access "$ups" || {
+		usb_ups_access_error="true"
+		log_error "Error enabling USB access for UPS '$ups'" "nut-server" "nut-server"
+		return 0
+	}
 	config_get_single "$ups" driver
 	driver="$val"
 
@@ -102,34 +177,7 @@ start_ups_driver() {
 		# no error exit code so we that we do not prevent other drivers from starting
 		return 0
 	}
-
-	procd_open_instance "$ups"
-	procd_set_param respawn
-	procd_set_param stderr 1
-	procd_set_param stdout 1
-	procd_set_param env NUT_DEBUG_SYSLOG="stderr"
-	procd_set_param env NUT_QUIET_INIT_UPSNOTIFY=true
-	procd_set_param env NUT_STATEPATH="${STATEPATH}"
-	procd_set_param command "/usr/libexec/nut/${driver}"
-	procd_append_param command -FF -a "$ups"
-	procd_append_param command -u "$RUNAS"
-	procd_close_instance
-
-	# If upsd is running, reload it to pick up new driver
-	if procd_running "nut-server" "upsd" >/dev/null 2>&1; then
-		signal_instance "upsd" "upsd" "reload" "HUP" "${STATEPATH}/upsd.pid" "" "nut-server"
-	else
-		start_server_instance
-	fi
-}
-
-# On reload, we need to use rpc_procd to add an instance to an already running
-# service, as procd_open_service is not called by default when doing a
-# reload vs start
-add_ups_driver() {
-	local ups="$1"
-	local requested="$2"
-	rc_procd start_ups_driver "$ups" "$requested"
+	rc_procd_service start_ups_service "$@"
 }
 
 common_preconditions() {
@@ -176,8 +224,9 @@ common_preconditions() {
 }
 
 stop_no_longer_configured_instances() {
-	local have_driver_instance=false
-	local have_upsd_instance=false
+	local have_driver_instance="false"
+	local have_upsd_instance="false"
+	local had_running_instance="false"
 	local instance instances
 	local driver val
 
@@ -190,39 +239,32 @@ stop_no_longer_configured_instances() {
 		if [ "$instance" = "upsd" ]; then
 			continue
 		fi
+		had_running_instance="true"
 		config_get_single "$instance" driver
 		driver="$val"
 		# Only stop not configured but running instances
 		if [ -z "$driver" ] && [ -n "$instance" ] && procd_running "nut-server" "$instance" >/dev/null 2>&1; then
-			procd_kill "nut-server" "$instance" 2>&1 | logger -t nut-server
+			log_msg "Stopping no longer configured ups '$instance'" "nut-server" "nut-server" notice
+			procd_kill "nut-server" "$instance"
 		fi
 	done
 	set +f
 
 	# Need to stop drivers before stopping upsd
-	# The second loop is required in case some instances failed to stop in the
-	# first loop (so we cannot just track instances in the above loop).
+	# The has_running_driver check is required in case some instances failed to
+	# stop in the first loop (so we cannot just track instances in the above loop).
 	# In addition, it is possible for hotplug triggered drivers start to start
-	# instances between the stop above, and this loop.
-	set -f
-	instances="$(list_running_instances "nut-server")"
-	[ -n "$instances" ] || return 0
-	for instance in $instances; do
-		if [ "$instance" = "upsd" ]; then
-			have_upsd_instance="true"
-			continue
-		fi
-		have_driver_instance="true"
-		break
-	done
-	set +f
+	# instances between the stop above, and this function.
+	has_running_driver
 
 	# If we have no UPS instances we must stop upsd or it will crash
 	# The "nut-server" service remains active and will 'see' configuration
 	# changes and execute reload_service when they are detected
-	if [ "$have_upsd_instance" = "true" ] && [ "$have_driver_instance" = "false" ]; then
-		# stop_server_instance
+	if [ "$have_upsd_instance" = "true" ] && [ "$have_driver_instance" = "false" ] && [ "$had_running_instance" = "true" ]; then
+		log_msg "Stopping upsd because no driver instances configured" "nut-server" "nut-server" "notice"
 		signal_instance "upsd" "upsd" "stop" "TERM" "${STATEPATH}/upsd.pid" "" "nut-server" "procd_kill" "nut-server" "upsd"
+	elif [ "$have_upsd_instance" = "false" ] && [ "$have_driver_instance" = "true" ]; then
+		start_server_instance
 	fi
 }
 
@@ -334,25 +376,6 @@ service_preconditions() {
 	return 0
 }
 
-# Start upsd instance
-start_server_instance() {
-	if [ -f "$NUT_KILLPOWER" ]; then
-		return 1
-	fi
-
-	procd_open_instance upsd
-	procd_set_param respawn
-	procd_set_param stderr 1
-	procd_set_param stdout 1
-	procd_set_param env NUT_DEBUG_SYSLOG="stderr"
-	procd_set_param env NUT_QUIET_INIT_UPSNOTIFY=true
-	procd_set_param env NUT_STATEPATH="$STATEPATH"
-	procd_set_param command /usr/sbin/upsd
-	procd_append_param command -FF
-	procd_append_param command -u "$RUNAS"
-	procd_close_instance
-}
-
 remove_var_config() {
 	for rm_file in "$USERS_C" "$UPS_C" "$UPSD_C" \
 		"$USERS_C.new" "$UPS_C.new" "$UPSD_C.new"; do
@@ -421,8 +444,13 @@ reload_ups_driver() {
 	# If the driver instance (UPS) was terminated, or stopped 'naturally',
 	# start it up again
 	if ! procd_running "nut-server" "$ups" >/dev/null 2>&1; then
-		add_ups_driver "$ups" "$ups"
+		start_ups_driver "$ups" "$ups"
+		start_server_instance
 	fi
+
+	# If the server instance (upsd) was terminated, or stopped 'naturally',
+	# start it up again
+	start_server_instance
 	return 0
 }
 
@@ -456,24 +484,22 @@ manage_instances() {
 	case "$action" in
 	start)
 		loop_through_drivers start_ups_driver || return 1
+		start_server_instance
 		;;
 	reload)
 		if service_active_no_instances "nut-server"; then
 			log_msg "nut-server active with no instances. Reloading." "nut-server" "nut-server" "info"
 		fi
-		if procd_running "nut-server" upsd >/dev/null 2>&1; then
-			signal_instance "upsd" "upsd" "reload" "HUP" "${STATEPATH}/upsd.pid" "" "nut-server" "procd_kill" "nut-server" "upsd"
-		fi
+
 		loop_through_drivers reload_ups_driver
 		ret=$?
 
-		# No config, or error loading config is fatal
-		config_load nut_server || {
-			log_config_load_error "nut_server" "nut-server" "nut-server"
-			return 1
-		}
+		if procd_running "nut-server" upsd >/dev/null 2>&1; then
+			signal_instance "upsd" "upsd" "reload" "HUP" "${STATEPATH}/upsd.pid" "" "nut-server" "procd_kill" "nut-server" "upsd"
+		fi
 
 		stop_no_longer_configured_instances
+
 		if [ $ret != "0" ]; then
 			return 1
 		fi
@@ -510,16 +536,14 @@ manage_service() {
 
 	case "$action" in
 	start)
+		service_preconditions "$action"
+		ret=$?
 		case "$instance" in
 		"")
-			service_preconditions "$action"
-			ret=$?
-
 			config_load nut_server || {
 				log_config_load_error "nut_server" "nut-server" "nut-server"
 				return 1
 			}
-			stop_no_longer_configured_instances
 
 			if [ "$ret" = "0" ]; then
 				manage_instances start || return 1
@@ -529,8 +553,6 @@ manage_service() {
 			;;
 		# We only start one service (upsd or one driver) from a given invocation
 		upsd)
-			service_preconditions "$action"
-			ret=$?
 			if [ "$ret" = "0" ]; then
 				start_server_instance
 			fi
@@ -539,25 +561,21 @@ manage_service() {
 				log_config_load_error "nut_server" "nut-server" "nut-server"
 				return 1
 			}
-			stop_no_longer_configured_instances
-
-			return $ret
 			;;
 		# We only start one service (upsd or one driver) from a given invocation
 		*)
-			service_preconditions "$action"
-			ret=$?
 			if [ "$ret" = "0" ]; then
 				loop_through_drivers start_ups_driver "$instance"
+				start_server_instance
 			fi
 			config_load nut_server || {
 				log_config_load_error "nut_server" "nut-server" "nut-server"
 				return 1
 			}
-			stop_no_longer_configured_instances
-			return $ret
 			;;
 		esac
+		stop_no_longer_configured_instances
+		return $ret
 		;;
 	reload)
 		service_preconditions "$action"
@@ -567,12 +585,6 @@ manage_service() {
 			manage_instances reload
 			ret=$?
 		fi
-
-		config_load nut_server || {
-			log_config_load_error "nut_server" "nut-server" "nut-server"
-			return 1
-		}
-		stop_no_longer_configured_instances
 
 		if [ "$ret" = "1" ]; then
 			return 1
@@ -628,6 +640,20 @@ reload_service() {
 # Stop NUT drivers and upsd (NUT server)
 stop_service() {
 	manage_service stop "$@"
+}
+
+boot() {
+	manage_service start
+	ret=$?
+	# Allow hotplug events after init
+	touch "$NUT_HOTPLUG_BOOT_COMPLETE_PATH"
+	[ "$ret" -eq 0 ] || return 1
+	local usb_ups_access_error="false"
+	loop_through_drivers start_ups_driver
+	[ "$usb_ups_access_error" = "false" ] || return 1
+	sleep 1
+	start_server_instance "upsd" || return 1
+	return 0
 }
 
 service_triggers() {

--- a/net/nut/files/nut-service.sh.functions
+++ b/net/nut/files/nut-service.sh.functions
@@ -251,9 +251,10 @@ add_interface_triggers() {
 		shift 3
 	fi
 
-	local interfaces interface trigger_failed
+	local interfaces interface trigger_failed val
 
-	config_get interfaces "$section" triggerlist
+	config_get_single "$section" triggerlist
+	interfaces="$val"
 
 	if [ -n "$interfaces" ] && [ "$interfaces" != "all" ]; then
 		set -f

--- a/net/nut/files/nut-service.sh.functions
+++ b/net/nut/files/nut-service.sh.functions
@@ -21,6 +21,7 @@ NUT_KILLPOWER="/var/run/killpower"
 
 # Disable NUT hotplug path
 NUT_DISABLE_HOTPLUG_PATH="/var/run/nut/disable-hotplug"
+NUT_HOTPLUG_BOOT_COMPLETE_PATH="/var/run/nut-hotplug-boot-complete"
 
 # Fallback STATEPATH setting
 NUT_BASE_STATEPATH="/var/run/nut"
@@ -47,6 +48,10 @@ allow_hotplug_restart() {
 	# Disable hotplug path; a sentinel created by config
 	# or nutshutdown
 	[ ! -f "$NUT_DISABLE_HOTPLUG_PATH" ] || return 1
+
+	# Initial boot complete; NUT hotplug allowed sentinel
+	# Created by nut-server initscript
+	[ -f "$NUT_HOTPLUG_BOOT_COMPLETE_PATH" ] || return 1
 
 	return 0
 }

--- a/net/nut/files/nut_cgi
+++ b/net/nut/files/nut_cgi
@@ -3,6 +3,3 @@
 #	option hostname localhost
 #	option port <number> # optional port number
 #	option displayname "Display Name"
-
-config upsset
-	option enable 0

--- a/net/nut/files/nut_cgi_root
+++ b/net/nut/files/nut_cgi_root
@@ -1,0 +1,2 @@
+config upsset
+	option enable 0

--- a/net/nut/files/nut_cgi_root
+++ b/net/nut/files/nut_cgi_root
@@ -1,0 +1,7 @@
+# Although the settings in this file affect security, the values of
+# settings themselves are not sensitive, therefore this file only
+# needs to be read-only for group and other, not accessible only by root.
+# That is permissions of 0644 are sufficiently secure.
+
+config upsset
+	option enable 0

--- a/net/nut/files/nut_monitor
+++ b/net/nut/files/nut_monitor
@@ -11,20 +11,17 @@
 # except /path/to/dir values which have no default
 # and defaultnotify which is an UCI specific setting
 #config upsmon upsmon
-#	option runas nutmon
 #	option deadtime 15
 #	option finaldelay 5 # final delay
 #	option hostsync 15
 #	option minsupplies 1
 #	option nocommwarntime 300 # no communications warn time
 #	option pollfaillogthrottlemax -1
-#	option notifycmd '/path/to/cmd'
 #	option pollfreq 5
 #	option pollfreqalert 5
 #	option offduration 30
 #	option overduration -1
 #	option oblbduration 0
-#	option shutdowncmd '/usr/sbin/nutshutdown'
 #	option rbwarntime 43200 # replace battery warn time
 #	option alarmcritical 1
 #	option shutdownexit 0
@@ -32,51 +29,5 @@
 #	option certverify 0
 #	option forcessl 0
 #	option debugmin 0
-#	option defaultnotify SYSLOG
 #	option interface_reload_delay 3000 # in milliseconds
 #	option triggerlist all # not configured by default
-
-#config monitor
-#	option type primary
-#	option upsname upsname
-#	option hostname localhost
-#	option port # optional port number
-#	option powervalue 1
-#	option username upsuser
-#	option password upspassword
-
-#config monitor
-#	option type secondary
-#	option upsname upsname
-#	option hostname localhost
-#	option port # optional port number
-#	option powervalue 1
-#	option username upsuser
-#	option password upspassword
-
-# notification config sections must be named with an uppercase valid
-# NUT event type, from the list at
-# https://networkupstools.org/docs/man/upsmon.conf.html
-#
-# Empty notifications sections will emit a default NOTIFYFLAG <event> SYSLOG
-# line, as otherwise the NUT default of SYSLOG+WALL would be used, and the
-# `wall` command is not present in OpenWrt by default
-
-#config notifications 'COMMOK'
-#	option message "Communications with UPS %s established"
-#	option flag "SYSLOG"
-
-#config notifications 'COMMBAD'
-#	option message "Communications with UPS %s lost"
-#	option flag "SYSLOG+EXEC"
-
-#config notifications 'ONLINE'
-#	option flag "IGNORE"
-
-#config notifications 'ONBATT'
-#	option message "UPS %s is on battery power"
-#	option flag "SYSLOG+EXEC"
-
-#config notifications 'SHUTDOWN'
-#	option message "UPS %s shutting down"
-#	option flag "SYSLOG+EXEC"

--- a/net/nut/files/nut_monitor
+++ b/net/nut/files/nut_monitor
@@ -1,91 +1,26 @@
-# **NOTE**: Due to the presence of passwords in this file, restrictive file
-# permissions on this file in actual use in /etc/config/nut_monitor should be
-# used. For example:
-# chown root:root /etc/config/nut_monitor
-# chmod 0600 /etc/config/nut_monitor
-
-# We only support one instance of upsmon, and its UCI
-# section must be named 'upsmon'
+# We only support one instance of upsmon, and its regular
+# UCI section must be named 'upsmon' in this file.
+# The security-sensitive section for upsmon must in the
+# nut_monitor_root config file and named 'upsmon_root'
 
 # defaults for the upsmon section are compile time defaults
 # except /path/to/dir values which have no default
 # and defaultnotify which is an UCI specific setting
 #config upsmon upsmon
-#	option runas nutmon
 #	option deadtime 15
 #	option finaldelay 5 # final delay
 #	option hostsync 15
 #	option minsupplies 1
 #	option nocommwarntime 300 # no communications warn time
 #	option pollfaillogthrottlemax -1
-#	option notifycmd '/path/to/cmd'
 #	option pollfreq 5
 #	option pollfreqalert 5
 #	option offduration 30
 #	option overduration -1
 #	option oblbduration 0
-#	option shutdowncmd '/usr/sbin/nutshutdown'
 #	option rbwarntime 43200 # replace battery warn time
 #	option alarmcritical 1
 #	option shutdownexit 0
-# NB: certificates only apply to SSL-enabled version
-# See https://github.com/networkupstools/nut/blob/master/docs/security.txt
-# openssl client certificate chain and private key
-#	option certfile /usr/local/etc/upsmon.pem
-# NSS or OpenSSL
-# For NSS path the directory with certificate and key databases
-# For OpenSSL path a file with one or more CA certificates
-#	option certpath /etc/nut/cert_db
-# Client certificate name and password to unlock the key for the certificate
-#	option certident '"certificate name" "database password"'
-#	option certverify 0
-#	option forcessl 0
 #	option debugmin 0
-#	option defaultnotify SYSLOG
 #	option interface_reload_delay 3000 # in milliseconds
 #	option triggerlist all # not configured by default
-
-#config monitor
-#	option type primary
-#	option upsname upsname
-#	option hostname localhost
-#	option port # optional port number
-#	option powervalue 1
-#	option username upsuser
-#	option password upspassword
-
-#config monitor
-#	option type secondary
-#	option upsname upsname
-#	option hostname localhost
-#	option port # optional port number
-#	option powervalue 1
-#	option username upsuser
-#	option password upspassword
-
-# notification config sections must be named with an uppercase valid
-# NUT event type, from the list at
-# https://networkupstools.org/docs/man/upsmon.conf.html
-#
-# Empty notifications sections will emit a default NOTIFYFLAG <event> SYSLOG
-# line, as otherwise the NUT default of SYSLOG+WALL would be used, and the
-# `wall` command is not present in OpenWrt by default
-
-#config notifications 'COMMOK'
-#	option message "Communications with UPS %s established"
-#	option flag "SYSLOG"
-
-#config notifications 'COMMBAD'
-#	option message "Communications with UPS %s lost"
-#	option flag "SYSLOG+EXEC"
-
-#config notifications 'ONLINE'
-#	option flag "IGNORE"
-
-#config notifications 'ONBATT'
-#	option message "UPS %s is on battery power"
-#	option flag "SYSLOG+EXEC"
-
-#config notifications 'SHUTDOWN'
-#	option message "UPS %s shutting down"
-#	option flag "SYSLOG+EXEC"

--- a/net/nut/files/nut_monitor_root
+++ b/net/nut/files/nut_monitor_root
@@ -1,0 +1,62 @@
+# **NOTE**: As these configuration are used in a root context, restrictive file
+# permissions on this file in actual use in /etc/config/nut_monitor should be
+# used. For example:
+# chown root:root /etc/config/nut_monitor_root
+# chmod 0600 /etc/config/nut_monitor_root
+
+# We only support one instance of upsmon, and its root UCI
+# section must be named 'upsmon_root'
+
+# defaults for the upsmon section are compile time defaults
+# except /path/to/dir values which have no default
+# and defaultnotify which is an UCI specific setting
+#config upsmon upsmon_root
+#	option runas nutmon
+#	option notifycmd '/path/to/cmd'
+#	option shutdowncmd '/usr/sbin/nutshutdown'
+#	option defaultnotify SYSLOG
+
+#config monitor
+#	option type primary
+#	option upsname upsname
+#	option hostname localhost
+#	option port # optional port number
+#	option powervalue 1
+#	option username upsuser
+#	option password upspassword
+
+#config monitor
+#	option type secondary
+#	option upsname upsname
+#	option hostname localhost
+#	option port # optional port number
+#	option powervalue 1
+#	option username upsuser
+#	option password upspassword
+
+# notification config sections must be named with an uppercase valid
+# NUT event type, from the list at
+# https://networkupstools.org/docs/man/upsmon.conf.html
+#
+# Empty notifications sections will emit a default NOTIFYFLAG <event> SYSLOG
+# line, as otherwise the NUT default of SYSLOG+WALL would be used, and the
+# `wall` command is not present in OpenWrt by default
+
+#config notifications 'COMMOK'
+#	option message "Communications with UPS %s established"
+#	option flag "SYSLOG"
+
+#config notifications 'COMMBAD'
+#	option message "Communications with UPS %s lost"
+#	option flag "SYSLOG+EXEC"
+
+#config notifications 'ONLINE'
+#	option flag "IGNORE"
+
+#config notifications 'ONBATT'
+#	option message "UPS %s is on battery power"
+#	option flag "SYSLOG+EXEC"
+
+#config notifications 'SHUTDOWN'
+#	option message "UPS %s shutting down"
+#	option flag "SYSLOG+EXEC"

--- a/net/nut/files/nut_monitor_root
+++ b/net/nut/files/nut_monitor_root
@@ -1,0 +1,74 @@
+# **NOTE**: As these configuration contain sensitive values, restrictive file
+# permissions on this file in actual use in /etc/config/nut_monitor_root should be
+# used. For example:
+# chown root:root /etc/config/nut_monitor_root
+# chmod 0600 /etc/config/nut_monitor_root
+
+# We only support one instance of upsmon, and its root UCI
+# section must be named 'upsmon_root'
+
+# defaults for the upsmon section are compile time defaults
+# except /path/to/dir values which have no default
+# and defaultnotify which is an UCI specific setting
+#config upsmon upsmon_root
+#	option runas nutmon
+#	option notifycmd '/path/to/cmd'
+#	option shutdowncmd '/usr/sbin/nutshutdown'
+#	option defaultnotify SYSLOG
+# NB: certificates only apply to SSL-enabled version
+# See https://github.com/networkupstools/nut/blob/master/docs/security.txt
+# openssl client certificate chain and private key
+#	option certfile /usr/local/etc/upsmon.pem
+# NSS or OpenSSL
+# For NSS path the directory with certificate and key databases
+# For OpenSSL path a file with one or more CA certificates
+#	option certpath /etc/nut/cert_db
+# Client certificate name and password to unlock the key for the certificate
+#	option certident '"certificate name" "database password"'
+#	option certverify 0
+#	option forcessl 0
+
+#config monitor
+#	option type primary
+#	option upsname upsname
+#	option hostname localhost
+#	option port # optional port number
+#	option powervalue 1
+#	option username upsuser
+#	option password upspassword
+
+#config monitor
+#	option type secondary
+#	option upsname upsname
+#	option hostname localhost
+#	option port # optional port number
+#	option powervalue 1
+#	option username upsuser
+#	option password upspassword
+
+# notification config sections must be named with an uppercase valid
+# NUT event type, from the list at
+# https://networkupstools.org/docs/man/upsmon.conf.html
+#
+# Empty notifications sections will emit a default NOTIFYFLAG <event> SYSLOG
+# line, as otherwise the NUT default of SYSLOG+WALL would be used, and the
+# `wall` command is not present in OpenWrt by default
+
+#config notifications 'COMMOK'
+#	option message "Communications with UPS %s established"
+#	option flag "SYSLOG"
+
+#config notifications 'COMMBAD'
+#	option message "Communications with UPS %s lost"
+#	option flag "SYSLOG+EXEC"
+
+#config notifications 'ONLINE'
+#	option flag "IGNORE"
+
+#config notifications 'ONBATT'
+#	option message "UPS %s is on battery power"
+#	option flag "SYSLOG+EXEC"
+
+#config notifications 'SHUTDOWN'
+#	option message "UPS %s shutting down"
+#	option flag "SYSLOG+EXEC"

--- a/net/nut/files/nut_server
+++ b/net/nut/files/nut_server
@@ -17,14 +17,6 @@
 # Configuration for UPS connected to serial-USB
 #	option enable_usb_serial 0
 
-
-#config user
-#	option username upsuser
-#	option password upspassword
-#	option actions optional-action
-#	list instcmd optional-instant-command
-#	option upsmon secondary|primary
-
 #config listen_address
 #	option address ::1 # example
 #	option port 3493 # compile-time default
@@ -33,10 +25,8 @@
 # We only support one 'upsd' section and it must be named 'upsd'
 #config upsd 'upsd'
 #	option maxage 15
-#	option statepath /var/run/nut
 #	option maxconn 1024
-#	option runas nut
-#	option interface_reload_delay 3000 # in milliseconds
+# option interface_reload_delay 3000 # in milliseconds
 # NB: certificates only apply to SSL-enabled version
 #	option certfile /usr/local/etc/upsd.pem
 #	option triggerlist all # not configured by default

--- a/net/nut/files/nut_server
+++ b/net/nut/files/nut_server
@@ -17,14 +17,6 @@
 # Configuration for UPS connected to serial-USB
 #	option enable_usb_serial 0
 
-
-#config user
-#	option username upsuser
-#	option password upspassword
-#	option actions optional-action
-#	list instcmd optional-instant-command
-#	option upsmon secondary|primary
-
 #config listen_address
 #	option address ::1 # example
 #	option port 3493 # compile-time default
@@ -33,22 +25,5 @@
 # We only support one 'upsd' section and it must be named 'upsd'
 #config upsd 'upsd'
 #	option maxage 15
-#	option statepath /var/run/nut
 #	option maxconn 1024
-#	option runas nut
 #	option interface_reload_delay 3000 # in milliseconds
-#	option triggerlist all # not configured by default
-#	option debug_min 0
-# NB: certificates only apply to SSL-enabled version
-# See https://github.com/networkupstools/nut/blob/master/docs/security.txt
-# openssl server certificate chain and private key
-#	option certfile /usr/local/etc/upsd.pem
-# NSS or OpenSSL
-# For NSS path the directory with certificate and key databases
-# For OpenSSL path a file with one or more CA certificates
-#	option certpath /etc/nut/cert_db
-# Server certificate name and password to unlock the key for the certificate
-#	option certident '"certificate name" "database password"'
-# 0 - NO, 1 - REQUEST, 2 - REQUIRE (and verify)
-#	option certrequest 0
-#	option disable_weak_ssl 0

--- a/net/nut/files/nut_server_root
+++ b/net/nut/files/nut_server_root
@@ -1,0 +1,12 @@
+# defaults for the upsd section are compile time defaults
+# We only support one 'upsd' root section and it must be named 'upsd_root'
+#config upsd 'upsd_root'
+#	option statepath /var/run/nut
+#	option runas nut
+
+#config user
+#	option username upsuser
+#	option password upspassword
+#	option actions optional-action
+#	list instcmd optional-instant-command
+#	option upsmon secondary|primary

--- a/net/nut/files/nut_server_root
+++ b/net/nut/files/nut_server_root
@@ -1,0 +1,35 @@
+# **NOTE**: As these configuration contain sensitive values, restrictive file
+# permissions on this file in actual use in /etc/config/nut_server_root should be
+# used. For example:
+# chown root:root /etc/config/nut_server_root
+# chmod 0600 /etc/config/nut_server_root
+
+# defaults for the upsd section are compile time defaults
+# We only support one 'upsd' root section and it must be named 'upsd_root'
+#config upsd 'upsd_root'
+#	option statepath /var/run/nut
+#	option runas nut
+# NB: certificates only apply to SSL-enabled version
+#	option certfile /usr/local/etc/upsd.pem
+#	option triggerlist all # not configured by default
+#	option debug_min 0
+# NB: certificates only apply to SSL-enabled version
+# See https://github.com/networkupstools/nut/blob/master/docs/security.txt
+# openssl server certificate chain and private key
+#	option certfile /usr/local/etc/upsd.pem
+# NSS or OpenSSL
+# For NSS path the directory with certificate and key databases
+# For OpenSSL path a file with one or more CA certificates
+#	option certpath /etc/nut/cert_db
+# Server certificate name and password to unlock the key for the certificate
+#	option certident '"certificate name" "database password"'
+# 0 - NO, 1 - REQUEST, 2 - REQUIRE (and verify)
+#	option certrequest 0
+#	option disable_weak_ssl 0
+
+#config user
+#	option username upsuser
+#	option password upspassword
+#	option actions optional-action
+#	list instcmd optional-instant-command
+#	option upsmon secondary|primary


### PR DESCRIPTION

## 📦 Package Details

**Maintainer:** @danielfdickinson

**Description:**
Reduce opportunities for an untrusted user with UCI write access to escalate privileges or write arbitrary configurations (i.e. config not part of their ACL).

* Introduces config_get_single which only allows accepts 7-bit ASCII characters from UCI configuration settings
* Splits UCI configuration files into main for each service, and a <service>_root config. The _root configuration holds any configuration which is or could lead to root-equivalence (such as setting RUNAS user, and defining executable notification commands).
* Uses config_load in a subshell where needed, so that the _root configurations do not get mixed in with the non-_root configurations.
* More validation of inputs

Hotplug scripts only use the non-root upsd configs, and have a separate variable context, so isolating their config_load in a subshell is not necessary.

We do however improve hotplug behavior for remove
and add logic to prevent thrashing on boot or hotplug

On boot, hotplug events were causing excessive start and stop action
for the upsd daemon and driver daemons. We fix that with two primary
actions:
  1. Don't restart service daemons on hotplug until after first boot
     has completed.
  2. Use more robust handling of procd instance starts by ensuring
     that the first start starts the nut-server service and all
     others add to the nut-server service (rather than replacing it).

Also introduce some a 'sleep' in hotplug to reduce bouncing, and
ignore hotplug events without a DEVNAME.

In addition clean up some logging and fix custom notification message config generation.

Corresponding LuCI PR is https://github.com/openwrt/luci/pull/8851

---

## 🧪 Run Testing Details

Lightly tested

- **OpenWrt Version:** OpenWrt SNAPSHOT r35431-4f2dc5cc64
- **OpenWrt Target/Subtarget:** bcm27xx/bcm2709
- **OpenWrt Device:** Raspberry Pi 2 Model B Rev 1.1

Re-tested on

- **OpenWrt Version:** OpenWrt SNAPSHOT r35906-3d1645ee26
- **OpenWrt Target/Subtarget:** bcm27xx/bcm2709
- **OpenWrt Device:** Raspberry Pi 2 Model B Rev 1.1

TODO: Re-test SSL (using a second device).

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
