### PR TITLE
tar: fix tar un-selectable without xz-utils

### DIFF
--- a/utils/tar/Makefile
+++ b/utils/tar/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tar
 PKG_VERSION:=1.35
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNU/tar
@@ -68,6 +68,7 @@ define Package/tar/config
 
 	config PACKAGE_TAR_XZ
 		bool "tar: Enable seamless xz support"
+		depends on PACKAGE_xz-utils
 		default y
 
 	config PACKAGE_TAR_ZSTD


### PR DESCRIPTION
Before the fix, if xz-utils was not selected,
tar and all packages depending on it
would be hidden and could not be selected.

Fixes: 3dcc4f1d3f ("tar: fix circular dependency on xz")

## 📦 Package Details

**Maintainer:** @GeorgeSapkin @BKPepe 
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->
Before fix, tar depends on xz-utils by default, which makes tar and all packages depending on it hidden until xz-utils selected.

(24.10 Not affected by this.)
---

## 🧪 Run Testing Details
This is not a runtime fix.

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:
No.

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
