### PR TITLE
mdio-tools: disable mold linker

### DIFF
--- a/net/mdio-tools/Makefile
+++ b/net/mdio-tools/Makefile
@@ -16,6 +16,8 @@ PKG_LICENSE_FILES:=COPYING
 
 PKG_MAINTAINER:=Damien Mascord <tusker@tusker.org>
 
+PKG_BUILD_FLAGS:=no-mold
+
 include $(INCLUDE_DIR)/package.mk
 
 define Package/mdio-tools


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @dmascord
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->
The mold linker is not supported by mdio-tools.
Disabling mold linker allows the package to be built on systems with a configured mold linker.

Fixes: #30101

---

## 🧪 Run Testing Details

- **OpenWrt Version:** snapshot
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** -

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
