### PR TITLE
trafficshaper: avoid recursive dependency

### DIFF
--- a/net/trafficshaper/Makefile
+++ b/net/trafficshaper/Makefile
@@ -8,24 +8,37 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=trafficshaper
 PKG_VERSION:=1.0.0
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 PKG_MAINTAINER:=Luiz Angelo Daros de Luca <luizluca@gmail.com>
 
 PKG_LICENSE:=GPL-2.0-or-later
 
 include $(INCLUDE_DIR)/package.mk
 
-define Package/trafficshaper
+define Package/trafficshaper/Default
   SECTION:=net
   CATEGORY:=Network
   TITLE:=WAN traffic shaper based on LAN addresses
   DEPENDS:=+tc +kmod-sched-core +kmod-sched-connmark +kmod-ifb \
-	+(PACKAGE_nftables-json||PACKAGE_nftables-nojson):nftables \
-	+!(PACKAGE_nftables-json||PACKAGE_nftables-nojson):iptables \
-	+(IPV6&&!(PACKAGE_nftables-json||PACKAGE_nftables-nojson)):ip6tables \
-	+kmod-sched-cake \
-	+!(PACKAGE_nftables-json||PACKAGE_nftables-nojson):iptables-mod-conntrack-extra
+	+kmod-sched-cake
+  PROVIDES:=trafficshaper
   PKGARCH:=all
+endef
+
+define Package/trafficshaper
+  $(call Package/trafficshaper/Default)
+  TITLE+= (nftables)
+  DEPENDS+= +nftables
+  VARIANT:=nftables
+  DEFAULT_VARIANT:=1
+endef
+
+define Package/trafficshaper-iptables
+  $(call Package/trafficshaper/Default)
+  TITLE+= (iptables)
+  DEPENDS+= +iptables +IPV6:ip6tables +iptables-mod-conntrack-extra
+  VARIANT:=iptables
+  CONFLICTS:=trafficshaper
 endef
 
 define Package/trafficshaper/description
@@ -36,9 +49,15 @@ define Package/trafficshaper/description
   the use (or not) of spare wan bandwidth when available.
 endef
 
+define Package/trafficshaper-iptables/description
+  $(call Package/trafficshaper/description)
+endef
+
 define Package/trafficshaper/conffiles
 /etc/config/trafficshaper
 endef
+
+Package/trafficshaper-iptables/conffiles = $(Package/trafficshaper/conffiles)
 
 define Build/Compile
 endef
@@ -50,4 +69,7 @@ define Package/trafficshaper/install
 	$(INSTALL_BIN) ./files/trafficshaper.init $(1)/etc/init.d/trafficshaper
 endef
 
+Package/trafficshaper-iptables/install = $(Package/trafficshaper/install)
+
 $(eval $(call BuildPackage,trafficshaper))
+$(eval $(call BuildPackage,trafficshaper-iptables))


### PR DESCRIPTION
Follow-up to [#29830](https://github.com/openwrt/packages/pull/29830) and the discussion after it was [merged](https://github.com/openwrt/packages/pull/29830#issuecomment-5035149170).

The conditional nftables dependency causes a recursive Kconfig dependency when
it resolves to `nftables-nojson`.

Split it into nftables and iptables variants instead.

## Package Details

**Maintainer:** Luiz Angelo Daros de Luca <luizluca@gmail.com> (@luizluca)
**Description:**

```text
trafficshaper             nftables (default)
trafficshaper-iptables    iptables
```

Both install the same init script and config. The iptables backend stays
available for older systems, while the normal package does not pull the
iptables userspace packages into nftables installations.

---

## Run Testing Details

- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** generic x86/64 build

I selected both variants as modules and ran `make defconfig`. The recursive
dependency is gone and both APKs build.

I also checked the generated dependencies. For the firewall backend, the normal
package only pulls `nftables`. The iptables variant pulls `iptables`,
`ip6tables`, and `iptables-mod-conntrack-extra`.

Also checked with:

```sh
git diff --check
busybox ash -n files/trafficshaper.init
```

---

## Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

Not applicable. This PR does not add or modify an upstream source patch.
