### PR TITLE
lua-eco: fix LUA_ECO_CRASH_BACKTRACE recursive dependency

### DIFF
--- a/lang/lua/lua-eco/Makefile
+++ b/lang/lua/lua-eco/Makefile
@@ -40,7 +40,6 @@ endef
 define Package/lua-eco/config
 	config LUA_ECO_CRASH_BACKTRACE
 		bool "Enable fatal signal C backtrace diagnostics"
-		depends on PACKAGE_lua-eco
 		depends on !(USE_MUSL && powerpc)
 		default n
 		help


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @zhaojh329

**Description:**

LUA_ECO_CRASH_BACKTRACE declared "depends on PACKAGE_lua-eco" while
lua-eco's DEPENDS carries "+LUA_ECO_CRASH_BACKTRACE:libunwind", which the
generator turns into "select libunwind if LUA_ECO_CRASH_BACKTRACE". kconfig
then sees lua-eco and the symbol depending on each other:

  error: recursive dependency detected!
    symbol LUA_ECO_CRASH_BACKTRACE depends on PACKAGE_lua-eco
    symbol PACKAGE_lua-eco depends on LUA_ECO_CRASH_BACKTRACE

Drop the redundant guard; the option only affects lua-eco's own build, so
nothing is pulled in when lua-eco itself is not selected.

Fixes: https://github.com/openwrt/packages/pull/30098#issuecomment-5113528752


---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [ ] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
