### PR TITLE
openvpn: enable DCO by default

### DIFF
--- a/net/openvpn/Config-mbedtls.in
+++ b/net/openvpn/Config-mbedtls.in
@@ -35,7 +35,7 @@ config OPENVPN_mbedtls_ENABLE_IPROUTE2
 config OPENVPN_mbedtls_ENABLE_DCO
 	depends on !OPENVPN_mbedtls_ENABLE_IPROUTE2
 	bool "Enable support for data channel offload"
-	default n
+	default y if !OPENVPN_mbedtls_ENABLE_IPROUTE2
 	help
 	  enable data channel offload support
 	  using the ovpn-dco-v2 kernel module

--- a/net/openvpn/Config-openssl.in
+++ b/net/openvpn/Config-openssl.in
@@ -39,7 +39,7 @@ config OPENVPN_openssl_ENABLE_IPROUTE2
 config OPENVPN_openssl_ENABLE_DCO
 	depends on !OPENVPN_openssl_ENABLE_IPROUTE2
 	bool "Enable support for data channel offload"
-	default n
+	default y if !OPENVPN_openssl_ENABLE_IPROUTE2
 	help
 	  enable data channel offload support
 	  using the ovpn-dco-v2 kernel module

--- a/net/openvpn/Config-wolfssl.in
+++ b/net/openvpn/Config-wolfssl.in
@@ -44,7 +44,7 @@ config OPENVPN_wolfssl_ENABLE_IPROUTE2
 config OPENVPN_wolfssl_ENABLE_DCO
 	depends on !OPENVPN_wolfssl_ENABLE_IPROUTE2
 	bool "Enable support for data channel offload"
-	default n
+	default y if !OPENVPN_wolfssl_ENABLE_IPROUTE2
 	select WOLFSSL_HAS_OPENVPN
 	help
 	  enable data channel offload support

--- a/net/openvpn/Makefile
+++ b/net/openvpn/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=openvpn
 
 PKG_VERSION:=2.7.4
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_URL:=\
 	https://build.openvpn.net/downloads/releases/ \


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:**  me

**Description:**

Enable the DCO option by default in the openvpn package to allow for better performance and have a use case for kmod-ovpn-dco-v2 :-)

Fixes: https://github.com/openwrt/packages/issues/30070


(cherry picked from commit 11e17a3ed625c34501568669303e3f447fe4f693)

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [ ] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
