### PR TITLE
modemmanager: skip virtual net devices in hotplug script

### DIFF
--- a/net/modemmanager/Makefile
+++ b/net/modemmanager/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=modemmanager
 PKG_VERSION:=1.24.0
-PKG_RELEASE:=11
+PKG_RELEASE:=12
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://gitlab.freedesktop.org/mobile-broadband/ModemManager.git

--- a/net/modemmanager/files/etc/hotplug.d/net/25-modemmanager-net
+++ b/net/modemmanager/files/etc/hotplug.d/net/25-modemmanager-net
@@ -8,6 +8,11 @@
 # We require a interface name
 [ -n "${INTERFACE}" ] || exit
 
+# Virtual net devices (SQM IFB, GRE, bridges, veth, tun/tap, ...)
+# can never be modems; mm_report_event drops them internally, skip
+# the log-noisy hotplug script entirely.
+case "${DEVPATH}" in /devices/virtual/*) exit ;; esac
+
 # Always make sure the rundir exists
 mkdir -m 0755 -p "${MODEMMANAGER_RUNDIR}"
 


### PR DESCRIPTION
Every net uevent - eth ports, USB hubs, bridges, taps, SQM IFB, GRE tunnels, veth, tun/tap - is handed to mmcli via `25-modemmanager-net`'s `mm_report_event` call, so ModemManager logs a `not supported by any plugin` notice per device on every boot and hotplug replay:

```
ModemManager[15132]: <msg> [base-manager] couldn't check support
  for device '.../fsl-ehci.0/usb1/1-1/1-1.1':
  not supported by any plugin
```

`mm_report_event()` already discards virtual devices internally, but only after `mm_log "info"` has written a `hotplug: add network interface XXX: event processed` line to daemon.info for every one of them.

Mirror the same guard in the hotplug script by exiting early when `DEVPATH` points under `/devices/virtual/*`, which covers SQM IFB, GRE, bridges, veth, tun/tap. This never rejects a physical modem port (kernel wwan, MHI, USB CDC/RNDIS/QMI/MBIM are all under real bus subtrees).

### Checklist
- [x] I have tested the change on real hardware.
- [x] `PKG_RELEASE` bumped.