### PR TITLE
strongswan: rename and migrate missleading options

### DIFF
--- a/net/strongswan/Makefile
+++ b/net/strongswan/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=strongswan
 PKG_VERSION:=6.0.7
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://download.strongswan.org/ https://download2.strongswan.org/

--- a/net/strongswan/files/etc/uci-defaults/strongswan
+++ b/net/strongswan/files/etc/uci-defaults/strongswan
@@ -26,9 +26,36 @@ migrate_ignore_routing_tables() {
 	uci commit ipsec
 }
 
+migrate_local_nat_child() {
+	local cfg="$1"
+
+	local local_nat value
+
+	config_get local_nat "$cfg" local_nat ""
+	[ -z "$local_nat" ] && return
+
+	uci -q delete "ipsec.${cfg}.local_nat"
+
+	# Replace 'local_subnet' with 'local_nat' and do not append.
+	# That's how it was previously done in the swanctl start script.
+	uci -q delete "ipsec.${cfg}.local_subnet"
+
+	for value in $local_nat; do
+		uci add_list "ipsec.${cfg}.local_subnet=${value}"
+	done
+}
+
+migrate_local_nat() {
+	config_load ipsec
+	config_foreach migrate_local_nat_child tunnel
+	config_foreach migrate_local_nat_child transport
+	uci commit ipsec
+}
+
 main() {
 	migrate_ipsec
 	migrate_ignore_routing_tables
+	migrate_local_nat
 }
 
 main

--- a/net/strongswan/files/etc/uci-defaults/strongswan
+++ b/net/strongswan/files/etc/uci-defaults/strongswan
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+. /lib/functions.sh
 migrate_ipsec() {
 	# Skip migration if the 'globals' section already exists
 	uci show ipsec.globals 1>/dev/null 2>/dev/null
@@ -96,12 +97,34 @@ migrate_remote_gateway() {
 	config_foreach migrate_remote_gateway_remote remote
 }
 
+migrate_local_ip_local() {
+	local cfg="$1"
+
+	local local_ip value
+
+	config_get local_ip "$cfg" local_ip ""
+	[ -z "$local_ip" ] && return
+
+	for value in $local_ip; do
+		uci add_list "ipsec.${cfg}.local_addrs=${value}"
+	done
+
+	uci -q delete "ipsec.${cfg}.local_ip"
+	uci commit ipsec
+}
+
+migrate_local_ip() {
+	config_load ipsec
+	config_foreach migrate_local_ip_local remote
+}
+
 main() {
 	migrate_ipsec
 	migrate_ignore_routing_tables
 	migrate_local_nat
 	migrate_gateway
 	migrate_remote_gateway
+	migrate_local_ip
 }
 
 main

--- a/net/strongswan/files/etc/uci-defaults/strongswan
+++ b/net/strongswan/files/etc/uci-defaults/strongswan
@@ -52,10 +52,34 @@ migrate_local_nat() {
 	uci commit ipsec
 }
 
+migrate_gateway_remote() {
+	local cfg="$1"
+
+	local gateway
+
+	config_get gateway "$cfg" gateway ""
+	[ -z "$gateway" ] && return
+
+	# The option 'any' is default for the 'remote_gateway' option if not set
+	# and does not need to be saved.
+	[ "$gateway" = "any" ] || {
+		uci -q set "ipsec.${cfg}.remote_gateway=${gateway}"
+	}
+
+	uci -q delete "ipsec.${cfg}.gateway"
+	uci commit ipsec
+}
+
+migrate_gateway() {
+	config_load ipsec
+	config_foreach migrate_gateway_remote remote
+}
+
 main() {
 	migrate_ipsec
 	migrate_ignore_routing_tables
 	migrate_local_nat
+	migrate_gateway
 }
 
 main

--- a/net/strongswan/files/etc/uci-defaults/strongswan
+++ b/net/strongswan/files/etc/uci-defaults/strongswan
@@ -75,11 +75,33 @@ migrate_gateway() {
 	config_foreach migrate_gateway_remote remote
 }
 
+migrate_remote_gateway_remote() {
+	local cfg="$1"
+
+	local remote_gateway value
+
+	config_get remote_gateway "$cfg" remote_gateway ""
+	[ -z "$remote_gateway" ] && return
+
+	for value in $remote_gateway; do
+		uci add_list "ipsec.${cfg}.remote_addrs=${value}"
+	done
+
+	uci -q delete "ipsec.${cfg}.remote_gateway"
+	uci commit ipsec
+}
+
+migrate_remote_gateway() {
+	config_load ipsec
+	config_foreach migrate_remote_gateway_remote remote
+}
+
 main() {
 	migrate_ipsec
 	migrate_ignore_routing_tables
 	migrate_local_nat
 	migrate_gateway
+	migrate_remote_gateway
 }
 
 main

--- a/net/strongswan/files/etc/uci-defaults/strongswan
+++ b/net/strongswan/files/etc/uci-defaults/strongswan
@@ -118,6 +118,27 @@ migrate_local_ip() {
 	config_foreach migrate_local_ip_local remote
 }
 
+migrate_local_sourceip_vips() {
+	local cfg="$1"
+
+	local local_sourceip value
+
+	config_get local_sourceip "$cfg" local_sourceip ""
+	[ -z "$local_sourceip" ] && return
+
+	for value in $local_sourceip; do
+		uci add_list "ipsec.${cfg}.vips=${value}"
+	done
+
+	uci -q delete "ipsec.${cfg}.local_sourceip"
+	uci commit ipsec
+}
+
+migrate_local_sourceip() {
+	config_load ipsec
+	config_foreach migrate_local_sourceip_vips remote
+}
+
 main() {
 	migrate_ipsec
 	migrate_ignore_routing_tables
@@ -125,6 +146,7 @@ main() {
 	migrate_gateway
 	migrate_remote_gateway
 	migrate_local_ip
+	migrate_local_sourceip
 }
 
 main

--- a/net/strongswan/files/swanctl.init
+++ b/net/strongswan/files/swanctl.init
@@ -553,6 +553,8 @@ config_remote() {
 	[ -n "$local_identifier" ] && swanctl_xappend3 "id = \"$local_identifier\""
 	[ "$local_auth_method" = pubkey ] && [ -n "$local_cert" ] && \
 		swanctl_xappend3 "certs = $local_cert"
+	[ "$local_auth_method" = pubkey ] && [ -n "$local_key" ] && \
+		swanctl_xappend3 "privkeys = $local_key"
 	swanctl_xappend2 "}"
 
 	swanctl_xappend2 "remote {"

--- a/net/strongswan/files/swanctl.init
+++ b/net/strongswan/files/swanctl.init
@@ -226,7 +226,6 @@ config_child() {
 	local mode="$2"
 
 	local startaction
-	local local_nat
 	local updown
 	local firewall
 	local lifetime
@@ -247,7 +246,6 @@ config_child() {
 	local remote_subnet
 
 	config_get startaction "$conf" startaction "route"
-	config_get local_nat "$conf" local_nat ""
 	config_get updown "$conf" updown ""
 	config_get firewall "$conf" firewall ""
 	config_get lifetime "$conf" lifetime ""
@@ -332,8 +330,6 @@ config_child() {
 		hw_offload=""
 		;;
 	esac
-
-	[ -n "$local_nat" ] && local_subnet="$local_nat"
 
 	swanctl_xappend3 "$conf {"
 

--- a/net/strongswan/files/swanctl.init
+++ b/net/strongswan/files/swanctl.init
@@ -374,7 +374,7 @@ config_child() {
 	[ -n "$dpdaction" ] && swanctl_xappend4 "dpd_action = $dpdaction"
 	[ -n "$replay_window" ] && swanctl_xappend4 "replay_window = $replay_window"
 
-        swanctl_xappend3 "}"
+	swanctl_xappend3 "}"
 }
 
 config_tunnel() {
@@ -513,9 +513,9 @@ config_remote() {
 
 	if [ -n "$local_key" ]; then
 		[ "$(dirname "$local_key")" != "." ] && \
-		   fatal "local_key $local_key can't be pathname"
+			fatal "local_key $local_key can't be pathname"
 		[ -f "/etc/swanctl/private/$local_key" ] || \
-		   fatal "local_key $local_key not found"
+			fatal "local_key $local_key not found"
 	fi
 
 	local ike_proposal
@@ -526,16 +526,16 @@ config_remote() {
 	if [ "$auth_method" = pubkey ]; then
 		if [ -n "$ca_cert" ]; then
 			[ "$(dirname "$ca_cert")" != "." ] && \
-			    fatal "ca_cert $ca_cert can't be pathname"
+				fatal "ca_cert $ca_cert can't be pathname"
 			[ -f "/etc/swanctl/x509ca/$ca_cert" ] || \
-			    fatal "ca_cert $ca_cert not found"
+				fatal "ca_cert $ca_cert not found"
 		fi
 
 		if [ -n "$local_cert" ]; then
 			[ "$(dirname "$local_cert")" != "." ] && \
-			    fatal "local_cert $local_cert can't be pathname"
+				fatal "local_cert $local_cert can't be pathname"
 			[ -f "/etc/swanctl/x509/$local_cert" ] || \
-			    fatal "local_cert $local_cert not found"
+				fatal "local_cert $local_cert not found"
 		fi
 	fi
 
@@ -559,7 +559,7 @@ config_remote() {
 
 	[ -n "$local_identifier" ] && swanctl_xappend3 "id = \"$local_identifier\""
 	[ "$local_auth_method" = pubkey ] && [ -n "$local_cert" ] && \
-	    swanctl_xappend3 "certs = $local_cert"
+		swanctl_xappend3 "certs = $local_cert"
 	swanctl_xappend2 "}"
 
 	swanctl_xappend2 "remote {"

--- a/net/strongswan/files/swanctl.init
+++ b/net/strongswan/files/swanctl.init
@@ -441,13 +441,11 @@ config_remote() {
 
 	local enabled
 	local gateway
-	local local_sourceip
-	local local_ip
-	local local_identifier
-	local remote_gateway
-	local remote_identifier
 	local pre_shared_key
 	local auth_method
+	local local_identifier
+	local remote_identifier
+	local local_ip
 	local keyingtries
 	local dpddelay
 	local encap
@@ -462,9 +460,10 @@ config_remote() {
 	local overtime
 	local send_cert
 	local send_certreq
+	local eap_id
+	local local_sourceip
 	local remote_ca_certs
 	local pools
-	local eap_id
 
 	config_get_bool enabled "$conf" enabled 0
 	[ $enabled -eq 0 ] && return
@@ -509,6 +508,7 @@ config_remote() {
 		;;
 	esac
 
+	local remote_gateway
 	[ "$gateway" = "any" ] && remote_gateway="%any" || remote_gateway="$gateway"
 
 	if [ -n "$local_key" ]; then

--- a/net/strongswan/files/swanctl.init
+++ b/net/strongswan/files/swanctl.init
@@ -436,7 +436,6 @@ config_remote() {
 	local conf="$1"
 
 	local enabled
-	local remote_gateway
 	local pre_shared_key
 	local auth_method
 	local local_identifier
@@ -457,6 +456,7 @@ config_remote() {
 	local send_cert
 	local send_certreq
 	local eap_id
+	local remote_addrs
 	local local_sourceip
 	local remote_ca_certs
 	local pools
@@ -464,7 +464,6 @@ config_remote() {
 	config_get_bool enabled "$conf" enabled 0
 	[ $enabled -eq 0 ] && return
 
-	config_get remote_gateway "$conf" remote_gateway '%any'
 	config_get pre_shared_key "$conf" pre_shared_key
 	config_get auth_method "$conf" authentication_method
 	config_get local_identifier "$conf" local_identifier ""
@@ -486,6 +485,7 @@ config_remote() {
 	config_get_bool send_certreq "$conf" send_certreq 1
 	config_get eap_id "$conf" eap_id "%any"
 
+	config_list_foreach "$conf" remote_addrs append_var remote_addrs ","
 	config_list_foreach "$conf" local_sourceip append_var local_sourceip ","
 	config_list_foreach "$conf" remote_ca_certs append_var remote_ca_certs ","
 	config_list_foreach "$conf" pools append_var pools ","
@@ -537,8 +537,7 @@ config_remote() {
 	swanctl_xappend0 "connections {"
 	swanctl_xappend1 "$conf {"
 	swanctl_xappend2 "local_addrs = $local_ip"
-	swanctl_xappend2 "remote_addrs = $remote_gateway"
-
+	[ -n "$remote_addrs" ] && swanctl_xappend2 "remote_addrs = $remote_addrs"
 	[ -n "$local_sourceip" ] && swanctl_xappend2 "vips = $local_sourceip"
 	[ -n "$fragmentation" ] && swanctl_xappend2 "fragmentation = $fragmentation"
 	[ -n "$pools" ] && swanctl_xappend2 "pools = $pools"

--- a/net/strongswan/files/swanctl.init
+++ b/net/strongswan/files/swanctl.init
@@ -225,26 +225,26 @@ config_child() {
 	local conf="$1"
 	local mode="$2"
 
-	local hw_offload
-	local interface
-	local ipcomp
-	local priority
-	local local_subnet
+	local startaction
 	local local_nat
 	local updown
 	local firewall
-	local remote_subnet
 	local lifetime
 	local dpdaction
 	local closeaction
-	local startaction
 	local if_id
 	local rekeytime
+	local ipcomp
+	local interface
+	local hw_offload
+	local priority
 	local rekeybytes
 	local lifebytes
 	local rekeypackets
 	local lifepackets
 	local replay_window
+	local local_subnet
+	local remote_subnet
 
 	config_get startaction "$conf" startaction "route"
 	config_get local_nat "$conf" local_nat ""

--- a/net/strongswan/files/swanctl.init
+++ b/net/strongswan/files/swanctl.init
@@ -457,7 +457,7 @@ config_remote() {
 	local eap_id
 	local local_addrs
 	local remote_addrs
-	local local_sourceip
+	local vips
 	local remote_ca_certs
 	local pools
 
@@ -486,7 +486,7 @@ config_remote() {
 
 	config_list_foreach "$conf" local_addrs append_var local_addrs ","
 	config_list_foreach "$conf" remote_addrs append_var remote_addrs ","
-	config_list_foreach "$conf" local_sourceip append_var local_sourceip ","
+	config_list_foreach "$conf" vips append_var vips ","
 	config_list_foreach "$conf" remote_ca_certs append_var remote_ca_certs ","
 	config_list_foreach "$conf" pools append_var pools ","
 
@@ -538,7 +538,7 @@ config_remote() {
 	swanctl_xappend1 "$conf {"
 	[ -n "$local_addrs" ] && swanctl_xappend2 "local_addrs = $local_addrs"
 	[ -n "$remote_addrs" ] && swanctl_xappend2 "remote_addrs = $remote_addrs"
-	[ -n "$local_sourceip" ] && swanctl_xappend2 "vips = $local_sourceip"
+	[ -n "$vips" ] && swanctl_xappend2 "vips = $vips"
 	[ -n "$fragmentation" ] && swanctl_xappend2 "fragmentation = $fragmentation"
 	[ -n "$pools" ] && swanctl_xappend2 "pools = $pools"
 

--- a/net/strongswan/files/swanctl.init
+++ b/net/strongswan/files/swanctl.init
@@ -436,7 +436,7 @@ config_remote() {
 	local conf="$1"
 
 	local enabled
-	local gateway
+	local remote_gateway
 	local pre_shared_key
 	local auth_method
 	local local_identifier
@@ -464,7 +464,7 @@ config_remote() {
 	config_get_bool enabled "$conf" enabled 0
 	[ $enabled -eq 0 ] && return
 
-	config_get gateway "$conf" gateway
+	config_get remote_gateway "$conf" remote_gateway '%any'
 	config_get pre_shared_key "$conf" pre_shared_key
 	config_get auth_method "$conf" authentication_method
 	config_get local_identifier "$conf" local_identifier ""
@@ -504,8 +504,6 @@ config_remote() {
 		;;
 	esac
 
-	local remote_gateway
-	[ "$gateway" = "any" ] && remote_gateway="%any" || remote_gateway="$gateway"
 
 	if [ -n "$local_key" ]; then
 		[ "$(dirname "$local_key")" != "." ] && \

--- a/net/strongswan/files/swanctl.init
+++ b/net/strongswan/files/swanctl.init
@@ -440,7 +440,6 @@ config_remote() {
 	local auth_method
 	local local_identifier
 	local remote_identifier
-	local local_ip
 	local keyingtries
 	local dpddelay
 	local encap
@@ -456,6 +455,7 @@ config_remote() {
 	local send_cert
 	local send_certreq
 	local eap_id
+	local local_addrs
 	local remote_addrs
 	local local_sourceip
 	local remote_ca_certs
@@ -468,7 +468,6 @@ config_remote() {
 	config_get auth_method "$conf" authentication_method
 	config_get local_identifier "$conf" local_identifier ""
 	config_get remote_identifier "$conf" remote_identifier ""
-	config_get local_ip "$conf" local_ip "%any"
 	config_get keyingtries "$conf" keyingtries "3"
 	config_get dpddelay "$conf" dpddelay "30s"
 	config_get_bool encap "$conf" encap 0
@@ -485,6 +484,7 @@ config_remote() {
 	config_get_bool send_certreq "$conf" send_certreq 1
 	config_get eap_id "$conf" eap_id "%any"
 
+	config_list_foreach "$conf" local_addrs append_var local_addrs ","
 	config_list_foreach "$conf" remote_addrs append_var remote_addrs ","
 	config_list_foreach "$conf" local_sourceip append_var local_sourceip ","
 	config_list_foreach "$conf" remote_ca_certs append_var remote_ca_certs ","
@@ -536,7 +536,7 @@ config_remote() {
 	swanctl_xappend0 "# config for $conf"
 	swanctl_xappend0 "connections {"
 	swanctl_xappend1 "$conf {"
-	swanctl_xappend2 "local_addrs = $local_ip"
+	[ -n "$local_addrs" ] && swanctl_xappend2 "local_addrs = $local_addrs"
 	[ -n "$remote_addrs" ] && swanctl_xappend2 "remote_addrs = $remote_addrs"
 	[ -n "$local_sourceip" ] && swanctl_xappend2 "vips = $local_sourceip"
 	[ -n "$fragmentation" ] && swanctl_xappend2 "fragmentation = $fragmentation"


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @pprindeville 

**Description:**

- Remove `local_nat` option, is no longer applicable in this form.
- Rename UCI option `gateway`  and `local_ip` to `remote_addrs` and `local_addrs` to match the naming used in swanctl configuration

LuCI changes https://github.com/openwrt/luci/pull/8881

---

## 🧪 Run Testing Details

- **OpenWrt Version:** master
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** APU3

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
