### PR TITLE
golang: disable host PIE on linux/ppc64le

### DIFF
--- a/lang/golang/golang-values.mk
+++ b/lang/golang/golang-values.mk
@@ -284,6 +284,8 @@ GO_ARCH_DEPENDS:=@(aarch64||arm||i386||i686||loongarch64||mips||mips64||mips64el
 # ASLR/PIE
 
 # From https://go.dev/src/internal/platform/supported.go
+#
+# linux/ppc64le is omitted because -buildmode=pie makes the bootstrap compiler segfault.
 GO_PIE_SUPPORTED_OS_ARCH:= \
   aix/ppc64 \
   android/386 \
@@ -300,7 +302,6 @@ GO_PIE_SUPPORTED_OS_ARCH:= \
   linux/arm \
   linux/arm64 \
   linux/loong64 \
-  linux/ppc64le \
   linux/riscv64 \
   linux/s390x \
   openbsd/arm64 \


### PR DESCRIPTION


## 📦 Package Details

**Maintainer:** @GeorgeSapkin 


**Description:**
Disable host PIE on linux/ppc64le. Fixes the following compile error when building Go 1.26.5 on that architecture:

    Building Go toolchain3 using go_bootstrap and Go toolchain2.
    go: error obtaining buildID for go tool compile: signal: segmentation fault (core dumped)
    go tool dist: FAILED: .../build_dir/hostpkg/go-1.26.5/pkg/tool/linux_ppc64le/go_bootstrap install -ldflags=all=-buildmode pie -v -a cmd/asm cmd/cgo cmd/compile cmd/link cmd/preprofile: exit status 1
    make[2]: *** [Makefile:100: .../build_dir/hostpkg/go-1.26.5/.built] Error 2
    make[2]: Leaving directory '.../feeds/packages/lang/golang/golang1.26'
    time: package/feeds/packages/golang1.26/host-compile#355.86#31.73#55.16
        ERROR: package/feeds/packages/golang1.26 [host] failed to build.
    make[1]: *** [package/Makefile:196: package/feeds/packages/golang1.26/host/compile] Error 1
    make[1]: Leaving directory '...'
    make: *** [.../include/toplevel.mk:233: package/feeds/packages/golang1.26/host/compile] Error 2

The failure occurs with bootstrap compiler versions Go 1.24.13, Go 1.26.1, and Go 1.26.5.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** Generic

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
