### PR TITLE
modemmanager: skip live report when MM isn't running yet

### DIFF
--- a/net/modemmanager/Makefile
+++ b/net/modemmanager/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=modemmanager
 PKG_VERSION:=1.24.0
-PKG_RELEASE:=11
+PKG_RELEASE:=12
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://gitlab.freedesktop.org/mobile-broadband/ModemManager.git

--- a/net/modemmanager/files/etc/hotplug.d/net/25-modemmanager-net
+++ b/net/modemmanager/files/etc/hotplug.d/net/25-modemmanager-net
@@ -8,6 +8,13 @@
 # We require a interface name
 [ -n "${INTERFACE}" ] || exit
 
+# Virtual net devices (SQM IFB, GRE, bridges, veth, tun/tap, ...)
+# can never be modems; mm_report_event drops them internally, skip
+# the log-noisy hotplug script entirely.
+case "${DEVPATH}" in
+	/devices/virtual/*) exit ;;
+esac
+
 # Always make sure the rundir exists
 mkdir -m 0755 -p "${MODEMMANAGER_RUNDIR}"
 

--- a/net/modemmanager/files/usr/share/ModemManager/modemmanager.common
+++ b/net/modemmanager/files/usr/share/ModemManager/modemmanager.common
@@ -158,6 +158,12 @@ mm_report_event() {
 			;;
 	esac
 
+	# Skip live report if MM isn't up; wrapper will replay from cache.
+	if [ ! -s "${MODEMMANAGER_PID_FILE}" ] || \
+		! kill -0 "$(cat "${MODEMMANAGER_PID_FILE}" 2>/dev/null)" 2>/dev/null; then
+		return
+	fi
+
 	# Report the event
 	mm_log "debug" "Report event: action=${action}, name=${name}, subsystem=${subsystem}"
 	result=$(mmcli --report-kernel-event="action=${action},name=${name},subsystem=${subsystem}" 2>&1)


### PR DESCRIPTION
At boot procd replays every previously-seen uevent before `/etc/init.d/modemmanager` starts. Each replay walks the `hotplug.d/` tree, which calls `mm_report_event()` in `modemmanager.common`. That helper does two independent things:

1. appends the event to `${MODEMMANAGER_EVENTS_CACHE}`, and
2. runs `mmcli --report-kernel-event=...` to notify a live MM.

Step 1 is what matters for boot; step 2 exists so events fired after MM is running get reported without waiting for the next cache replay. The cache path is intentional: `ModemManager-wrapper` starts MM, then `mm_report_events_from_cache()` polls `mmcli -L` until the bus is available and replays every cached event.

At boot MM isn't on the bus yet, so step 2 always fails with:

```
daemon.err ModemManager[NNN]: hotplug: Couldn't report kernel event: error: couldn't get bus: Could not connect: No such file or directory
```

That's one `daemon.err` line per hotplug script per port, per boot. On a dual-modem board that's a dozen spurious errors before MM even starts. Nothing is lost — the wrapper's cache replay picks them all up seconds later — but the log noise makes real ModemManager errors harder to spot.

Guard the live call with a cheap pidfile-based liveness check. If MM isn't running, the event is silently cached and the wrapper handles it. If MM is running, behavior is unchanged.

## Reproducer
Any OpenWrt install with `modemmanager` and at least one modem attached. `logread | grep 'Couldn\'t report kernel event'` after boot shows one line per port.

## Verification
Built for `aarch64_generic` (LS1046-based board with two Telit FN990 modems, MHI PCI attached, ports `wwan0{at0,at1,qcdm0,mbim0}` and `wwan1{at0,at1,qcdm0,mbim0}` plus `ttyUSB{0,1}`). Before: 12 `Couldn't report kernel event` errors per boot. After: 0. Runtime hotplug (unplug + replug a modem) still works — mmcli is invoked normally once MM's pidfile exists.