### PR TITLE
snapcast: fix "dirty" cmake-add-build-with-soxr-option.patch

### DIFF
--- a/sound/snapcast/patches/010-cmake-add-build-with-soxr-option.patch
+++ b/sound/snapcast/patches/010-cmake-add-build-with-soxr-option.patch
@@ -17,8 +17,6 @@ Assisted-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
  CMakeLists.txt | 5 ++++-
  1 file changed, 4 insertions(+), 1 deletion(-)
 
-diff --git a/CMakeLists.txt b/CMakeLists.txt
-index ef2252d..eb76646 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -264,7 +264,10 @@ if(NOT WIN32 AND NOT ANDROID)
@@ -33,6 +31,3 @@ index ef2252d..eb76646 100644
    if(SOXR_FOUND)
      add_compile_definitions(HAS_SOXR)
    else()
--- 
-2.47.3
-


### PR DESCRIPTION
Refresh "cmake-add-build-with-soxr-option"-patch.
The CI/CD pipeline checks whether patches are byte-identical to what `make package/$(PKG_NAME)/refresh` produces.
While the patch applied cleanly, it contained the index-line and a git-footer, which caused the CI/CD-pipeline's patch-check  to bail out.

Related to https://github.com/openwrt/packages/pull/30079#issuecomment-5100710841 ff.

I won't merge this one this time :)

/cc @BKPepe 


## 📦 Package Details

**Maintainer:** @xabolcs @davidandreoletti
<sub>Szabolcs Hubai <szab.hu@gmail.com>, David Andreoletti <david@andreoletti.net></sub>

**Description:**
see above

---

## 🧪 Run Testing Details

- **OpenWrt Version:** master (`305c7599e5fa400cf6221fd0a596dbd014529235`)
- **OpenWrt Target/Subtarget:** x86_64
- **OpenWrt Device:** qemu/kvm

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [X] It can be applied using `git am`
- [X] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [X] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>