### PR TITLE
libxmlb: update to 0.3.29

### DIFF
--- a/libs/libxmlb/Makefile
+++ b/libs/libxmlb/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libxmlb
-PKG_VERSION:=0.3.23
+PKG_VERSION:=0.3.29
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/hughsie/libxmlb/releases/download/$(PKG_VERSION)
-PKG_HASH:=ab86eb2073592448a4e0263ab56e222de092c0a3964b66a8d696cac071c8ee3c
+PKG_HASH:=448294be33bfae62f00fa66e506f1cae80237ce71b7ab6530aefa75005eeb08a
 
 PKG_MAINTAINER:=Lukas Voegl <lvoegl@tdt.de>
 PKG_LICENSE:=LGPL-2.1-or-later


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @lvoegl

**Description:**
Since current version 0.3.23 there were a few bugfixes (OOB read, NULL pointer dereference) and certain XML queries have been sped up.

Release notes: https://github.com/hughsie/libxmlb/releases/tag/0.3.29

---

## 🧪 Run Testing Details

- **OpenWrt Version:** master
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** APU3
---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.