### PR TITLE
ddns-scripts: update_porkbun_v3.sh bugfix for second level domains

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.4
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_LICENSE:=GPL-2.0
 

--- a/net/ddns-scripts/files/usr/lib/ddns/update_porkbun_v3.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/update_porkbun_v3.sh
@@ -8,6 +8,8 @@
 # given domain and subdomain. Existing CNAME and ALIAS records WILL NOT BE
 # EDITED OR DELETED!  "username" and "password" configurations should be set to
 # Porkbun API key and secret key, respectively.
+# For second level domains or nested subdomains use "@" to separate between the subdomain and the domain
+# e.g. nested.sub@domain.co.tld
 #
 # Porkbun API documentation:
 # https://porkbun.com/api/json/v3/documentation#DNS%20Create%20Record
@@ -29,11 +31,23 @@ __API="https://api.porkbun.com/api/json/v3"
 [ -z "$username" ] && write_log 14 "Service section not configured correctly! Missing 'username'"
 [ -z "$password" ] && write_log 14 "Service section not configured correctly! Missing 'password'"
 
-# Split FQDN into domain and subdomain(s)
-__DOMAIN_REGEX='^\(\(.*\)\.\)\?\([^.]\+\.[^.]\+\)$'
-echo $domain | grep "$__DOMAIN_REGEX" > /dev/null || write_log 14 "Invalid domain! Check 'domain' config"
-__DOMAIN=$(echo $domain | sed -e "s/$__DOMAIN_REGEX/\3/")
-__SUBDOMAIN=$(echo $domain | sed -e "s/$__DOMAIN_REGEX/\2/")
+if echo "$domain" | grep -Fq '@'; then
+	# split __SUBDOMAIN __DOMAIN from $domain
+	# given data:
+	# @example.com for "domain record"
+	# host.sub@example.com for a "host record"
+	__SUBDOMAIN=$(printf %s "$domain" | cut -d@ -f1)
+	__DOMAIN=$(printf %s "$domain" | cut -d@ -f2)
+else
+	# Split FQDN into domain and subdomain(s)
+	__DOMAIN_REGEX='^\(\(.*\)\.\)\?\([^.]\+\.[^.]\+\)$'
+	echo $domain | grep "$__DOMAIN_REGEX" > /dev/null || write_log 14 "Invalid domain! Check 'domain' config"
+	__DOMAIN=$(echo $domain | sed -e "s/$__DOMAIN_REGEX/\3/")
+	__SUBDOMAIN=$(echo $domain | sed -e "s/$__DOMAIN_REGEX/\2/")
+fi
+
+# Porkbun returns record names as FQDNs
+__FQDN="${__SUBDOMAIN:+${__SUBDOMAIN}.}${__DOMAIN}"
 
 # Determine IPv4 or IPv6 address and record type
 if [ "$use_ipv6" -eq 1 ]; then
@@ -78,7 +92,7 @@ function callback_review_record() {
 	json_get_var id "id"
 	json_get_var name "name"
 	json_get_var type "type"
-	[ "$name" == "$domain" -a "$type" == "$__TYPE" ] && echo "$id"
+	[ "$name" == "$__FQDN" -a "$type" == "$__TYPE" ] && echo "$id"
 	json_select ..
 }
 


### PR DESCRIPTION
Update to support second level domains, code copied from update_cloudflare_com_v4.sh

## 📦 Package Details

**Maintainer:** @feckert @cahorn 
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
Fix for https://github.com/openwrt/packages/issues/30017
Uses "@" in $domain to find the split for the subdomain, if no "@" found then just continues with the old way to avoid breaking something.
I just copied this from the cloudflare updater script.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:** 

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
