### PR TITLE
strongswan: add mark option for use with VTI

### DIFF
--- a/net/strongswan/files/swanctl.init
+++ b/net/strongswan/files/swanctl.init
@@ -239,6 +239,7 @@ config_child() {
 	local closeaction
 	local startaction
 	local if_id
+	local mark
 	local rekeytime
 	local rekeybytes
 	local lifebytes
@@ -254,6 +255,7 @@ config_child() {
 	config_get dpdaction "$conf" dpdaction "none"
 	config_get closeaction "$conf" closeaction "none"
 	config_get if_id "$conf" if_id ""
+	config_get mark "$conf" mark ""
 	config_get rekeytime "$conf" rekeytime ""
 	config_get_bool ipcomp "$conf" ipcomp 0
 	config_get interface "$conf" interface ""
@@ -345,6 +347,7 @@ config_child() {
 	[ -n "$interface" ] && swanctl_xappend4 "interface = $interface"
 	[ -n "$priority" ] && swanctl_xappend4 "priority = $priority"
 	[ -n "$if_id" ] && swanctl_xappend4 "if_id_in = $if_id" "if_id_out = $if_id"
+	[ -n "$mark" ] && swanctl_xappend4 "mark_in = $mark" "mark_out = $mark"
 	[ -n "$startaction" -a "$startaction" != "none" ] && swanctl_xappend4 "start_action = $startaction"
 	[ -n "$closeaction" -a "$closeaction" != "none" ] && swanctl_xappend4 "close_action = $closeaction"
 	swanctl_xappend4 "esp_proposals = $esp_proposal"


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @pprindeville 
**Description:**
Add mark option for use with VTI interfaces. Merge mark_in and mark_out for symmetry with if_id.

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.