### PR TITLE
nfs-kernel-server: correct libsqlite3 dependency

### DIFF
--- a/net/nfs-kernel-server/Makefile
+++ b/net/nfs-kernel-server/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nfs-kernel-server
 PKG_VERSION:=2.9.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_HASH:=302846343bf509f8f884c23bdbd0fe853b7f7cbb6572060a9082279d13b21a2c
 
 PKG_SOURCE:=nfs-utils-$(PKG_VERSION).tar.xz
@@ -33,7 +33,7 @@ define Package/nfs-kernel-server/Default
 	SECTION:=net
 	CATEGORY:=Network
 	SUBMENU:=Filesystem
-	DEPENDS:=+libblkid +libuuid +libtirpc +lsqlite3 +libxml2 +libnl
+  DEPENDS:=+libblkid +libuuid +libtirpc +libsqlite3 +libxml2 +libnl
 	URL:=https://nfs.sourceforge.net/
 endef
 


### PR DESCRIPTION
lsqlite3 is for LUA bindings, libsqlite3 is the actual lib

## 📦 Package Details

**Maintainer:** @graysky2

**Description:**
This is just a minor thing as the LUA bindings depend on the lib itself, so this just removes a useless dependency.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** master/SNAPSHOT
- **OpenWrt Target/Subtarget:** i386/x64
- **OpenWrt Device:** AMD Ryzen-based PC serving as my router

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
