### PR TITLE
mesh11sd: add new package

### DIFF
--- a/net/mesh11sd/Makefile
+++ b/net/mesh11sd/Makefile
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Copyright (C) 2022 - 2026 BlueWave Projects and Services  <licence@blue-wave.net>
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=mesh11sd
+PKG_VERSION:=6.2.1
+PKG_RELEASE:=2
+
+PKG_MAINTAINER:=Rob White <rob@blue-wave.net>
+PKG_LICENSE:=GPL-2.0-or-later
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/opennds/mesh11sd/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=8ee36f12873a4648edc0ba5ac991a93ae79c6cd48940d9b7e999bb845cf78471
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/mesh11sd
+  SUBMENU:=Mesh
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=Dynamic 802.11s Mesh Management Daemon
+  PKGARCH:=all
+  URL:=https://github.com/opennds/mesh11sd
+endef
+
+define Package/mesh11sd/description
+  Mesh11sd autonomously manages all aspects of an 802.11s mesh network.
+  It acts as a service daemon.
+  Mesh parameters are dynamically set across all nodes.
+  Point to multi-point vxlan tunneling is provided by default.
+  Custom vlan trunking over the vxlan tunnel is fully supported.
+  Cabled sections of backhaul are fully supported.
+  Access Point usage data is collected in a central database.
+  A command line interface is provided for many functions.
+  An optional Customer/Client Premises Equipment (CPE) mode is provided
+  CPE mode greatly simplifies rollout of community WISP projects.
+endef
+
+define Package/mesh11sd/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/mesh11sd $(1)/usr/sbin
+	$(INSTALL_CONF) $(PKG_BUILD_DIR)/linux_openwrt/mesh11sd/files/etc/config/mesh11sd $(1)/etc/config/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/linux_openwrt/mesh11sd/files/etc/init.d/mesh11sd $(1)/etc/init.d/
+endef
+
+define Package/mesh11sd/conffiles
+/etc/config/mesh11sd
+endef
+
+define Build/Compile
+endef
+
+$(eval $(call BuildPackage,mesh11sd))

--- a/net/mesh11sd/patches/100-do-not-run-get_current_setup-until-after-version-argument.patch
+++ b/net/mesh11sd/patches/100-do-not-run-get_current_setup-until-after-version-argument.patch
@@ -1,0 +1,51 @@
+From 443cdb4c9f0ca20466f6ae31a81047bfeb95825c Mon Sep 17 00:00:00 2001
+From: Rob White <rob@blue-wave.net>
+Date: Thu, 6 Aug 2026 21:57:14 +0000
+Subject: [PATCH] Fix - do not run get_current_setup until after version
+ argument
+
+get_current_setup() runs before any argument is parsed, so mesh11sd -v
+and mesh11sd -h collect the whole runtime environment first. That
+includes refresh_bridgemac(), which calls wait_for_interface() for
+br-lan; when that interface is not up, the poll loop runs for the full
+interface_timeout, ten seconds by default.
+
+On a running router br-lan is up, the loop exits on its first iteration
+and the delay is invisible. It shows up wherever the interface is absent
+or still coming up, such as the OpenWrt package CI, which probes every
+installed executable for its version with a ten second timeout.
+
+Handle the informational options first and exit, then run the setup for
+the options that need it.
+
+Upstream-Status: Backport [https://github.com/openNDS/mesh11sd/commit/443cdb4c9f0ca20466f6ae31a81047bfeb95825c]
+---
+--- a/src/mesh11sd
++++ b/src/mesh11sd
+@@ -5976,8 +5976,6 @@ else
+ 	mesh11sdpid=$(pgrep -f "/bin/sh /usr/sbin/mesh11sd")
+ fi
+ 
+-get_current_setup 2> /dev/null
+-
+ if [ -z "$1" ] || [ "$1" = "-h" ] || [ $1 = "--help" ] || [ $1 = "help" ]; then
+ 	echo "
+   Usage: mesh11sd [option] [argument...]]
+@@ -6153,11 +6151,16 @@ if [ -z "$1" ] || [ "$1" = "-h" ] || [ $
+   For further documentation, see: https://github.com/openNDS/mesh11sd#readme
+ 
+ "
++	exit 0
+ 
+ elif [ "$1" = "-v" ] || [ $1 = "--version" ] || [ $1 = "version" ]; then
+ 	echo "mesh11sd version $version"
++	exit 0
++fi
++
++get_current_setup 2> /dev/null
+ 
+-elif [ "$1" = "debuglevel" ]; then
++if [ "$1" = "debuglevel" ]; then
+ 
+ 	if [ -z "$2" ];then
+ 		echo "$debuglevel"

--- a/net/mesh11sd/patches/101-fix-licence-discrepancy.patch
+++ b/net/mesh11sd/patches/101-fix-licence-discrepancy.patch
@@ -1,0 +1,24 @@
+From 9d18091f27e5fdd9406c6ac03267199a059fc8f5 Mon Sep 17 00:00:00 2001
+From: Rob White <rob@blue-wave.net>
+Date: Thu, 6 Aug 2026 21:46:37 +0000
+Subject: [PATCH] Fix -licence discrepancy
+
+The script header claimed GPL version 3 or later, while the LICENSE file
+the project ships is GPL version 2. Make the header agree with it.
+
+Upstream-Status: Backport [https://github.com/openNDS/mesh11sd/commit/9d18091f27e5fdd9406c6ac03267199a059fc8f5]
+---
+--- a/src/mesh11sd
++++ b/src/mesh11sd
+@@ -1,9 +1,9 @@
+ #!/bin/sh
+ # Copyright (C) BlueWave Projects and Services 2015-2026
+ #
+-#	This software is released under the GNU General Public License version 3 or any later version.
++#	This software is released under the GNU General Public License version 2 or any later version.
+ #	This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation,
+-#	either version 3 of the License, or (at your option) any later version.
++#	either version 2 of the License, or (at your option) any later version.
+ #
+ #	This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ #	See the GNU General Public License for more details.

--- a/net/mesh11sd/patches/102-fix-typo-in-get_current_setup-apmond_cgi_dir.patch
+++ b/net/mesh11sd/patches/102-fix-typo-in-get_current_setup-apmond_cgi_dir.patch
@@ -1,0 +1,21 @@
+From d0db5353ffc8574c30620fae1f54b13f7f873c6f Mon Sep 17 00:00:00 2001
+From: Rob White <rob@blue-wave.net>
+Date: Thu, 6 Aug 2026 22:05:02 +0000
+Subject: [PATCH] Fix - typo in get_current_setup() getting apmond_cgi_dir
+
+The length was taken from $apmon_cgi_dir, which is never set, so strlen
+was always 0 and the trailing slash check read the wrong character.
+
+Upstream-Status: Backport [https://github.com/openNDS/mesh11sd/commit/d0db5353ffc8574c30620fae1f54b13f7f873c6f]
+---
+--- a/src/mesh11sd
++++ b/src/mesh11sd
+@@ -989,7 +989,7 @@ get_current_setup() {
+ 		apmond_cgi_dir="/www/cgi-bin"
+ 	fi
+ 
+-	strlen=$((${#apmon_cgi_dir}));
++	strlen=$((${#apmond_cgi_dir}));
+ 	lastchar=${apmond_cgi_dir:$strlen -1 :1}
+ 
+ 	if [ "$lastchar" != "/" ]; then


### PR DESCRIPTION
Adds mesh11sd from the openwrt/routing feed — the routing packages are being moved into openwrt/packages one by one, as discussed in openwrt/routing#184.

The content matches the current routing feed master. Once this is merged, the package will be removed from the routing feed (a coordinated removal PR is prepared there).

Maintainer: @bluewavenet