### PR TITLE
ulogd: update output plugins config flags

### DIFF
--- a/net/ulogd/Makefile
+++ b/net/ulogd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ulogd
 PKG_VERSION:=2.0.9
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://netfilter.org/pub/ulogd/
@@ -127,31 +127,28 @@ CONFIGURE_ARGS += \
 	--enable-nflog
 
 ifneq ($(DEVELOPER)$(CONFIG_PACKAGE_ulogd-mod-dbi),)
-	CONFIGURE_ARGS += --with-dbi \
-		--with-dbi-inc=$(STAGING_DIR)/usr/include/dbi \
-		--with-dbi-lib=$(STAGING_DIR)/usr/lib
+	CONFIGURE_ARGS += --enable-dbi
 else
-	CONFIGURE_ARGS += --without-dbi
+	CONFIGURE_ARGS += --disable-dbi
 endif
 
 ifneq ($(DEVELOPER)$(CONFIG_PACKAGE_ulogd-mod-mysql),)
-	CONFIGURE_ARGS += \
-		--with-mysql-inc=$(STAGING_DIR)/usr/include/mysql \
-		--with-mysql-lib=$(STAGING_DIR)/usr/lib/mysql
+	CONFIGURE_ARGS += --enable-mysql \
+					  --with-mysql-config=$(STAGING_DIR)/usr/bin/mysql_config
 else
-	CONFIGURE_ARGS += --without-mysql
+	CONFIGURE_ARGS += --disable-mysql
 endif
 
 ifneq ($(DEVELOPER)$(CONFIG_PACKAGE_ulogd-mod-pgsql),)
-	CONFIGURE_ARGS += --with-pgsql="$(STAGING_DIR)/usr"
+	CONFIGURE_ARGS += --enable-pgsql
 else
-	CONFIGURE_ARGS += --without-pgsql
+	CONFIGURE_ARGS += --disable-pgsql
 endif
 
 ifneq ($(CONFIG_PACKAGE_ulogd-mod-sqlite),)
-	CONFIGURE_ARGS += --with-sqlite="$(STAGING_DIR)/usr"
+	CONFIGURE_ARGS += --enable-sqlite3
 else
-	CONFIGURE_ARGS += --without-sqlite
+	CONFIGURE_ARGS += --disable-sqlite3
 endif
 
 define Package/ulogd/install


### PR DESCRIPTION
Start from ulogd 2.0.8, using `--enable-XYZ` instead of `--with-XYZ` https://git.netfilter.org/ulogd2/commit/configure.ac?id=794f0385ab60fd8c52ff3ce498c8aac78b58ac20
