### PR TITLE
mdns-repeater: bump to 2026.07.16~488feaf7, simplify MAKE_FLAGS

### DIFF
--- a/net/mdns-repeater/Makefile
+++ b/net/mdns-repeater/Makefile
@@ -6,13 +6,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mdns-repeater
-PKG_RELEASE:=2
+PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=https://github.com/geekman/mdns-repeater.git
 PKG_SOURCE_PROTO=git
-PKG_SOURCE_DATE:=2023-12-16
-PKG_SOURCE_VERSION:=f714ec4d8a0eee248ead29c2ae1bb37f124a568f
-PKG_MIRROR_HASH:=ccc76784483550bcbe3b65f2efee39372516c2cf5d18ef58636cf2661139c4b8
+PKG_SOURCE_DATE:=2026-07-16
+PKG_SOURCE_VERSION:=488feaf7da1a4b54de120ea00f0f3eb629cdfd8e
+PKG_MIRROR_HASH:=9fd326c4d7874ff5c7145c9bb9c11408dd31cda568aafe7d134a12cb3579bac5
 
 PKG_MAINTAINER:=Alexander Koenig <alex@lisas.de>
 PKG_LICENSE:=GPL-2.0-or-later
@@ -28,10 +28,7 @@ define Package/mdns-repeater
   URL:=https://github.com/geekman/mdns-repeater
 endef
 
-MAKE_FLAGS += \
-	HGVERSION='dummy' \
-	CFLAGS='$(TARGET_CFLAGS) $(TARGET_CPPFLAGS) -DHGVERSION="\"$(VERSION)\""' \
-	LDFLAGS='$(TARGET_LDFLAGS)'
+MAKE_FLAGS += HGVERSION='$(VERSION)'
 
 define Package/mdns-repeater/install
 	$(INSTALL_DIR) $(1)/usr/sbin


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @axkg  

**Description:**

Now that @BKPepe's change to not override CFLAGS is accepted upstream (geekman/mdns-repeater#28), simplify the Makefile to only pass through the version string (HGVERSION). All other flags now get forwarded by default as expected.

---

This is indeed more elegant, thank you!

Version string looks as expected:

```console
root@Elk:~# /usr/sbin/mdns-repeater -h
mDNS repeater (version 2026.07.16~488feaf7-r1)
```

File maintains symbols/debug info before being stripped:

```console
ubuntu@eagle-26:~/openwrt/build_dir/target-aarch64_cortex-a53_musl/mdns-repeater-2026.07.16~488feaf7$ file mdns-repeater
mdns-repeater: ELF 64-bit LSB pie executable, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-musl-aarch64.so.1, with debug_info, not stripped
```

Build log: [mdns-repeater.log](https://github.com/user-attachments/files/30371401/mdns-repeater.log) (built on openwrt/openwrt@aac6df7bdc76d72200e6c2a4ca1aceed351fa77b, newer than runtime)

---

## 🧪 Run Testing Details

- **OpenWrt Version:** snapshot r35180-aef2523de1 (openwrt/openwrt@aef2523de1)
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** Banana-Pi R4 (2x SFP+)

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.