### PR TITLE
vobject: add missing pytz and six dependencies

### DIFF
--- a/lang/python/vobject/Makefile
+++ b/lang/python/vobject/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=vobject
 PKG_VERSION:=0.9.9
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=Apache-2.0
 
 PYPI_NAME:=$(PKG_NAME)
@@ -23,7 +23,7 @@ define Package/python3-vobject
   CATEGORY:=Languages
   TITLE:=VObject
   URL:=https://py-vobject.github.io/
-  DEPENDS:=+python3 +python3-dateutil
+  DEPENDS:=+python3 +python3-dateutil +python3-pytz +python3-six
 endef
 
 define Package/python3-vobject/description

--- a/lang/python/vobject/test.sh
+++ b/lang/python/vobject/test.sh
@@ -5,6 +5,12 @@
 python3 - << 'EOF'
 import vobject
 
+# Upstream declares pytz and six as hard runtime requirements, so make sure
+# both resolve; a missing pytz is what broke the change_tz console script.
+import pytz
+import six
+from dateutil import tz
+
 # Parse a simple vCard
 vcard_text = """BEGIN:VCARD
 VERSION:3.0
@@ -31,6 +37,9 @@ cal = vobject.readOne(ical_text)
 events = list(cal.vevent_list)
 assert len(events) == 1
 assert events[0].summary.value == "Test Event"
+
+# Verify change_tz imports (requires pytz)
+from vobject.change_tz import change_tz
 
 print("python3-vobject OK")
 EOF


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me

**Description:**

vobject 0.9.9 lists both pytz and six as unconditional runtime requirements
in install_requires, but neither was in DEPENDS. Running the change_tz
console script failed with "ModuleNotFoundError: No module named 'pytz'".

six happened to resolve transitively through python3-dateutil even though
vobject/base.py imports it directly, so list it explicitly rather than rely
on another package's dependency.

Extend test.sh to check that both modules import and that vobject.change_tz
loads.

Fixes: https://github.com/openwrt/packages/issues/29992


---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
