### PR TITLE
bird2: add new package

### DIFF
--- a/net/bird2/Makefile
+++ b/net/bird2/Makefile
@@ -1,0 +1,129 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Copyright (C) 2009-2017 OpenWrt.org
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=bird2
+PKG_VERSION:=2.19.2
+PKG_RELEASE:=2
+
+PKG_SOURCE:=bird-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://bird.nic.cz/download/
+PKG_HASH:=aff89abba3b92b7637bd57e0168b8d7ae887747f160ada4973378ad72f5f3660
+
+PKG_MAINTAINER:=Toke Høiland-Jørgensen <toke@toke.dk>
+PKG_LICENSE:=GPL-2.0-or-later
+PKG_LICENSE_FILES:=README
+PKG_CPE_ID:=cpe:/a:nic:bird
+
+PKG_BUILD_DEPENDS:=ncurses readline
+PKG_BUILD_DIR:=$(BUILD_DIR)/bird-$(PKG_VERSION)
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/bird2
+  TITLE:=The BIRD Internet Routing Daemon (v2)
+  URL:=https://bird.nic.cz/
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=Routing and Redirection
+  DEPENDS:=+libpthread
+  CONFLICTS:=bird1-ipv4 bird1-ipv6 bird4 bird6
+endef
+
+define Package/bird2c
+  TITLE:=The BIRD command-line client (v2)
+  URL:=https://bird.nic.cz/
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=Routing and Redirection
+  DEPENDS:=+bird2 +libreadline +libncurses
+  CONFLICTS:=bird1c-ipv4 bird1c-ipv6 birdc4 birdc6
+endef
+
+define Package/bird2cl
+  TITLE:=The BIRD lightweight command-line client (v2)
+  URL:=https://bird.nic.cz/
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=Routing and Redirection
+  DEPENDS:=+bird2
+  CONFLICTS:=bird1cl-ipv4 bird1cl-ipv6 birdcl4 birdcl6
+endef
+
+define Package/bird2/Default/description
+  BIRD is an internet routing daemon which manages TCP/IP routing tables
+  with support of modern routing protocols, easy to use configuration
+  interface and powerful route filtering language. It is lightweight and
+  efficient and therefore appropriate for small embedded routers.
+endef
+
+define Package/bird2/description
+  $(call Package/bird2/Default/description)
+
+  BIRD supports OSPFv2, RIPv2, Babel and BGP protocols for IPv4 and
+  OSPFv3, RIPng, Babel and BGP protocols for IPv6.
+
+  In BGP, BIRD supports communities, multiprotocol extensions, MD5
+  authentication, 32bit AS numbers and could act as a route server or a
+  route reflector. BIRD also supports multiple RIBs, multiple kernel
+  routing tables and redistribution between the protocols with a powerful
+  configuration syntax.
+
+  This is the 2.0 branch of Bird which integrates support for IPv4 and IPv6
+  into a single branch, and also adds support for the Babel routing protocol.
+endef
+
+define Package/bird2c/description
+  $(call Package/bird2/Default/description)
+
+  This is a BIRD command-line client. It is used to send commands to BIRD,
+  commands can perform simple actions such as enabling/disabling of
+  protocols, telling BIRD to show various information, telling it to show
+  a routing table filtered by a filter, or asking BIRD to reconfigure.
+
+  Unless you can't afford dependency on ncurses and readline, you
+  should install BIRD command-line client together with BIRD.
+endef
+
+define Package/bird2cl/description
+  $(call Package/bird2/Default/description)
+
+  This is a BIRD lightweight command-line client. It is used to send commands
+  to BIRD, commands can perform simple actions such as enabling/disabling of
+  protocols, telling BIRD to show various information, telling it to show
+  a routing table filtered by a filter, or asking BIRD to reconfigure.
+endef
+
+CONFIGURE_ARGS += --disable-libssh
+
+define Package/bird2/conffiles
+/etc/bird.conf
+/etc/bird4.conf
+/etc/bird6.conf
+endef
+
+define Package/bird2/install
+	$(INSTALL_DIR)  $(1)/usr/sbin
+	$(INSTALL_BIN)  $(PKG_BUILD_DIR)/bird $(1)/usr/sbin/
+	$(INSTALL_DIR)  $(1)/etc
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/doc/bird.conf.example $(1)/etc/bird.conf
+	$(INSTALL_DIR)  $(1)/etc/init.d
+	$(INSTALL_BIN)  ./files/bird.init $(1)/etc/init.d/bird
+endef
+
+define Package/bird2c/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/birdc $(1)/usr/sbin/
+endef
+
+define Package/bird2cl/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/birdcl $(1)/usr/sbin/
+endef
+
+$(eval $(call BuildPackage,bird2))
+$(eval $(call BuildPackage,bird2c))
+$(eval $(call BuildPackage,bird2cl))

--- a/net/bird2/Makefile
+++ b/net/bird2/Makefile
@@ -101,8 +101,6 @@ CONFIGURE_ARGS += --disable-libssh
 
 define Package/bird2/conffiles
 /etc/bird.conf
-/etc/bird4.conf
-/etc/bird6.conf
 endef
 
 define Package/bird2/install

--- a/net/bird2/files/bird.init
+++ b/net/bird2/files/bird.init
@@ -1,0 +1,25 @@
+#!/bin/sh /etc/rc.common
+# Copyright (C) 2010-2017 OpenWrt.org
+
+USE_PROCD=1
+START=70
+STOP=10
+
+BIRD_BIN="/usr/sbin/bird"
+BIRD_CONF="/etc/bird.conf"
+BIRD_PID_FILE="/var/run/bird.pid"
+
+start_service() {
+    mkdir -p /var/run
+    procd_open_instance
+    procd_set_param command $BIRD_BIN -f -c $BIRD_CONF -P $BIRD_PID_FILE
+    procd_set_param file "$BIRD_CONF"
+    procd_set_param stdout 1
+    procd_set_param stderr 1
+    procd_set_param respawn
+    procd_close_instance
+}
+
+reload_service() {
+    procd_send_signal bird
+}

--- a/net/bird2/patches/000-ospf-bus-error.patch
+++ b/net/bird2/patches/000-ospf-bus-error.patch
@@ -1,0 +1,18 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Matt Reeve <matt@mreeve.com>
+Date: Tue, 10 Aug 2021 12:41:04 +0100
+Subject: [PATCH] Fix bus error on OSPF on IPQ806X
+
+---
+
+--- a/proto/ospf/topology.h
++++ b/proto/ospf/topology.h
+@@ -41,7 +41,7 @@ struct top_hash_entry
+   u8 mode;			/* LSA generated during RT calculation (LSA_RTCALC or LSA_STALE)*/
+   u8 nhs_reuse;			/* Whether nhs nodes can be reused during merging.
+ 				   See a note in rt.c:add_cand() */
+-};
++} PACKED;
+ 
+ 
+ /* Prevents ospf_hash_find() to ignore the entry, for p->lsrqh and p->lsrth */

--- a/net/bird2/patches/000-ospf-bus-error.patch
+++ b/net/bird2/patches/000-ospf-bus-error.patch
@@ -3,8 +3,24 @@ From: Matt Reeve <matt@mreeve.com>
 Date: Tue, 10 Aug 2021 12:41:04 +0100
 Subject: [PATCH] Fix bus error on OSPF on IPQ806X
 
----
+On a Netgear R7800, if ospf v2 or v3 is configured in bird.conf, it fails
+to start with this error:
 
+    kernel: Alignment trap: not handling instruction f44c0a1f at [<00035848>]
+    kernel: Unhandled fault: alignment exception (0x801) at 0x007e0624
+
+The problem is due to a struct not being properly aligned on the ARMv7
+architecture.
+
+This patch fixes the problem by adding the "PACKED" macro to the affected
+struct. Note that upstream may later fix this in another way, in which
+case this patch will not be required.
+
+Upstream-Status: not submitted. As of 2.19.2 the structure still carries
+no alignment attribute.
+
+Signed-off-by: Matt Reeve <matt@mreeve.com>
+---
 --- a/proto/ospf/topology.h
 +++ b/proto/ospf/topology.h
 @@ -41,7 +41,7 @@ struct top_hash_entry

--- a/net/bird2/patches/0001-birdc-Use-var-tmp-for-history-file.patch
+++ b/net/bird2/patches/0001-birdc-Use-var-tmp-for-history-file.patch
@@ -1,0 +1,29 @@
+From e77b14853c1dcb3034e1af155f49e3b943203c4e Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Toke=20H=C3=B8iland-J=C3=B8rgensen?= <toke@toke.dk>
+Date: Mon, 24 Nov 2025 12:57:52 +0100
+Subject: [PATCH] birdc: Use /var/tmp for history file
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+We don't want birdc to write its history file to flash, so hard-code the
+history file to /var/tmp instead.
+
+Signed-off-by: Toke Høiland-Jørgensen <toke@toke.dk>
+---
+ client/birdc.c | 4 +---
+ 1 file changed, 1 insertion(+), 3 deletions(-)
+
+--- a/client/birdc.c
++++ b/client/birdc.c
+@@ -146,9 +146,7 @@ input_help(int arg, int key UNUSED)
+ void
+ history_init(void)
+ {
+-  const char *homedir = getenv("HOME");
+-  if (!homedir)
+-    homedir = ".";
++  const char *homedir = "/var/tmp";
+   history_file = malloc(strlen(homedir) + sizeof(HISTORY));
+   if (!history_file)
+     die("couldn't alloc enough memory for history file name");

--- a/net/bird2/test-version.sh
+++ b/net/bird2/test-version.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# shellcheck shell=busybox
+
+case "$PKG_NAME" in
+bird2|bird2c|bird2cl)
+	# birdc and birdcl do not report a version; check the daemon,
+	# which both clients depend on anyway
+	bird --version 2>&1 | grep -F "$PKG_VERSION"
+	;;
+
+*)
+	echo "Untested package: $PKG_NAME" >&2
+	exit 1
+	;;
+esac


### PR DESCRIPTION
Adds bird2 from the openwrt/routing feed — the routing packages are being moved into openwrt/packages one by one, as discussed in openwrt/routing#184.

Includes the SPDX license identifier cleanup pending in openwrt/routing#1193.

The content matches the current routing feed master. Once this is merged, the package will be removed from the routing feed (a coordinated removal PR is prepared there).

Maintainer: @tohojo, @PolynomialDivision