### PR TITLE
bind: bump to 9.20.26

### DIFF
--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
-PKG_VERSION:=9.20.23
+PKG_VERSION:=9.20.26
 PKG_RELEASE:=1
 USERID:=bind=57:bind=57
 
@@ -22,7 +22,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:= \
 	https://www.mirrorservice.org/sites/ftp.isc.org/isc/bind9/$(PKG_VERSION) \
 	https://ftp.isc.org/isc/bind9/$(PKG_VERSION)
-PKG_HASH:=5d4475aed3f9e500ef554b2b14d972bdb83d33de214a9b3be92918ea46908371
+PKG_HASH:=55248def0f870c4c46b3de72978ea972615131516663188a4564dca1d20bf350
 
 PKG_INSTALL:=1
 PKG_BUILD_FLAGS:=no-mips16

--- a/net/bind/patches/fix-usr-allow-rndc-addzone#1.patch
+++ b/net/bind/patches/fix-usr-allow-rndc-addzone#1.patch
@@ -13,7 +13,7 @@ restore the automatic zone to the view.
 
 --- a/bin/named/server.c
 +++ b/bin/named/server.c
-@@ -13919,6 +13919,7 @@ do_addzone(named_server_t *server, ns_cf
+@@ -13934,6 +13934,7 @@ do_addzone(named_server_t *server, ns_cf
  	   bool redirect, isc_buffer_t **text) {
  	isc_result_t result, tresult;
  	dns_zone_t *zone = NULL;
@@ -21,7 +21,7 @@ restore the automatic zone to the view.
  	bool locked = false;
  #ifndef HAVE_LMDB
  	FILE *fp = NULL;
-@@ -13937,7 +13938,13 @@ do_addzone(named_server_t *server, ns_cf
+@@ -13952,7 +13953,13 @@ do_addzone(named_server_t *server, ns_cf
  	} else {
  		result = dns_view_findzone(view, name, DNS_ZTFIND_EXACT, &zone);
  		if (result == ISC_R_SUCCESS) {
@@ -36,7 +36,7 @@ restore the automatic zone to the view.
  		}
  	}
  	if (result != ISC_R_NOTFOUND) {
-@@ -13946,6 +13953,10 @@ do_addzone(named_server_t *server, ns_cf
+@@ -13961,6 +13968,10 @@ do_addzone(named_server_t *server, ns_cf
  
  	isc_loopmgr_pause(named_g_loopmgr);
  
@@ -47,7 +47,7 @@ restore the automatic zone to the view.
  #ifndef HAVE_LMDB
  	/*
  	 * Make sure we can open the configuration save file
-@@ -14050,6 +14061,11 @@ do_addzone(named_server_t *server, ns_cf
+@@ -14065,6 +14076,11 @@ do_addzone(named_server_t *server, ns_cf
  		/* Remove the zone from the zone table */
  		dns_view_delzone(view, zone);
  		goto cleanup;
@@ -59,7 +59,7 @@ restore the automatic zone to the view.
  	}
  
  	/* Flag the zone as having been added at runtime */
-@@ -14066,6 +14082,22 @@ do_addzone(named_server_t *server, ns_cf
+@@ -14081,6 +14097,22 @@ do_addzone(named_server_t *server, ns_cf
  
  cleanup:
  


### PR DESCRIPTION
Fixes several security issues:
 - CVE-2026-11331 Fix handling of rpz CNAME expansion that returns name too long.
 - CVE-2026-11721 Invalid signed wildcard records were being accepted.
 - CVE-2026-13321 Fix DNSSEC validation bypass via out-of-zone NSEC Next Field.
 - CVE-2026-10723 Correct verification of NSEC3 signer name.
 - CVE-2026-12617 Do no assert for some specifics CNAME and DNAME queries.
 - CVE-2026-10822 Malformed DNSKEY records could trigger an assertion.
 - CVE-2026-11605 Prevent excessive validation work from crafted negative responses.
 - CVE-2026-11622 Prevent cache exhaustion under sustained attack.

Full release notes are available upstream at
https://ftp.isc.org/isc/bind9/9.20.26/doc/arm/html/changelog.html

## 📦 Package Details

**Maintainer:** me

## 🧪 Run Testing Details

- **OpenWrt Version:** master
- **OpenWrt Target/Subtarget:** mvebu/cortexa9
- **OpenWrt Device:** wrt1900acs

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [x] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
