### PR TITLE
nodogsplash: add new package

### DIFF
--- a/net/nodogsplash/Makefile
+++ b/net/nodogsplash/Makefile
@@ -1,0 +1,72 @@
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=nodogsplash
+PKG_VERSION:=5.0.2
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/nodogsplash/nodogsplash/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=908d3674e93726fdcefb4c3b6705c745753435df9d46425781a57e3f6b417797
+
+PKG_MAINTAINER:=Moritz Warning <moritzwarning@web.de>
+PKG_LICENSE:=GPL-2.0-or-later
+PKG_LICENSE_FILES:=COPYING
+
+PKG_FIXUP:=autoreconf
+PKG_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/nodogsplash
+  SUBMENU:=Captive Portals
+  SECTION:=net
+  CATEGORY:=Network
+  DEPENDS:=+libpthread +libmicrohttpd-no-ssl +iptables-nft \
+           +iptables-mod-nat-extra +iptables-mod-ipopt \
+           +iptables-mod-conntrack-extra
+  TITLE:=Open public network gateway daemon
+  URL:=https://github.com/nodogsplash/nodogsplash
+endef
+
+define Package/nodogsplash/description
+  Nodogsplash is a Captive Portal that offers a simple way to
+  provide restricted access to the Internet by showing a splash
+  page to the user before Internet access is granted.
+endef
+
+define Package/nodogsplash/install
+	$(INSTALL_DIR) $(1)/usr/lib/nodogsplash
+	$(INSTALL_BIN) ./files/usr/lib/nodogsplash/restart.sh $(1)/usr/lib/nodogsplash/
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/nodogsplash $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/ndsctl $(1)/usr/bin/
+	$(INSTALL_DIR) $(1)/etc/nodogsplash/htdocs/
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/resources/splash.html $(1)/etc/nodogsplash/htdocs/
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/resources/splash.css $(1)/etc/nodogsplash/htdocs/
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/resources/status.html $(1)/etc/nodogsplash/htdocs/
+	$(INSTALL_DIR) $(1)/etc/nodogsplash/htdocs/images
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/resources/splash.jpg $(1)/etc/nodogsplash/htdocs/images/
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_CONF) ./files/etc/config/nodogsplash $(1)/etc/config/
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/etc/init.d/nodogsplash $(1)/etc/init.d/
+	$(INSTALL_DIR) $(1)/etc/uci-defaults
+	$(INSTALL_BIN) ./files/etc/uci-defaults/40_nodogsplash $(1)/etc/uci-defaults/
+endef
+
+define Package/nodogsplash/postrm
+#!/bin/sh
+uci delete firewall.nodogsplash
+uci commit firewall
+endef
+
+define Package/nodogsplash/conffiles
+/etc/config/nodogsplash
+endef
+
+$(eval $(call BuildPackage,nodogsplash))

--- a/net/nodogsplash/files/etc/config/nodogsplash
+++ b/net/nodogsplash/files/etc/config/nodogsplash
@@ -1,0 +1,152 @@
+
+# The options available here are an adaptation of the settings used in nodogsplash.conf.
+# See https://github.com/nodogsplash/nodogsplash/blob/master/resources/nodogsplash.conf
+
+config nodogsplash
+  # Set to 0 to disable nodogsplash
+  option enabled 1
+
+  # Set to 0 to disable hook that makes nodogsplash restart when the firewall restarts.
+  # This hook is needed as a restart of Firewall overwrites nodogsplash iptables entries.
+  option fwhook_enabled '1'
+
+  # WebRoot
+  # Default: /etc/nodogsplash/htdocs
+  #
+  # The local path where the splash page content resides.
+  # ie. Serve the file splash.html from this directory
+  #option webroot '/etc/nodogsplash/htdocs'
+
+  # Use plain configuration file
+  #option config '/etc/nodogsplash/nodogsplash.conf'
+
+  # Use this option to set the device nodogsplash will bind to.
+  # The value may be an interface section in /etc/config/network or a device name such as br-lan.
+  option gatewayinterface 'br-lan'
+
+  # GatewayPort
+  # Default: 2050
+  #
+  # Nodogsplash's own http server uses gateway address as its IP address.
+  # The port it listens to at that IP can be set here; default is 2050.
+  #
+  #option gatewayport '2050'
+
+
+  option gatewayname 'OpenWrt Nodogsplash'
+  option maxclients '250'
+
+  # Enables debug output (0-3)
+  #option debuglevel '1'
+
+  # Client timeouts in minutes
+  option preauthidletimeout '30'
+  option authidletimeout '120'
+  # Session Timeout is the interval after which clients are forced out (a value of 0 means never)
+  option sessiontimeout '1200'
+
+  # The interval in seconds at which nodogsplash checks client timeout status
+  option checkinterval '600'
+
+  # Enable BinAuth Support.
+  # If set, a program is called with several parameters on authentication (request) and deauthentication.
+  # Request for authentication:
+  # $<BinAuth> auth_client <client_mac> '<username>' '<password>'
+  #
+  # The username and password values may be empty strings and are URL encoded.
+  # The program is expected to output the number of seconds the client
+  # is to be authenticated. Zero or negative seconds will cause the authentification request
+  # to be rejected. The same goes for an exit code that is not 0.
+  # The output may contain a user specific download and upload limit in KBit/s:
+  # <seconds> <upload> <download>
+  #
+  # Called on authentication or deauthentication:
+  # $<BinAuth> <*auth|*deauth> <incoming_bytes> <outgoing_bytes> <session_start> <session_end>
+  #
+  # "client_auth": Client authenticated via this script.
+  # "client_deauth": Client deauthenticated by the client via splash page.
+  # "idle_deauth": Client was deauthenticated because of inactivity.
+  # "timeout_deauth": Client was deauthenticated because the session timed out.
+  # "ndsctl_auth": Client was authenticated manually by the ndsctl tool.
+  # "ndsctl_deauth": Client was deauthenticated by the ndsctl tool.
+  # "shutdown_deauth": Client was deauthenticated by Nodogsplash terminating.
+  #
+  # Values session_start and session_start are in seconds since 1970 or 0 for unknown/unlimited.
+  #
+  #option binauth '/bin/myauth.sh'
+  # Enable PreAuth Support.
+  #
+  # A simple login script is provided in the package.
+  # This generates a login page asking for usename and email address.
+  # User logins are recorded in the log file /tmp/ndslog.log
+  # Details of how the script works are contained in comments in the script itself.
+  #
+  # The Preauth program will output html code that will be served to the client by NDS
+  # Using html GET the Preauth program may call:
+  # /nodogsplash_preauth/ to ask the client for more information
+  # or
+  # /nodogsplash_auth/ to authenticate the client
+  #
+  # The Preauth program should append at least the client ip to the query string
+  # (using html input type hidden) for all calls to /nodogsplash_preauth/
+  # It must also obtain the client token using ndsctl (or the original query string if fas_secure_enabled=0)
+  # for NDS authentication when calling /nodogsplash_auth/
+  #
+  #option preauth '/usr/lib/nodogsplash/login.sh'
+
+  # Your router may have several interfaces, and you
+  # probably want to keep them private from the gatewayinterface.
+  # If so, you should block the entire subnets on those interfaces, e.g.:
+  #list authenticated_users 'block to 192.168.0.0/16'
+  #list authenticated_users 'block to 10.0.0.0/8'
+
+  # Typical ports you will probably want to open up.
+  #list authenticated_users 'allow tcp port 22'
+  #list authenticated_users 'allow tcp port 53'
+  #list authenticated_users 'allow udp port 53'
+  #list authenticated_users 'allow tcp port 80'
+  #list authenticated_users 'allow tcp port 443'
+  # Or for happy customers allow all
+  list authenticated_users 'allow all'
+
+  # For preauthenticated users to resolve IP addresses in their
+  # initial request not using the router itself as a DNS server,
+  # Leave commented to help prevent DNS tunnelling
+  #list preauthenticated_users 'allow tcp port 53'
+  #list preauthenticated_users 'allow udp port 53'
+
+  # Allow ports for SSH/Telnet/DNS/DHCP/HTTP/HTTPS
+  list users_to_router 'allow tcp port 22'
+  list users_to_router 'allow tcp port 23'
+  list users_to_router 'allow tcp port 53'
+  list users_to_router 'allow udp port 53'
+  list users_to_router 'allow udp port 67'
+  list users_to_router 'allow tcp port 80'
+
+  # MAC addresses that are / are not allowed to access the splash page
+  # Value is either 'allow' or 'block'. The allowedmac or blockedmac list is used.
+  #option macmechanism 'allow'
+  #list allowedmac '00:00:C0:01:D0:0D'
+  #list allowedmac '00:00:C0:01:D0:1D'
+  #list blockedmac '00:00:C0:01:D0:2D'
+
+  # MAC addresses that do not need to authenticate
+  #list trustedmac '00:00:C0:01:D0:1D'
+
+  # Nodogsplash uses specific HEXADECIMAL values to mark packets used by iptables as a bitwise mask.
+  # This mask can conflict with the requirements of other packages such as mwan3, sqm etc
+  # Any values set here are interpreted as in hex format.
+  #
+  # List: fw_mark_authenticated
+  # Default: 30000 (0011|0000|0000|0000|0000 binary)
+  #
+  # List: fw_mark_trusted
+  # Default: 20000 (0010|0000|0000|0000|0000 binary)
+  #
+  # List: fw_mark_blocked
+  # Default: 10000 (0001|0000|0000|0000|0000 binary)
+  #
+  #option fw_mark_authenticated '30000'
+  #option fw_mark_trusted '20000'
+  #option fw_mark_blocked '10000'
+

--- a/net/nodogsplash/files/etc/init.d/nodogsplash
+++ b/net/nodogsplash/files/etc/init.d/nodogsplash
@@ -1,0 +1,215 @@
+#!/bin/sh /etc/rc.common
+
+#
+# Startup/shutdown script for nodogsplash captive portal
+#
+
+START=95
+STOP=95
+
+USE_PROCD=1
+
+IPT=/usr/sbin/iptables
+WD_DIR=/usr/bin
+
+# Run in PROCD (-f) and log to SYSLOG (-s)
+OPTIONS="-f -s"
+#
+
+CONFIG=""
+
+
+addline() {
+  append CONFIG "$1" "$N"
+}
+
+setup_mac_lists() {
+  local cfg="$1"
+  local macs=""
+  local val
+
+  append_mac() {
+    append macs "$1" ","
+  }
+
+  config_get val "$cfg" macmechanism
+  if [ -z "$val" ]; then
+    # Check if we have AllowedMACList or BlockedMACList defined they will be ignored
+    config_get val "$cfg" allowedmac
+    if [ -n "$val" ]; then
+      echo "Ignoring allowedmac - macmechanism not \"allow\"" >&2
+    fi
+
+    config_get val "$cfg" blockedmac
+    if [ -n "$val" ]; then
+      echo "Ignoring blockedmac - macmechanism not \"block\"" >&2
+    fi
+  elif [ "$val" = "allow" ]; then
+    config_list_foreach "$cfg" allowedmac append_mac
+    addline "MACmechanism allow"
+    addline "AllowedMACList $macs"
+  elif [ "$val" = "block" ]; then
+    config_list_foreach "$cfg" blockedmac append_mac
+    addline "MACmechanism block"
+    addline "BlockedMACList $macs"
+  else
+    echo "Invalid macmechanism '$val' - allow or block are valid." >&2
+    return 1
+  fi
+
+  macs=""
+  config_list_foreach "$cfg" trustedmac append_mac
+  if [ -n "$macs" ]; then
+    addline "TrustedMACList $macs"
+  fi
+
+  return 0
+}
+
+setup_firewall() {
+  local cfg="$1"
+  local uci_name
+  local val
+
+  append_firewall() {
+    addline "  FirewallRule $1"
+  }
+
+  for rule in authenticated-users preauthenticated-users users-to-router trusted-users trusted-users-to-router; do
+    # uci does not allow dashes
+    uci_name=${rule//-/_}
+    addline "FirewallRuleSet $rule {"
+    config_list_foreach "$cfg" "$uci_name" append_firewall
+    addline "}"
+    config_get val "$cfg" "policy_${uci_name}"
+    if [ -n "$val" ]; then
+      addline "EmptyRuleSetPolicy $rule $val"
+    fi
+  done
+}
+
+wait_for_interface() {
+  local ifname="$1"
+  local timeout=10
+
+  for i in $(seq $timeout); do
+    if [ $(ip -4 addr show dev $ifname 2> /dev/null | grep -c inet) -ne 0 ]; then
+      break
+    fi
+    sleep 1
+    if [ $i = $timeout ]; then
+      echo "Interface $ifname not detected." >&2
+      return 1
+    fi
+  done
+
+  return 0
+}
+
+generate_uci_config() {
+  local cfg="$1"
+  local val
+  local ifname
+  local download
+  local upload
+
+  # Init config file content
+  CONFIG="# auto-generated config file from /etc/config/nodogsplash"
+
+  config_get val "$cfg" config
+  if [ -n "$val" ]; then
+    if [ ! -f "$val" ]; then
+      echo "Configuration file '$file' doesn't exist." >&2
+      return 1
+    fi
+    addline "$(cat $val)"
+  fi
+
+  config_get ifname "$cfg" gatewayinterface
+
+  # Get device name if interface name is a section name in /etc/config/network
+  if network_get_device tmp "$ifname"; then
+    ifname="$tmp"
+  fi
+
+  if [ -z "$ifname" ]; then
+    echo "Option network or gatewayinterface missing." >&2
+    return 1
+  fi
+
+  wait_for_interface "$ifname" || return 1
+
+  addline "GatewayInterface $ifname"
+
+  for option in preauth binauth \
+    daemon debuglevel maxclients gatewayname gatewayinterface gatewayiprange \
+    gatewayaddress gatewayport webroot splashpage statuspage \
+    redirecturl sessiontimeout preauthidletimeout authidletimeout checkinterval \
+    setmss mssvalue trafficcontrol downloadlimit uploadlimit \
+    syslogfacility ndsctlsocket fw_mark_authenticated \
+    fw_mark_blocked fw_mark_trusted
+  do
+    config_get val "$cfg" "$option"
+
+    if [ -n "$val" ]; then
+      addline "$option $val"
+    fi
+  done
+  for option in fasport fasremoteip faspath fas_secure_enabled ; do
+    config_get val "$cfg" "$option"
+    if [ -n "$val" ]; then
+      echo "Warning: nodogsplash does not support $val"
+      return 1
+    fi
+  done
+  config_get download "$cfg" downloadlimit
+  config_get upload "$cfg" uploadlimit
+
+  if [ -n "$upload" -o -n "$download" ]; then
+    addline "TrafficControl yes"
+  fi
+
+  setup_mac_lists "$cfg" || return 1
+  setup_firewall "$cfg"
+
+  echo "$CONFIG" > "/tmp/etc/nodogsplash_$cfg.conf"
+  return 0
+}
+
+# setup configuration and start instance
+create_instance() {
+  local cfg="$1"
+  local val
+
+  config_get_bool val "$cfg" enabled 0
+  [ $val -gt 0 ] || return 0
+
+  if ! generate_uci_config "$cfg"; then
+    echo "Can not generate uci config. Will not start instance $cfg." >&2
+    return 1
+  fi
+
+  procd_open_instance $cfg
+  procd_set_param command /usr/bin/nodogsplash -c "/tmp/etc/nodogsplash_$cfg.conf" $OPTIONS
+  procd_set_param respawn
+  procd_set_param file "/tmp/etc/nodogsplash_$cfg.conf"
+  procd_close_instance
+}
+
+start_service() {
+  # For network_get_device()
+  include /lib/functions
+
+  # For nodogsplash.conf file
+  mkdir -p /tmp/etc/
+
+  config_load nodogsplash
+  config_foreach create_instance nodogsplash
+}
+
+stop_service() {
+  # When procd terminates nodogsplash, it does not exit fast enough.
+  # Otherwise procd will restart nodogsplash twice. First time starting
+  # nodogsplash fails, second time it succeeds.
+  sleep 1
+}

--- a/net/nodogsplash/files/etc/init.d/nodogsplash
+++ b/net/nodogsplash/files/etc/init.d/nodogsplash
@@ -119,7 +119,7 @@ generate_uci_config() {
   config_get val "$cfg" config
   if [ -n "$val" ]; then
     if [ ! -f "$val" ]; then
-      echo "Configuration file '$file' doesn't exist." >&2
+      echo "Configuration file '$val' doesn't exist." >&2
       return 1
     fi
     addline "$(cat $val)"
@@ -142,7 +142,7 @@ generate_uci_config() {
   addline "GatewayInterface $ifname"
 
   for option in preauth binauth \
-    daemon debuglevel maxclients gatewayname gatewayinterface gatewayiprange \
+    daemon debuglevel maxclients gatewayname gatewayiprange \
     gatewayaddress gatewayport webroot splashpage statuspage \
     redirecturl sessiontimeout preauthidletimeout authidletimeout checkinterval \
     setmss mssvalue trafficcontrol downloadlimit uploadlimit \
@@ -158,7 +158,7 @@ generate_uci_config() {
   for option in fasport fasremoteip faspath fas_secure_enabled ; do
     config_get val "$cfg" "$option"
     if [ -n "$val" ]; then
-      echo "Warning: nodogsplash does not support $val"
+      echo "Warning: nodogsplash does not support $option"
       return 1
     fi
   done

--- a/net/nodogsplash/files/etc/uci-defaults/40_nodogsplash
+++ b/net/nodogsplash/files/etc/uci-defaults/40_nodogsplash
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+uci -q batch <<-EOF
+	delete firewall.nodogsplash
+	set firewall.nodogsplash=include
+	set firewall.nodogsplash.type=script
+	set firewall.nodogsplash.path=/usr/lib/nodogsplash/restart.sh
+	commit firewall
+EOF

--- a/net/nodogsplash/files/usr/lib/nodogsplash/restart.sh
+++ b/net/nodogsplash/files/usr/lib/nodogsplash/restart.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# Check if nodogsplash is running
+if ndsctl status &> /dev/null; then
+  if [ "$(uci -q get nodogsplash.@nodogsplash[0].fwhook_enabled)" = "1" ]; then
+    /etc/init.d/nodogsplash restart
+  fi
+fi


### PR DESCRIPTION
Adds nodogsplash from the openwrt/routing feed — the routing packages are being moved into openwrt/packages one by one, as discussed in openwrt/routing#184.

The content matches the current routing feed master. Once this is merged, the package will be removed from the routing feed (a coordinated removal PR is prepared there).

Maintainer: @mwarning