### PR TITLE
erlang: stop shipping sasl in the base package

### DIFF
--- a/lang/erlang/Makefile
+++ b/lang/erlang/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=erlang
 PKG_VERSION:=28.5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=otp_src_$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/erlang/otp/releases/download/OTP-$(PKG_VERSION)
@@ -379,7 +379,7 @@ define Package/erlang/install
 		$(CP) $(PKG_INSTALL_DIR)/usr/lib/erlang/bin/$$$$f $(1)/usr/lib/erlang/bin/ ; \
 	done
 	$(INSTALL_DIR) $(1)/usr/lib/erlang/lib
-	for m in erts kernel sasl stdlib; do \
+	for m in erts kernel stdlib; do \
 		$(CP) $(PKG_INSTALL_DIR)/usr/lib/erlang/lib/$$$$m-* $(1)/usr/lib/erlang/lib/ ; \
 		rm -rf $(1)/usr/lib/erlang/lib/$$$$m-*/examples ; \
 		rm -rf $(1)/usr/lib/erlang/lib/$$$$m-*/src ; \

--- a/lang/erlang/test-version.sh
+++ b/lang/erlang/test-version.sh
@@ -6,6 +6,6 @@ erlang)
 	timeout 60s erl -noshell \
 		-eval "V = erlang:system_info(otp_release), io:format(\"OTP ~s~n\", [V])" \
 		-s init stop 2>&1 | \
-		grep -qF "OTP ${otp_major}"
+		grep -F "OTP ${otp_major}"
 	;;
 esac

--- a/lang/erlang/test.sh
+++ b/lang/erlang/test.sh
@@ -5,7 +5,7 @@ erlang)
 	# Check erl binary is present and prints the right OTP version
 	otp_major="${2%%.*}"
 	timeout 60s erl -noshell -eval "V = erlang:system_info(otp_release), io:format(\"OTP ~s~n\", [V])" -s init stop 2>&1 | \
-		grep -qF "OTP ${otp_major}" || {
+		grep -F "OTP ${otp_major}" || {
 		echo "FAIL: erl did not report expected OTP version '$2' (major: $otp_major)"
 		exit 1
 	}


### PR DESCRIPTION
`Package/erlang/install` copies `erts`, `kernel`, `sasl` and `stdlib` into `/usr/lib/erlang/lib`, while `BuildModule` builds `erlang-sasl` from the very same `sasl` directory. Both packages therefore own `usr/lib/erlang/lib/sasl-*/ebin/*.beam`.

apk refuses to overwrite files owned by another package, so installing `erlang-sasl` next to `erlang` fails:

```
ERROR: erlang-sasl-28.5-r1: trying to overwrite usr/lib/erlang/lib/sasl-4.3.2/ebin/alarm_handler.beam owned by erlang-28.5-r1.
```

Since `erlang-sasl` depends on `erlang`, the subpackage cannot be installed at all, and that takes `erlang-os-mon` and `erlang-reltool` with it. The overlap dates back to the import from the old packages feed and only surfaced once `erlang: update to 28.5` added test scripts and CI began run-testing every subpackage.

Leave `sasl` to `erlang-sasl`, which is what that subpackage is for. The base package keeps `bin/start_sasl.boot`: it is inert while the runtime boots via `start_clean`, and it is needed once `erlang-sasl` is installed.

The second commit is the `grep -q` removal split out of #29912, which was blocked on this fix.