### PR TITLE
apparmor: stage libapparmor headers via InstallDev

### DIFF
--- a/utils/apparmor/Makefile
+++ b/utils/apparmor/Makefile
@@ -4,7 +4,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=apparmor
 PKG_VERSION:=3.0.13
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_VERSION:=v$(PKG_VERSION)
@@ -153,6 +153,13 @@ define Build/Install
 	+$(MAKE_VARS) PYTHON=$(HOST_PYTHON) VERSION=$(PYTHON3_VERSION) \
 		CFLAGS="$(TARGET_CFLAGS)" LDFLAGS="$(TARGET_LDFLAGS)" USE_SYSTEM=1 $(MAKE) $(PKG_JOBS) -C $(PKG_BUILD_DIR)/profiles \
 		$(MAKE_FLAGS) DESTDIR="$(PKG_INSTALL_DIR)-profiles" install
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include/sys $(1)/usr/lib $(1)/usr/lib/pkgconfig
+	$(CP) $(PKG_INSTALL_DIR)-libapparmor/usr/include/sys/*.h $(1)/usr/include/sys/
+	$(CP) $(PKG_INSTALL_DIR)-libapparmor/usr/lib/libapparmor.so* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)-libapparmor/usr/lib/pkgconfig/libapparmor.pc $(1)/usr/lib/pkgconfig/
 endef
 
 define Package/libapparmor/install


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @oskarirauta 

**Description:**

Add a Build/InstallDev so libapparmor's header (sys/apparmor.h), the libapparmor.so link and the pkg-config file are copied into the staging directory. Without this, packages cannot build against libapparmor even though the runtime shared library is provided; e.g. stress-ng's AppArmor stressors fall back to "built without sys/apparmor.h".


---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
