### PR TITLE
strongswan: swanctl.init: remove invalid privkeys option

### DIFF
--- a/net/strongswan/Makefile
+++ b/net/strongswan/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=strongswan
 PKG_VERSION:=6.0.7
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://download.strongswan.org/ https://download2.strongswan.org/

--- a/net/strongswan/files/swanctl.init
+++ b/net/strongswan/files/swanctl.init
@@ -505,6 +505,10 @@ config_remote() {
 	esac
 
 
+	# swanctl.conf has no "privkeys" option in connections.<conn>.local<suffix>;
+	# strongSwan auto-selects the private key from /etc/swanctl/private by
+	# matching it against the certificate configured via "certs". We only
+	# need to make sure the referenced key file actually exists there.
 	if [ -n "$local_key" ]; then
 		[ "$(dirname "$local_key")" != "." ] && \
 			fatal "local_key $local_key can't be pathname"
@@ -553,8 +557,6 @@ config_remote() {
 	[ -n "$local_identifier" ] && swanctl_xappend3 "id = \"$local_identifier\""
 	[ "$local_auth_method" = pubkey ] && [ -n "$local_cert" ] && \
 		swanctl_xappend3 "certs = $local_cert"
-	[ "$local_auth_method" = pubkey ] && [ -n "$local_key" ] && \
-		swanctl_xappend3 "privkeys = $local_key"
 	swanctl_xappend2 "}"
 
 	swanctl_xappend2 "remote {"


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me

**Description:**

Writing 'privkeys = $local_key' into the generated swanctl.conf is therefore a no-op at best: the option is unknown to the parser and gets silently dropped, so it never had any effect on which key was used.

Drop the bogus assignment. The existing local_key validation making sure the referenced file exists under '/etc/swanctl/private'. Since that's still useful to catch misconfiguration early, and add a comment explaining why nothing is written to swanctl.conf for it.

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
