### PR TITLE
freeradius3: fix recursive dependency from libopenssl-legacy

### DIFF
--- a/net/freeradius3/Makefile
+++ b/net/freeradius3/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=freeradius3
 PKG_VERSION:=3.2.10
 PKG_VERSION_UNDERSCORE:=$(subst .,_,${PKG_VERSION})
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=freeradius-server-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/FreeRADIUS/freeradius-server/releases/download/release_$(PKG_VERSION_UNDERSCORE)/
@@ -46,7 +46,7 @@ endef
 
 define Package/freeradius3
   $(call Package/freeradius3/Default)
-  DEPENDS:=+freeradius3-common
+  DEPENDS:=+freeradius3-common +FREERADIUS3_OPENSSL:libopenssl +FREERADIUS3_OPENSSL:libopenssl-legacy
   TITLE:=A flexible RADIUS server (version 3)
 endef
 
@@ -710,7 +710,7 @@ endef
 
 define Package/freeradius3-utils
   $(call Package/freeradius3/Default)
-  DEPENDS:=+freeradius3-common
+  DEPENDS:=+freeradius3-common +FREERADIUS3_OPENSSL:libopenssl +FREERADIUS3_OPENSSL:libopenssl-legacy
   TITLE:=Misc. client utilities
 endef
 


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:**  me

**Description:**

The 3.2.10 update made freeradius3-common select libopenssl-legacy, which hard-depends on libopenssl; the generator propagates that onto common's selectors (freeradius3, freeradius3-utils) as a FREERADIUS3_OPENSSL depends, looping with the SSL choice. Declare the OpenSSL deps there too to break it.

Fixes: https://github.com/openwrt/packages/pull/30081#issuecomment-5100951400


---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [ ] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

