### PR TITLE
mwan3: Add configurable nslookup name for mwan3track

### DIFF
--- a/net/mwan3/files/usr/sbin/mwan3track
+++ b/net/mwan3/files/usr/sbin/mwan3track
@@ -252,6 +252,7 @@ main() {
 			exit 1
 		fi
 	}
+    config_get nslookup_name $INTERFACE nslookup_name www.google.com
 	config_get reliability $INTERFACE reliability 1
 	config_get count $INTERFACE count 1
 	config_get timeout $INTERFACE timeout 4
@@ -347,7 +348,7 @@ main() {
 						result=$(grep Lost $TRACK_OUTPUT | awk '{print $12}')
 					;;
 					nslookup)
-						WRAP nslookup www.google.com $track_ip > $TRACK_OUTPUT &
+						WRAP nslookup $nslookup_name $track_ip > $TRACK_OUTPUT &
 						wait $!
 						result=$?
 					;;


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @feckert 

**Description:**
Instead of hardcoding www.google.com as the name to look up using the nslookup method, allow the config to specify a name, defaulting to www.google.com.

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [x] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
