### PR TITLE
bmx7: add new package

### DIFF
--- a/net/bmx7/Makefile
+++ b/net/bmx7/Makefile
@@ -1,0 +1,164 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=bmx7
+PKG_VERSION:=2024.06.11
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/bmx-routing/bmx7.git
+PKG_SOURCE_VERSION:=9020896f89006bc5d3487222eefc7ddea9e8b2bd
+PKG_MIRROR_HASH:=a085904a48544d71ec815fa61c329925d89aca72a051941551290d292a6150d7
+
+PKG_MAINTAINER:=Axel Neumann <axel@notmail.org>
+PKG_LICENSE:=GPL-2.0-or-later
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+TARGET_CFLAGS += $(FPIC)
+
+MAKE_ARGS += EXTRA_CFLAGS="$(TARGET_CFLAGS) \
+				-I. \
+				-I$(STAGING_DIR)/usr/include \
+				-DCORE_LIMIT=20000 \
+				-DTRAFFIC_DUMP \
+				-DNO_TRACE_FUNCTION_CALLS \
+				-DBMX7_LIB_IWINFO" \
+				EXTRA_LDFLAGS="$(TARGET_LDFLAGS) \
+			 	-L$(STAGING_DIR)/usr/lib -liwinfo" \
+				CC="$(TARGET_CC)" \
+				INSTALL_DIR="$(PKG_INSTALL_DIR)" \
+				build_all
+
+MAKE_PATH:=src
+
+define Package/bmx7/Default
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=Routing and Redirection
+  TITLE:=BMX7 layer 3 routing daemon
+  URL:=https://github.com/bmx-routing/bmx7
+  DEPENDS:=+zlib +libmbedtls +libiwinfo
+endef
+
+define Package/bmx7/description
+  BMX7 routing daemon supporting securely-entrusted IPv6 (and IPv4in6) routing
+endef
+
+define Package/bmx7
+  $(call Package/bmx7/Default)
+  MENU:=1
+endef
+
+define Package/bmx7-uci-config
+  $(call Package/bmx7/Default)
+  DEPENDS:=bmx7 +libuci
+  TITLE:=configuration plugin based on uci (recommended!)
+endef
+
+define Package/bmx7-iwinfo
+  $(call Package/bmx7/Default)
+  DEPENDS:=bmx7 +libiwinfo
+  TITLE:=link characteristics plugin via libiwinfo (recommended!)
+endef
+
+define Package/bmx7-topology
+  $(call Package/bmx7/Default)
+  DEPENDS:=bmx7
+  TITLE:=topology plugin
+endef
+
+define Package/bmx7-json
+  $(call Package/bmx7/Default)
+  DEPENDS:=bmx7 +libjson-c
+  TITLE:=json plugin based on json-c
+endef
+
+define Package/bmx7-sms
+  $(call Package/bmx7/Default)
+  DEPENDS:=bmx7
+  TITLE:=sms plugin
+endef
+
+define Package/bmx7-tun
+  $(call Package/bmx7/Default)
+  DEPENDS:=bmx7 +kmod-ip6-tunnel +kmod-iptunnel6 +kmod-tun
+  TITLE:=ipip-based tunnel plugin (recommended!)
+endef
+
+define Package/bmx7-table
+  $(call Package/bmx7/Default)
+  DEPENDS:=bmx7 +bmx7-tun
+  TITLE:=plugin to announce routes from tables via tunnels
+endef
+
+define Package/bmx7/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/$(MAKE_PATH)/bmx7 $(1)/usr/sbin/bmx7
+endef
+
+define Build/Compile
+	+$(MAKE) $(PKG_JOBS) -C $(PKG_BUILD_DIR)/$(MAKE_PATH) $(MAKE_ARGS)
+endef
+
+define Package/bmx7-uci-config/conffiles
+/etc/config/bmx7
+/etc/bmx7/
+endef
+
+define Package/bmx7-uci-config/install
+	$(INSTALL_DIR) $(1)/usr/lib $(1)/etc/config $(1)/etc/init.d
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/$(MAKE_PATH)/lib/bmx7_uci_config/bmx7_config.so \
+		$(1)/usr/lib/bmx7_config.so
+	$(INSTALL_BIN) ./files/etc/init.d/bmx7 $(1)/etc/init.d/bmx7
+	$(INSTALL_CONF) ./files/etc/config/bmx7 $(1)/etc/config/bmx7
+endef
+
+define Package/bmx7-iwinfo/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/$(MAKE_PATH)/lib/bmx7_iwinfo/bmx7_iwinfo.so \
+		$(1)/usr/lib/bmx7_iwinfo.so
+endef
+
+define Package/bmx7-topology/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/$(MAKE_PATH)/lib/bmx7_topology/bmx7_topology.so \
+		$(1)/usr/lib/bmx7_topology.so
+endef
+
+define Package/bmx7-json/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/$(MAKE_PATH)/lib/bmx7_json/bmx7_json.so \
+		$(1)/usr/lib/bmx7_json.so
+endef
+
+define Package/bmx7-sms/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/$(MAKE_PATH)/lib/bmx7_sms/bmx7_sms.so \
+		$(1)/usr/lib/bmx7_sms.so
+endef
+
+define Package/bmx7-tun/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/$(MAKE_PATH)/lib/bmx7_tun/bmx7_tun.so \
+		$(1)/usr/lib/bmx7_tun.so
+endef
+
+define Package/bmx7-table/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/$(MAKE_PATH)/lib/bmx7_table/bmx7_table.so \
+		$(1)/usr/lib/bmx7_table.so
+endef
+
+$(eval $(call BuildPackage,bmx7))
+$(eval $(call BuildPackage,bmx7-uci-config))
+$(eval $(call BuildPackage,bmx7-iwinfo))
+$(eval $(call BuildPackage,bmx7-topology))
+$(eval $(call BuildPackage,bmx7-json))
+$(eval $(call BuildPackage,bmx7-sms))
+$(eval $(call BuildPackage,bmx7-table))
+$(eval $(call BuildPackage,bmx7-tun))

--- a/net/bmx7/files/etc/config/bmx7
+++ b/net/bmx7/files/etc/config/bmx7
@@ -1,0 +1,47 @@
+# for more information:
+# https://github.com/bmx-routing/bmx7/
+# options execute: bmx7 --help
+
+config 'bmx7' 'general'
+#        option 'runtimeDir' '/var/run/bmx7'
+#        option 'trustedNodesDir' '/etc/bmx7/trustedNodes'
+
+#config 'plugin'
+#        option 'plugin' 'bmx7_config.so'
+
+#config 'plugin'
+#        option 'plugin' 'bmx7_json.so'
+
+#config 'plugin'
+#        option 'plugin' 'bmx7_sms.so'
+
+#config 'plugin'
+#        option 'plugin' 'bmx7_iwinfo.so'
+
+config 'dev' 'mesh_1'
+        option 'dev' 'br-lan'
+
+config 'dev' 'mesh_2'
+        option 'dev' 'wlan0'
+
+#config 'plugin'
+#        option 'plugin' 'bmx7_tun.so'
+
+#config 'plugin'
+#        option 'plugin' 'bmx7_table.so'
+
+#config 'tunDev' default
+#        option 'tunDev' 'default'
+#        option 'tun6Address' '2012:0:0:6666::1/64'
+#        option 'tun4Address' '10.66.66.1/24'
+
+
+#config 'tunOut'
+#        option 'tunOut' 'ip6'
+#        option 'network' '2012::/16'
+#        option 'exportDistance' '0'
+
+#config 'tunOut'
+#        option 'tunOut' 'ip4'
+#        option 'network' '10.0.0.0/9'
+#        option 'minPrefixLen' '27'

--- a/net/bmx7/files/etc/init.d/bmx7
+++ b/net/bmx7/files/etc/init.d/bmx7
@@ -1,0 +1,28 @@
+#!/bin/sh /etc/rc.common
+START=91
+USE_PROCD=1
+
+BIN=/usr/sbin/bmx7
+CONF=/etc/config/bmx7
+
+start_service() {
+	cd /root/ || return
+	while pgrep -f mac80211.sh ; do sleep 1; done
+
+	procd_open_instance "bmx7"
+	procd_set_param command "$BIN"
+	procd_append_param command -f "$CONF" -d0
+	procd_set_param limits core=20000
+	procd_set_param stdout 1
+	procd_set_param stderr 1
+	procd_set_param respawn
+	procd_close_instance
+}
+
+reload_service() {
+    "$BIN" -c configReload
+}
+
+service_triggers() {
+    procd_add_reload_trigger "bmx7"
+}

--- a/net/bmx7/patches/020-siocgstamp.patch
+++ b/net/bmx7/patches/020-siocgstamp.patch
@@ -1,0 +1,45 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Sun, 30 Aug 2020 14:09:17 -0700
+Subject: [PATCH] fix compilation with uClibc-ng
+
+---
+
+--- a/src/schedule.c
++++ b/src/schedule.c
+@@ -376,7 +376,9 @@ loop4Event:
+ 					continue;
+ 				}
+ 
++#ifdef SIOCGSTAMP
+ 				ioctl(pb.i.iif->rx_mcast_sock, SIOCGSTAMP, &(pb.i.tv_stamp));
++#endif
+ 
+ 				rx_packet(&pb);
+ 
+@@ -402,7 +404,9 @@ loop4Event:
+ 					continue;
+ 				}
+ 
++#ifdef SIOCGSTAMP
+ 				ioctl(pb.i.iif->rx_fullbrc_sock, SIOCGSTAMP, &(pb.i.tv_stamp));
++#endif
+ 
+ 				rx_packet(&pb);
+ 
+@@ -452,10 +456,15 @@ loop4Event:
+ 					}
+ 				}
+ #endif
++#ifdef SIOCGSTAMP
+ 				if (tv_stamp == NULL)
+ 					ioctl(pb.i.iif->unicast_sock, SIOCGSTAMP, &(pb.i.tv_stamp));
+ 				else
+ 					timercpy(&(pb.i.tv_stamp), tv_stamp);
++#else
++				if (tv_stamp)
++					timercpy(&(pb.i.tv_stamp), tv_stamp);
++#endif
+ 
+ 				rx_packet(&pb);
+ 

--- a/net/bmx7/test-version.sh
+++ b/net/bmx7/test-version.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+# shellcheck shell=busybox
+
+case "$PKG_NAME" in
+bmx7)
+	# The version of bmx7 is derived from the source date, which the
+	# binary does not report. `bmx7 -v` is not an alternative: the
+	# key path option is applied before the version option, so a
+	# missing node key gets generated first - "Creating RSA2048
+	# private key. This can take a while", as bmx7 puts it.
+	exit 0
+	;;
+
+bmx7-*)
+	# Plugins are libraries and do not provide version information
+	exit 0
+	;;
+
+*)
+	echo "Untested package: $PKG_NAME" >&2
+	exit 1
+	;;
+esac


### PR DESCRIPTION
Adds bmx7 from the openwrt/routing feed — the routing packages are being moved into openwrt/packages one by one, as discussed in openwrt/routing#184.

Includes the Makefile cleanup and CI test-version.sh pending in openwrt/routing#1194.

The content matches the current routing feed master. Once this is merged, the package will be removed from the routing feed (a coordinated removal PR is prepared there).

Maintainer: @axn