### PR TITLE
rustnet: add new package

### DIFF
--- a/net/rustnet/Makefile
+++ b/net/rustnet/Makefile
@@ -1,22 +1,23 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rustnet
-PKG_VERSION:=1.5.0
+PKG_VERSION:=1.6.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/domcyrus/rustnet/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=f6425992dc5a8a700323c1231d1833a135cd93424d86cfaa788eed6cb700fe33
+PKG_HASH:=245fc7074d5f142fbf1c798233be86b715b4f2ce3b3cfec10fabdcbbc9345ddb
 
 PKG_MAINTAINER:=Jonir Rings <i@jonirrings.com>
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 
-PKG_BUILD_DEPENDS:=rust/host bpf-headers bpftool/host
+PKG_BUILD_DEPENDS:=rust/host
 PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/bpf.mk
+include $(INCLUDE_DIR)/nls.mk
 include ../../lang/rust/rust-package.mk
 
 define Package/rustnet
@@ -24,18 +25,26 @@ define Package/rustnet
   CATEGORY:=Network
   TITLE:=Per-process network monitor with DPI
   URL:=https://github.com/domcyrus/rustnet
-  # You need enable KERNEL_DEBUG_INFO_BTF and KERNEL_BPF_EVENTS
-  DEPENDS:=@(aarch64||x86_64||riscv64) $(BPF_DEPENDS) +libpcap +libcap +libelf
+  DEPENDS:=@(aarch64||x86_64) $(BPF_DEPENDS) $(INTL_DEPENDS) \
+   @KERNEL_DEBUG_INFO_BTF @KERNEL_BPF_EVENTS \
+   +libpcap +libelf
 endef
 
 define Package/rustnet/description
   A terminal-based, per-process network monitoring tool with deep
   packet inspection. Maps TCP, UDP, and QUIC connections to owning
-  processes using eBPF (Linux), PKTAP (macOS), or native APIs,
-  with DPI for HTTP, TLS/SNI, DNS, SSH, QUIC, and many other protocols.
+  processes using eBPF, with DPI for HTTP, TLS/SNI, DNS, SSH, QUIC,
+  and many other protocols.
   Supports exporting annotated PCAPNG files with process metadata
   and GeoIP enrichment.
 endef
+
+# Fixes the main/target crate graph link only (reaches RUSTFLAGS). The
+# separate build-script link (rustnet-host's build.rs, via libbpf-cargo ->
+# libbpf-rs -> libbpf-sys -> -lelf, compiled for the host under cargo's
+# resolver-v2 host/target feature+rustflags split) is fixed independently
+# via patches/ - see that patch's header comment. See openwrt/packages#24375.
+RUSTC_LDFLAGS+= $(if $(INTL_FULL),-L$(INTL_PREFIX)/lib -lintl)
 
 define Package/rustnet/install
 	$(INSTALL_DIR) $(1)/usr/bin

--- a/net/rustnet/Makefile
+++ b/net/rustnet/Makefile
@@ -1,0 +1,46 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=rustnet
+PKG_VERSION:=1.5.0
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/domcyrus/rustnet/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=f6425992dc5a8a700323c1231d1833a135cd93424d86cfaa788eed6cb700fe33
+
+PKG_MAINTAINER:=Jonir Rings <i@jonirrings.com>
+PKG_LICENSE:=Apache-2.0
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_DEPENDS:=rust/host bpf-headers bpftool/host
+PKG_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/bpf.mk
+include ../../lang/rust/rust-package.mk
+
+define Package/rustnet
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=Per-process network monitor with DPI
+  URL:=https://github.com/domcyrus/rustnet
+  # You need enable KERNEL_DEBUG_INFO_BTF and KERNEL_BPF_EVENTS
+  DEPENDS:=@(aarch64||x86_64||riscv64) $(BPF_DEPENDS) +libpcap +libcap +libelf
+endef
+
+define Package/rustnet/description
+  A terminal-based, per-process network monitoring tool with deep
+  packet inspection. Maps TCP, UDP, and QUIC connections to owning
+  processes using eBPF (Linux), PKTAP (macOS), or native APIs,
+  with DPI for HTTP, TLS/SNI, DNS, SSH, QUIC, and many other protocols.
+  Supports exporting annotated PCAPNG files with process metadata
+  and GeoIP enrichment.
+endef
+
+define Package/rustnet/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/bin/rustnet $(1)/usr/bin
+endef
+
+$(eval $(call RustBinPackage,rustnet))
+$(eval $(call BuildPackage,rustnet))

--- a/net/rustnet/patches/001-build-libbpf-sys.patch
+++ b/net/rustnet/patches/001-build-libbpf-sys.patch
@@ -1,0 +1,36 @@
+From 7ddcfb1ef81e11eca6202bbdde5091d0590ad0a8 Mon Sep 17 00:00:00 2001
+From: Jonir Rings <i@jonirrings.com>
+Date: Sun, 30 Aug 2026 11:03:56 +0800
+Subject: [PATCH] fix libbpf-sys build failure
+
+---
+ crates/rustnet-host/Cargo.toml | 13 +-
+ 1 file changed, 13 insertion(+), 1 deletion(-)
+
+--- a/crates/rustnet-host/Cargo.toml
++++ b/crates/rustnet-host/Cargo.toml
+@@ -19,7 +19,13 @@
+
+ [features]
+ # eBPF-based process attribution on Linux (libbpf). No effect on other platforms.
+-ebpf = ["dep:bitflags", "dep:libbpf-rs", "dep:libbpf-cargo"]
++# dep:libbpf-sys additionally forces libbpf-sys's vendored-libelf feature for
++# the build-script (host) dependency graph specifically - libbpf-cargo pulls
++# in libbpf-sys only transitively via libbpf-rs, and cargo's resolver keeps
++# host-side (build-dependency) and target-side (normal dependency) feature
++# unification separate, so enabling vendoring via the target-side libbpf-rs
++# dependency alone does not reach the build script's own link step.
++ebpf = ["dep:bitflags", "dep:libbpf-rs", "dep:libbpf-cargo", "dep:libbpf-sys"]
+
+ [dependencies]
+ rustnet-core.workspace = true
+@@ -48,3 +54,9 @@ anyhow.workspace = true
+
+ [target.'cfg(target_os = "linux")'.build-dependencies]
+ libbpf-cargo = { version = "0.27", optional = true }
++# Forces vendored-libelf for the build-script's own copy of libbpf-sys (see
++# the ebpf feature comment above). Not used directly by build.rs; its sole
++# purpose is feature unification within the build-dependency graph.
++libbpf-sys = { version = "1.7", optional = true, default-features = false, features = [
++    "vendored-libelf",
++] }


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @jonirrings
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:** rustnet is a terminal-based network monitoring tool with deep packet inspection.
<!-- Briefly describe what this package does or what changes are introduced -->

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12
- **OpenWrt Target/Subtarget:** tested on x64/aarch64
- **OpenWrt Device:** tested on my BPI-R4

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/rustnet/refresh V=s
  ```
- [x] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
