### PR TITLE
Update update_porkbun_v3.sh to work with second level domains

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.4
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_LICENSE:=GPL-2.0
 

--- a/net/ddns-scripts/files/usr/lib/ddns/update_porkbun_v3.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/update_porkbun_v3.sh
@@ -29,11 +29,20 @@ __API="https://api.porkbun.com/api/json/v3"
 [ -z "$username" ] && write_log 14 "Service section not configured correctly! Missing 'username'"
 [ -z "$password" ] && write_log 14 "Service section not configured correctly! Missing 'password'"
 
-# Split FQDN into domain and subdomain(s)
-__DOMAIN_REGEX='^\(\(.*\)\.\)\?\([^.]\+\.[^.]\+\)$'
-echo $domain | grep "$__DOMAIN_REGEX" > /dev/null || write_log 14 "Invalid domain! Check 'domain' config"
-__DOMAIN=$(echo $domain | sed -e "s/$__DOMAIN_REGEX/\3/")
-__SUBDOMAIN=$(echo $domain | sed -e "s/$__DOMAIN_REGEX/\2/")
+if echo "$domain" | grep -Fq '@'; then
+	# split __HOST __DOMAIN from $domain
+	# given data:
+	# @example.com for "domain record"
+	# host.sub@example.com for a "host record"
+	__SUBDOMAIN=$(printf %s "$domain" | cut -d@ -f1)
+	__DOMAIN=$(printf %s "$domain" | cut -d@ -f2)
+else
+	# Split FQDN into domain and subdomain(s)
+	__DOMAIN_REGEX='^\(\(.*\)\.\)\?\([^.]\+\.[^.]\+\)$'
+	echo $domain | grep "$__DOMAIN_REGEX" > /dev/null || write_log 14 "Invalid domain! Check 'domain' config"
+	__DOMAIN=$(echo $domain | sed -e "s/$__DOMAIN_REGEX/\3/")
+	__SUBDOMAIN=$(echo $domain | sed -e "s/$__DOMAIN_REGEX/\2/")
+fi
 
 # Determine IPv4 or IPv6 address and record type
 if [ "$use_ipv6" -eq 1 ]; then


### PR DESCRIPTION
Update to support second level domains, code copied from update_cloudflare_com_v4.sh


## 📦 Package Details

**Maintainer:** @feckert @cahorn 
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->
Fix for https://github.com/openwrt/packages/issues/30017 
Uses "@" in $domain to find the split for the subdomain, if no "@" found then just continues with the old way to avoid breaking something. 
I just copied this from the cloudflare updater script.
---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12
- **OpenWrt Target/Subtarget:** 
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
