### PR TITLE
snapcast: make build options explicit and per-package deps precise

### DIFF
--- a/sound/snapcast/Makefile
+++ b/sound/snapcast/Makefile
@@ -4,7 +4,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=snapcast
 PKG_VERSION:=0.35.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/snapcast/snapcast.git
@@ -16,25 +16,75 @@ PKG_LICENSE:=GPL-3.0-or-later
 PKG_LICENSE_FILES:=LICENSE
 PKG_CPE_ID:=cpe:/a:badaix:snapcast
 
+# Optional features are individually selectable (see Package/snapserver/config).
+# Listing the symbols here reconfigures and rebuilds the package whenever any of
+# them is toggled.
+PKG_CONFIG_DEPENDS:= \
+	CONFIG_SNAPCAST_ALSA \
+	CONFIG_SNAPCAST_AVAHI \
+	CONFIG_SNAPCAST_EXPAT \
+	CONFIG_SNAPCAST_FLAC \
+	CONFIG_SNAPCAST_OPUS \
+	CONFIG_SNAPCAST_SOXR \
+	CONFIG_SNAPCAST_SSL \
+	CONFIG_SNAPCAST_VORBIS
+
+# snapserver and snapclient are produced by a single source build, so every
+# enabled feature library must be staged whenever the source is built,
+# regardless of which of the two binary packages is selected. These are pure
+# build-time prerequisites; the precise per-binary runtime dependencies (what
+# actually lands on the target) are declared in each Package/* DEPENDS below.
+PKG_BUILD_DEPENDS:= \
+	$(if $(CONFIG_SNAPCAST_ALSA),alsa-lib) \
+	$(if $(CONFIG_SNAPCAST_AVAHI),libavahi-client) \
+	$(if $(CONFIG_SNAPCAST_EXPAT),libexpat) \
+	$(if $(CONFIG_SNAPCAST_FLAC),libflac) \
+	$(if $(CONFIG_SNAPCAST_OPUS),libopus) \
+	$(if $(CONFIG_SNAPCAST_SOXR),libsoxr) \
+	$(if $(CONFIG_SNAPCAST_SSL),libopenssl) \
+	$(if $(CONFIG_SNAPCAST_VORBIS),libvorbis libvorbisidec) \
+	boost
+
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
 
+# Every upstream build switch is pinned explicitly for reproducible builds; the
+# optional ones follow their config symbol. Client-only desktop backends other
+# than ALSA are unavailable on OpenWrt and stay off.
 CMAKE_OPTIONS += \
 	-DBUILD_TESTS=OFF \
-	-DBUILD_WITH_ALSA=ON \
-	-DBUILD_WITH_AVAHI=OFF \
+	-DBUILD_WITH_ALSA=$(if $(CONFIG_SNAPCAST_ALSA),ON,OFF) \
+	-DBUILD_WITH_AVAHI=$(if $(CONFIG_SNAPCAST_AVAHI),ON,OFF) \
+	-DBUILD_WITH_EXPAT=$(if $(CONFIG_SNAPCAST_EXPAT),ON,OFF) \
+	-DBUILD_WITH_FLAC=$(if $(CONFIG_SNAPCAST_FLAC),ON,OFF) \
 	-DBUILD_WITH_JACK=OFF \
+	-DBUILD_WITH_OPUS=$(if $(CONFIG_SNAPCAST_OPUS),ON,OFF) \
 	-DBUILD_WITH_PIPEWIRE=OFF \
 	-DBUILD_WITH_PULSE=OFF \
-	-DBUILD_WITH_SSL=OFF \
-	-DBUILD_WITH_TREMOR=ON
+	-DBUILD_WITH_SDL2=OFF \
+	-DBUILD_WITH_SOXR=$(if $(CONFIG_SNAPCAST_SOXR),ON,OFF) \
+	-DBUILD_WITH_SSL=$(if $(CONFIG_SNAPCAST_SSL),ON,OFF) \
+	-DBUILD_WITH_TREMOR=$(if $(CONFIG_SNAPCAST_VORBIS),ON,OFF) \
+	-DBUILD_WITH_VORBIS=$(if $(CONFIG_SNAPCAST_VORBIS),ON,OFF) \
+	-DWERROR=OFF
 
 define Package/snapcast/Default
   SECTION:=sound
   CATEGORY:=Sound
   TITLE:=Synchronous multiroom audio player
-  DEPENDS:=+alsa-lib +libexpat +libatomic +libogg +libflac +libopus +boost +libsoxr
   URL:=https://github.com/snapcast/snapcast
+  # Dependencies common to both binaries. Feature libraries that only one of the
+  # two links are added in the respective package below, so each package pulls
+  # only what its binary actually needs at runtime.
+  DEPENDS:= \
+	+SNAPCAST_ALSA:alsa-lib \
+	+SNAPCAST_AVAHI:libavahi-client \
+	+SNAPCAST_FLAC:libflac \
+	+SNAPCAST_OPUS:libopus \
+	+SNAPCAST_SSL:libopenssl \
+	+libatomic \
+	+libogg \
+	+libstdcpp
 endef
 
 define Package/snapcast/Default/description
@@ -53,16 +103,78 @@ define Package/snapcast/Default/description
 
 endef
 
+# The optional-feature menu is shared by both binaries (single source build), so
+# it is declared once. The symbols are free-standing (no "depends on
+# PACKAGE_*"): the packages reference them in DEPENDS, and a back-dependency
+# here would form a Kconfig recursion.
+define Package/snapserver/config
+	menu "Snapcast feature selection"
+
+		config SNAPCAST_ALSA
+			bool "ALSA support (server capture source + client playback)"
+			default y
+			help
+				Adds a dependency on alsa-lib.
+
+		config SNAPCAST_AVAHI
+			bool "Avahi / zeroconf support"
+			default n
+			help
+				Adds a dependency on libavahi-client.
+
+		config SNAPCAST_EXPAT
+			bool "EXPAT / XML support (server)"
+			default y
+			help
+				Adds a dependency on libexpat.
+
+		config SNAPCAST_FLAC
+			bool "FLAC codec support"
+			default y
+			help
+				Adds a dependency on libflac.
+
+		config SNAPCAST_OPUS
+			bool "Opus codec support"
+			default y
+			help
+				Adds a dependency on libopus.
+
+		config SNAPCAST_SOXR
+			bool "SOXR resampling support (server)"
+			default y
+			help
+				Adds a dependency on libsoxr.
+
+		config SNAPCAST_SSL
+			bool "SSL / TLS support"
+			default n
+			help
+				Adds a dependency on libopenssl.
+
+		config SNAPCAST_VORBIS
+			bool "Ogg Vorbis support (server encoder + client Tremor decoder)"
+			default y
+			help
+				Adds dependencies on libvorbis (server) and
+				libvorbisidec (client).
+	endmenu
+endef
+
 define Package/snapserver
   $(call Package/snapcast/Default)
   TITLE+= (server)
-  DEPENDS+=+libvorbis
+  DEPENDS+= \
+	+SNAPCAST_EXPAT:libexpat \
+	+SNAPCAST_SOXR:libsoxr \
+	+SNAPCAST_VORBIS:libvorbis
 endef
 
 define Package/snapclient
   $(call Package/snapcast/Default)
   TITLE+= (client)
-  DEPENDS+=+libvorbisidec
+  DEPENDS+= \
+	+SNAPCAST_VORBIS:libvorbisidec
 endef
 
 define Package/snapserver/description

--- a/sound/snapcast/patches/010-cmake-add-build-with-soxr-option.patch
+++ b/sound/snapcast/patches/010-cmake-add-build-with-soxr-option.patch
@@ -1,0 +1,38 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mirko Vogt <foss@mirko.in>
+Date: Mon, 20 Jul 2026 12:00:00 +0000
+Subject: [PATCH] cmake: add an explicit BUILD_WITH_SOXR option
+
+Upstream looks SOXR up with an unconditional pkg_search_module(), so the
+optional resampling feature is enabled purely by whether libsoxr is
+discoverable in the build environment. In a shared package staging that
+is non-deterministic. Guard the lookup behind a real option (default ON,
+preserving previous behaviour) and mark it REQUIRED, so an
+enabled-but-missing libsoxr fails at configure time instead of silently
+dropping the feature.
+
+Signed-off-by: Mirko Vogt <foss@mirko.in>
+Assisted-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+---
+ CMakeLists.txt | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ef2252d..eb76646 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -264,7 +264,10 @@ if(NOT WIN32 AND NOT ANDROID)
+     endif()
+   endif()
+ 
+-  pkg_search_module(SOXR soxr)
++  option(BUILD_WITH_SOXR "Build with SOXR resampling support" ON)
++  if(BUILD_WITH_SOXR)
++    pkg_search_module(SOXR REQUIRED soxr)
++  endif()
+   if(SOXR_FOUND)
+     add_compile_definitions(HAS_SOXR)
+   else()
+-- 
+2.47.3
+


### PR DESCRIPTION
Pin every CMake BUILD_WITH_* switch and expose the optional features as config symbols, so builds are reproducible and snapserver/snapclient each depend only on the libraries their binary actually links (boost is header-only and becomes a build-only dependency).

Add a patch introducing a BUILD_WITH_SOXR option: upstream looks SOXR up with an unconditional pkg_search_module(), so resampling gets enabled purely by whether libsoxr happens to be discoverable in the shared staging dir - non-deterministic in a package feed. The option makes it an explicit, REQUIRED choice (enabled-but-missing fails at configure time instead of silently dropping the feature).

Assisted-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

## 📦 Package Details

**Maintainer:** @xabolcs @davidandreoletti 
<sub>Szabolcs Hubai <szab.hu@gmail.com>, David Andreoletti <david@andreoletti.net></sub>

**Description:**
see above

---

## 🧪 Run Testing Details

- **OpenWrt Version:** master (`305c7599e5fa400cf6221fd0a596dbd014529235`)
- **OpenWrt Target/Subtarget:** x86_64
- **OpenWrt Device:** qemu/kvm

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [X] It can be applied using `git am`
- [X] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [X] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
