### PR TITLE
[25.12] nghttp2: bump to 1.70.0

### DIFF
--- a/libs/nghttp2/Makefile
+++ b/libs/nghttp2/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nghttp2
-PKG_VERSION:=1.66.0
+PKG_VERSION:=1.70.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/nghttp2/nghttp2/releases/download/v$(PKG_VERSION)
-PKG_HASH:=00ba1bdf0ba2c74b2a4fe6c8b1069dc9d82f82608af24442d430df97c6f9e631
+PKG_HASH:=e05cb1388eaca3830aded4ccf20044b6e1ac1a61411dcca11b0437c4285c8bc2
 
 PKG_MAINTAINER:=Hans Dedecker <dedeckeh@gmail.com>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Various Updates (1.66.0 to 1.70.0)

Notable Changes:
Fixes CVE-2026-27135 (1.68.1)


(cherry picked from commit fade4013e0a97ccefb3a36ac19b80fb97a67e0e3)
