### PR TITLE
libextractor: don't auto-link libapparmor

### DIFF
--- a/libs/libextractor/Makefile
+++ b/libs/libextractor/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libextractor
 PKG_VERSION:=1.14
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 # ToDo:
 # - package missing optional dependencies: libexiv2, gsf, librpm, smf, tidy
@@ -62,6 +62,9 @@ CONFIGURE_ARGS += \
 	--disable-gsf \
 	--disable-rpath \
 	--with$(if $(CONFIG_PACKAGE_libextractor-plugin-gstreamer),,out)-gstreamer
+
+CONFIGURE_VARS += \
+	ac_cv_lib_apparmor_aa_change_profile=no
 
 TARGET_CFLAGS += -D__GNU_LIBRARY__
 


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:**  me

**Description:**

When libapparmor installs headers and libraries for build, libextractor picks it up and fails with "missing dependencies libapparmor.so.1").

Disable it explicitly via configure.

Fixes: https://github.com/openwrt/packages/pull/30068#issuecomment-5107754731
Fixes: 3253c6c9b ("apparmor: stage libapparmor headers via InstallDev")

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [ ] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
