### PR TITLE
ldns: update to 1.9.2

### DIFF
--- a/libs/ldns/Makefile
+++ b/libs/ldns/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ldns
-PKG_VERSION:=1.8.3
+PKG_VERSION:=1.9.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.nlnetlabs.nl/downloads/ldns
-PKG_HASH:=c3f72dd1036b2907e3a56e6acf9dfb2e551256b3c1bbd9787942deeeb70e7860
+PKG_HASH:=b524fa21994b6e834200ceb8c27f1b84bda5982fe35706f058196c079db94d5d
 
 PKG_MAINTAINER:=Eric Luehrsen <ericluehrsen@gmail.com>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @EricLuehrsen

**Description:**
Many changes since version 1.8.3, also CVE-2026-10846 (although maybe that is not dangerous for our use cases). Most importantly, 1.8.3 didn't compile with glibc & GCC 15.

https://github.com/NLnetLabs/ldns/blob/1.9.2/Changelog

---

## 🧪 Run Testing Details

- **OpenWrt Version:** snapshot/master
- **OpenWrt Target/Subtarget:** x86/x86_64
- **OpenWrt Device:** PC

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.