### PR TITLE
gpsd: run as dedicated 'gpsd' system user

### DIFF
--- a/utils/gpsd/Makefile
+++ b/utils/gpsd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gpsd
 PKG_VERSION:=3.26.1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@SAVANNAH/$(PKG_NAME)
@@ -45,6 +45,7 @@ define Package/gpsd
   SECTION:=utils
   CATEGORY:=Utilities
   TITLE:=An interface daemon for GPS receivers
+  USERID:=gpsd:gpsd:dialout=20
   DEPENDS+= +gpsd-utils
 endef
 
@@ -101,6 +102,8 @@ SCONS_VARS += \
 	LINKFLAGS="$(TARGET_LDFLAGS)"
 
 SCONS_OPTIONS += \
+	gpsd_user=gpsd \
+	gpsd_group=dialout \
 	target_platform=linux \
 	dbus_export=no \
 	tsip=no \


### PR DESCRIPTION
Create a dedicated `gpsd` system user at package-install time (via `USERID`), pin gpsd's built-in privilege-separation identity to it via the SConstruct `gpsd_user` option, and pin the drop-privileges group to `dialout` via `gpsd_group` so device access continues to work post-drop regardless of the build host.

## Background

`gpsd` needs to start as root to open the underlying tty / serial device, but immediately `setuid()`s to a configured unprivileged identity for the rest of its lifetime — a well-established privilege-separation feature of the daemon itself.

Today the package leaves `gpsd_user` at scons' default `nobody`. Sharing `nobody` across daemons is a hardening anti-pattern:

* a compromise of any one `nobody`-owned process can trivially interfere with any other;
* file ownership no longer distinguishes daemons in an audit trail;
* filesystem ACLs / SELinux-style policies keyed to `nobody` become useless.

## Change

* `USERID:=gpsd:gpsd:dialout=20` — creates a dedicated `gpsd` system user and group at install time and adds the user to the statically-allocated `dialout` group (GID 20, from base-files). Dynamic (unpinned) UID/GID for `gpsd` itself — no cross-distro muscle memory depends on a specific number here.
* `gpsd_user=gpsd` scons option — bakes the requested drop-privileges user into the binary.
* `gpsd_group=dialout` scons option — makes the daemon's post-drop group explicit. scons defaults `gpsd_group` to `dialout` on most build hosts (`uucp` on Gentoo), so pinning it removes the dependency on the builder's `/etc/gentoo-release`; a Gentoo builder would otherwise bake in `uucp`, a group base-files does not ship, and gpsd's `getgrnam()` fallback silently keeps root's gid in that case.
* `PKG_RELEASE` bumped.

Note on the `dialout=20` third field: gpsd calls `setgroups(0, NULL)` immediately before dropping privileges, so supplementary group memberships on the target user are discarded and cannot carry `/dev/tty*` access — that is `gpsd_group`'s job. The `/etc/group` membership is still worth keeping (matches Debian, lets an operator run `gpsdctl` / `gpsmon` as the `gpsd` user against device nodes) but is not what enables the running daemon to open serial ports.

## Effects

* Any future gpsd RCE (there have been NMEA / UBX parsing bugs historically) is contained to files owned by `gpsd`, not to a shared `nobody`.
* Matches the long-standing Debian `gpsd` packaging convention (`adduser --system gpsd`, member of `dialout`).
* No behaviour change for correctly-configured setups; installations that had explicitly leaned on `nobody` as the gpsd identity are trivially migrated.
