### PR TITLE
sing-box: bump to 1.13.18 without Naive outbound support

### DIFF
--- a/net/sing-box/Makefile
+++ b/net/sing-box/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sing-box
-PKG_VERSION:=1.12.22
+PKG_VERSION:=1.13.18
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/SagerNet/sing-box/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=6c4333c3f53a07cc96b63a801fdf6c156820d51cd2eb05e44ea78df290a45377
+PKG_HASH:=e41ed9d7adecd7597c1d5cc91818366a9538d94b41c244225ac40ac948c643f5
 
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_LICENSE_FILES:=LICENSE
@@ -20,6 +20,7 @@ PKG_BUILD_FLAGS:=no-mips16
 GO_PKG:=github.com/sagernet/sing-box
 GO_PKG_BUILD_PKG:=$(GO_PKG)/cmd/sing-box
 
+GO_PKG_LDFLAGS:=-checklinkname=0
 GO_PKG_LDFLAGS_X:=$(GO_PKG)/constant.Version=$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk
@@ -63,6 +64,9 @@ define Package/sing-box/config
 		config SINGBOX_WITH_ACME
 			bool "Build with ACME TLS certificate issuer support"
 
+		config SINGBOX_WITH_CCM
+			bool "Build with Claude Code Multiplexer service support"
+
 		config SINGBOX_WITH_CLASH_API
 			bool "Build with Clash API support"
 			default y
@@ -79,6 +83,9 @@ define Package/sing-box/config
 		config SINGBOX_WITH_GVISOR
 			bool "Build with gVisor support"
 			default y
+
+		config SINGBOX_WITH_OCM
+			bool "Build with OpenAI Codex Multiplexer service support"
 
 		config SINGBOX_WITH_QUIC
 			bool "Build with QUIC support"
@@ -103,11 +110,13 @@ endef
 
 PKG_CONFIG_DEPENDS:= \
 	CONFIG_SINGBOX_WITH_ACME \
+	CONFIG_SINGBOX_WITH_CCM \
 	CONFIG_SINGBOX_WITH_CLASH_API \
 	CONFIG_SINGBOX_WITH_DHCP \
 	CONFIG_SINGBOX_WITH_EMBEDDED_TOR \
 	CONFIG_SINGBOX_WITH_GRPC \
 	CONFIG_SINGBOX_WITH_GVISOR \
+	CONFIG_SINGBOX_WITH_OCM \
 	CONFIG_SINGBOX_WITH_QUIC \
 	CONFIG_SINGBOX_WITH_TAILSCALE \
 	CONFIG_SINGBOX_WITH_UTLS \
@@ -118,20 +127,24 @@ ifeq ($(BUILD_VARIANT),tiny)
 ifeq ($(CONFIG_SMALL_FLASH),)
 GO_PKG_TAGS:=with_gvisor
 endif
-GO_PKG_TAGS:=$(GO_PKG_TAGS),with_quic,with_utls,with_clash_api
+GO_PKG_TAGS:=$(subst $(space),$(comma),$(strip $(GO_PKG_TAGS) with_quic with_utls with_clash_api badlinkname tfogo_checklinkname0))
 else
 GO_PKG_TAGS:=$(subst $(space),$(comma),$(strip \
 	$(if $(CONFIG_SINGBOX_WITH_ACME),with_acme) \
+	$(if $(CONFIG_SINGBOX_WITH_CCM),with_ccm) \
 	$(if $(CONFIG_SINGBOX_WITH_CLASH_API),with_clash_api) \
 	$(if $(CONFIG_SINGBOX_WITH_DHCP),with_dhcp) \
 	$(if $(CONFIG_SINGBOX_WITH_EMBEDDED_TOR),with_embedded_tor) \
 	$(if $(CONFIG_SINGBOX_WITH_GRPC),with_grpc) \
 	$(if $(CONFIG_SINGBOX_WITH_GVISOR),with_gvisor) \
+	$(if $(CONFIG_SINGBOX_WITH_OCM),with_ocm) \
 	$(if $(CONFIG_SINGBOX_WITH_QUIC),with_quic) \
 	$(if $(CONFIG_SINGBOX_WITH_TAILSCALE),with_tailscale) \
 	$(if $(CONFIG_SINGBOX_WITH_UTLS),with_utls) \
 	$(if $(CONFIG_SINGBOX_WITH_V2RAY_API),with_v2ray_api) \
 	$(if $(CONFIG_SINGBOX_WITH_WIREGUARD),with_wireguard) \
+	badlinkname \
+	tfogo_checklinkname0 \
 ))
 endif
 


### PR DESCRIPTION
This patch updates sing-box from 1.12.22 to 1.13.18.

Upstream release information:
https://github.com/SagerNet/sing-box/releases/tag/v1.13.0
https://github.com/SagerNet/sing-box/releases/tag/v1.13.18

### Scope note:

**The upstream Naive outbound feature is intentionally not enabled in this update.**
Naive outbound requires additional build system integration because it depends on
Chromium Network Stack (Cronet). Depending on target and build mode, it requires
either the Cronet runtime library or a Chromium-based toolchain.
Upstream documentation:
https://sing-box.sagernet.org/configuration/outbound/naive/#structure

### Changes:

**1. Add upstream linker flags and compatibility build tags**

Add linker flags required by the sing-box upstream release build:
- -checklinkname=0

Documentation:
https://sing-box.sagernet.org/installation/build-from-source/#linker-flags

-checklinkname=0 is required by the sing-box 1.13.x build configuration due to its use of
low-level go:linkname functionality and the stricter linkname validation in newer Go toolchains.

Add upstream compatibility build tags required by sing-box 1.13.x:
- badlinkname
- tfogo_checklinkname0

These tags are part of the upstream sing-box release build configuration:
https://sing-box.sagernet.org/installation/build-from-source/#build-tags

**2. Add optional CCM and OCM build options**

Add new optional OpenWrt configuration options:
- CONFIG_SINGBOX_WITH_CCM
  Build with Claude Code Multiplexer service support
- CONFIG_SINGBOX_WITH_OCM
  Build with OpenAI Codex Multiplexer service support

Both options are disabled by default and are only enabled when explicitly
selected by the user.

The corresponding upstream build tags are:
- with_ccm
- with_ocm

Documentation: https://sing-box.sagernet.org/installation/build-from-source/#build-tags

## 📦 Package Details

**Maintainer:**  @brvphoenix 
---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12.5
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** Xiaomi Mi Router AX3000T