### PR TITLE
sudo: create sudo group

### DIFF
--- a/admin/sudo/Makefile
+++ b/admin/sudo/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=sudo
 PKG_REALVERSION:=1.9.17p2
 PKG_VERSION:=$(subst p,_p,$(PKG_REALVERSION))
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_REALVERSION).tar.gz
 PKG_SOURCE_URL:=https://www.sudo.ws/dist
@@ -34,6 +34,7 @@ define Package/sudo
   CATEGORY:=Administration
   TITLE:=Delegate authority to run commands
   URL:=https://www.sudo.ws/
+  USERID:=:sudo
   DEPENDS:= +USE_GLIBC:libcrypt-compat
 endef
 


### PR DESCRIPTION
Add a `sudo` system group at package-install time via the existing `USERID` mechanism.

## Rationale

Sudoers configurations that grant privileges to the `sudo` group – the near-universal Debian/Ubuntu idiom, e.g.

```
%sudo ALL=(ALL:ALL) NOPASSWD: ALL
```

fail silently on OpenWrt today because no `sudo` group exists in `/etc/group`. `sudo(8)` logs *"unknown group: sudo"* and skips the rule. Administrators also cannot `usermod -aG sudo <user>` without the group being present, so there is no straightforward way to delegate root without hand-editing `/etc/group` or writing per-user sudoers snippets.

Seeding the group here matches how OpenWrt already handles other service accounts (`chrony`, `dbus`, `ntpd`, `tor`, `squid`, `stubby`, …): the `USERID` mechanism creates them lazily via `add_group_and_user` in the postinst script.

## Behaviour

* No privileges are granted by default. The change only creates the group; the shipped `/etc/sudoers` is untouched. An administrator still has to (a) add users to the `sudo` group and (b) provide a sudoers rule that references it, exactly as on Debian.
* `PKG_RELEASE` bumped from 1 to 2.

## GID choice

No numeric GID is pinned. The group name is what sudoers, `addgroup(1)`, and `getgrnam()` operate on; the numeric GID is invisible to sudo's authorisation path and matters only for on-disk group ownership metadata (e.g. `chgrp sudo` persisted to shared storage), which this package does not do. Letting `add_group_and_user` pick a dynamic GID in the 32768+ range keeps `sudo` outside of base-files' reserved low-range group space and avoids any name-vs-number collision debate.