### PR TITLE
bird3: add new package

### DIFF
--- a/net/bird3/Makefile
+++ b/net/bird3/Makefile
@@ -98,8 +98,6 @@ TARGET_LDFLAGS += -latomic
 
 define Package/bird3/conffiles
 /etc/bird.conf
-/etc/bird4.conf
-/etc/bird6.conf
 endef
 
 define Package/bird3/install

--- a/net/bird3/Makefile
+++ b/net/bird3/Makefile
@@ -1,0 +1,126 @@
+# SPDX-License-Identifier: GPL-2.0-only
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=bird3
+PKG_VERSION:=3.3.2
+PKG_RELEASE:=2
+
+PKG_SOURCE:=bird-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://bird.nic.cz/download/
+PKG_HASH:=21297d7a02edd700ae82de5a630055a9cb88a99e2e7e45551bc7d6c1e5b4de2c
+
+PKG_MAINTAINER:=Toke Høiland-Jørgensen <toke@toke.dk>, Nick Hainke <vincent@systemli.org>
+PKG_LICENSE:=GPL-2.0-or-later
+PKG_LICENSE_FILES:=README
+PKG_CPE_ID:=cpe:/a:nic:bird
+
+PKG_BUILD_DEPENDS:=ncurses readline
+PKG_BUILD_DIR:=$(BUILD_DIR)/bird-$(PKG_VERSION)
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/bird3
+  TITLE:=The BIRD Internet Routing Daemon (v3)
+  URL:=https://bird.nic.cz/
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=Routing and Redirection
+  DEPENDS:=+libpthread +libatomic
+  CONFLICTS:=bird2
+endef
+
+define Package/bird3c
+  TITLE:=The BIRD command-line client (v3)
+  URL:=https://bird.nic.cz/
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=Routing and Redirection
+  DEPENDS:=+bird3 +libreadline +libncurses
+  CONFLICTS:=bird2
+endef
+
+define Package/bird3cl
+  TITLE:=The BIRD lightweight command-line client (v3)
+  URL:=https://bird.nic.cz/
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=Routing and Redirection
+  DEPENDS:=+bird3
+  CONFLICTS:=bird2
+endef
+
+define Package/bird3/Default/description
+  BIRD is an internet routing daemon which manages TCP/IP routing tables
+  with support of modern routing protocols, easy to use configuration
+  interface and powerful route filtering language. It is lightweight and
+  efficient and therefore appropriate for small embedded routers.
+endef
+
+define Package/bird3/description
+  $(call Package/bird3/Default/description)
+
+  BIRD supports OSPFv2, RIPv2, Babel and BGP protocols for IPv4 and
+  OSPFv3, RIPng, Babel and BGP protocols for IPv6.
+
+  In BGP, BIRD supports communities, multiprotocol extensions, MD5
+  authentication, 32bit AS numbers and could act as a route server or a
+  route reflector. BIRD also supports multiple RIBs, multiple kernel
+  routing tables and redistribution between the protocols with a powerful
+  configuration syntax.
+
+  This is the 3.0 branch of Bird which is a multithreaded rewrite.
+endef
+
+define Package/bird3c/description
+  $(call Package/bird3/Default/description)
+
+  This is a BIRD command-line client. It is used to send commands to BIRD,
+  commands can perform simple actions such as enabling/disabling of
+  protocols, telling BIRD to show various information, telling it to show
+  a routing table filtered by a filter, or asking BIRD to reconfigure.
+
+  Unless you can't afford dependency on ncurses and readline, you
+  should install BIRD command-line client together with BIRD.
+endef
+
+define Package/bird3cl/description
+  $(call Package/bird3/Default/description)
+
+  This is a BIRD lightweight command-line client. It is used to send commands
+  to BIRD, commands can perform simple actions such as enabling/disabling of
+  protocols, telling BIRD to show various information, telling it to show
+  a routing table filtered by a filter, or asking BIRD to reconfigure.
+endef
+
+CONFIGURE_ARGS += --disable-libssh
+TARGET_LDFLAGS += -latomic
+
+define Package/bird3/conffiles
+/etc/bird.conf
+/etc/bird4.conf
+/etc/bird6.conf
+endef
+
+define Package/bird3/install
+	$(INSTALL_DIR)  $(1)/usr/sbin
+	$(INSTALL_BIN)  $(PKG_BUILD_DIR)/bird $(1)/usr/sbin/
+	$(INSTALL_DIR)  $(1)/etc
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/doc/bird.conf.example $(1)/etc/bird.conf
+	$(INSTALL_DIR)  $(1)/etc/init.d
+	$(INSTALL_BIN)  ./files/bird.init $(1)/etc/init.d/bird
+endef
+
+define Package/bird3c/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/birdc $(1)/usr/sbin/
+endef
+
+define Package/bird3cl/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/birdcl $(1)/usr/sbin/
+endef
+
+$(eval $(call BuildPackage,bird3))
+$(eval $(call BuildPackage,bird3c))
+$(eval $(call BuildPackage,bird3cl))

--- a/net/bird3/files/bird.init
+++ b/net/bird3/files/bird.init
@@ -1,0 +1,25 @@
+#!/bin/sh /etc/rc.common
+# Copyright (C) 2010-2017 OpenWrt.org
+
+USE_PROCD=1
+START=70
+STOP=10
+
+BIRD_BIN="/usr/sbin/bird"
+BIRD_CONF="/etc/bird.conf"
+BIRD_PID_FILE="/var/run/bird.pid"
+
+start_service() {
+    mkdir -p /var/run
+    procd_open_instance
+    procd_set_param command $BIRD_BIN -f -c $BIRD_CONF -P $BIRD_PID_FILE
+    procd_set_param file "$BIRD_CONF"
+    procd_set_param stdout 1
+    procd_set_param stderr 1
+    procd_set_param respawn
+    procd_close_instance
+}
+
+reload_service() {
+    procd_send_signal bird
+}

--- a/net/bird3/patches/0001-birdc-Use-var-tmp-for-history-file.patch
+++ b/net/bird3/patches/0001-birdc-Use-var-tmp-for-history-file.patch
@@ -1,0 +1,29 @@
+From e77b14853c1dcb3034e1af155f49e3b943203c4e Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Toke=20H=C3=B8iland-J=C3=B8rgensen?= <toke@toke.dk>
+Date: Mon, 24 Nov 2025 12:57:52 +0100
+Subject: [PATCH] birdc: Use /var/tmp for history file
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+We don't want birdc to write its history file to flash, so hard-code the
+history file to /var/tmp instead.
+
+Signed-off-by: Toke Høiland-Jørgensen <toke@toke.dk>
+---
+ client/birdc.c | 4 +---
+ 1 file changed, 1 insertion(+), 3 deletions(-)
+
+--- a/client/birdc.c
++++ b/client/birdc.c
+@@ -146,9 +146,7 @@ input_help(int arg, int key UNUSED)
+ void
+ history_init(void)
+ {
+-  const char *homedir = getenv("HOME");
+-  if (!homedir)
+-    homedir = ".";
++  const char *homedir = "/var/tmp";
+   history_file = malloc(strlen(homedir) + sizeof(HISTORY));
+   if (!history_file)
+     die("couldn't alloc enough memory for history file name");

--- a/net/bird3/test-version.sh
+++ b/net/bird3/test-version.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# shellcheck shell=busybox
+
+case "$PKG_NAME" in
+bird3|bird3c|bird3cl)
+	# birdc and birdcl do not report a version; check the daemon,
+	# which both clients depend on anyway
+	bird --version 2>&1 | grep -F "$PKG_VERSION"
+	;;
+
+*)
+	echo "Untested package: $PKG_NAME" >&2
+	exit 1
+	;;
+esac


### PR DESCRIPTION
Adds bird3 from the openwrt/routing feed — the routing packages are being moved into openwrt/packages one by one, as discussed in openwrt/routing#184.

Includes the bird3cl title fix and PKG_CPE_ID addition pending in openwrt/routing#1193.

The content matches the current routing feed master. Once this is merged, the package will be removed from the routing feed (a coordinated removal PR is prepared there).

Maintainer: @tohojo, @PolynomialDivision