### PR TITLE
snapcast: add libsoxr dependency to snapclient (as was done already for snapserver)

### DIFF
--- a/sound/snapcast/Makefile
+++ b/sound/snapcast/Makefile
@@ -141,10 +141,12 @@ define Package/snapserver/config
 				Adds a dependency on libopus.
 
 		config SNAPCAST_SOXR
-			bool "SOXR resampling support (server)"
+			bool "SOXR resampling support (server + client)"
 			default y
 			help
-				Adds a dependency on libsoxr.
+				High-quality SoX resampling, compiled into
+				both binaries (build-wide -DBUILD_WITH_SOXR).
+				Adds a dependency on libsoxr to each.
 
 		config SNAPCAST_SSL
 			bool "SSL / TLS support"
@@ -174,6 +176,7 @@ define Package/snapclient
   $(call Package/snapcast/Default)
   TITLE+= (client)
   DEPENDS+= \
+	+SNAPCAST_SOXR:libsoxr \
 	+SNAPCAST_VORBIS:libvorbisidec
 endef
 


### PR DESCRIPTION
snapcast: add libsoxr dependency to snapclient

SNAPCAST_SOXR passes -DBUILD_WITH_SOXR, which is a build-wide CMake
option: snapserver and snapclient are built from one source tree and 
both link libsoxr. The dependency was declared only on snapserver, so
with SNAPCAST_SOXR enabled (the default) the snapclient package failed
at the packaging step:

  Package snapclient is missing dependencies for the following libraries:
  libsoxr.so.0

Declare +SNAPCAST_SOXR:libsoxr on snapclient too, and relabel the option
"(server + client)" so its build-wide scope is clear.

## 📦 Package Details

**Maintainer:** @xabolcs @davidandreoletti 
<sub>Szabolcs Hubai <szab.hu@gmail.com>, David Andreoletti <david@andreoletti.net></sub>

**Description:**
see above

---

## 🧪 Run Testing Details

- **OpenWrt Version:** master (`305c7599e5fa400cf6221fd0a596dbd014529235`)
- **OpenWrt Target/Subtarget:** x86_64
- **OpenWrt Device:** qemu/kvm

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [X] It can be applied using `git am`
- [X] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [X] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>