### PR TITLE
attr, domoticz, openzwave: move the version check to test-version.sh

### DIFF
--- a/utils/attr/test-version.sh
+++ b/utils/attr/test-version.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+# shellcheck shell=busybox
+
+case "$1" in
+	attr)
+		getfattr --version | grep -F "$2" || exit 1
+		setfattr --version | grep -F "$2" || exit 1
+		# attr does not implement --version; its getopt string is
+		# "s:V:g:r:lqLRS", where -V takes a value, so just verify it
+		# is present
+		[ -x /usr/bin/attr ] || exit 1
+		;;
+
+	libattr)
+		# ships no executable, nothing to assert
+		exit 0
+		;;
+
+	*)
+		echo "Untested package: $1" >&2
+		exit 1
+		;;
+esac

--- a/utils/attr/test.sh
+++ b/utils/attr/test.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-case "$1" in
-	attr)
-		# attr does not implement --version; just verify it is present
-		[ -x /usr/bin/attr ] || exit 1
-		;;
-esac

--- a/utils/domoticz/test-version.sh
+++ b/utils/domoticz/test-version.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# shellcheck shell=busybox
+
+case "$1" in
+	domoticz)
+		# domoticz has no flag that prints its version; just verify the
+		# binary is present
+		[ -x /usr/bin/domoticz ] || exit 1
+		;;
+
+	*)
+		echo "Untested package: $1" >&2
+		exit 1
+		;;
+esac

--- a/utils/domoticz/test.sh
+++ b/utils/domoticz/test.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-case "$1" in
-	domoticz)
-		[ -x /usr/bin/domoticz ] || exit 1
-		;;
-esac

--- a/utils/openzwave/test-version.sh
+++ b/utils/openzwave/test-version.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# shellcheck shell=busybox
+
+case "$1" in
+	openzwave)
+		# MinOZW prints "OpenZWave Version 1.6-1965-g3fff11d2", which never
+		# matches PKG_VERSION (1.6.1965); just verify the binary is present
+		[ -x /usr/bin/MinOZW ] || exit 1
+		;;
+
+	libopenzwave|openzwave-config)
+		# ship no executable, nothing to assert
+		exit 0
+		;;
+
+	*)
+		echo "Untested package: $1" >&2
+		exit 1
+		;;
+esac

--- a/utils/openzwave/test.sh
+++ b/utils/openzwave/test.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-case "$1" in
-	openzwave)
-		[ -x /usr/bin/MinOZW ] || exit 1
-		;;
-esac


### PR DESCRIPTION
In actions-shared-workflows the version is now checked in `test-version.sh`, while `test.sh` is left for the generic tests.

- `attr` — the move also tightens the check. The package installs `attr`, `getfattr` and `setfattr`, and the latter two do implement `--version`, so the version is now asserted for them; only `attr` itself keeps the presence check, because its getopt string is `s:V:g:r:lqLRS`, where `-V` takes a value rather than printing a version.
- `domoticz` — reports no version at all, so the override only asserts that the binary is present.
- `openzwave` — `MinOZW` does report one, but as `OpenZWave Version 1.6-1965-g3fff11d2`, which never matches `PKG_VERSION` (`1.6.1965`). As the package's only executable it failed the generic probe outright, which is what surfaced this.

Each script also gained arms for its remaining binary packages and an `*)` fallback, so an unknown sub-package fails loudly instead of falling off the end of the `case` and returning 0.

`attr` and `domoticz` were split out of #30112: building domoticz pulls in boost, icu and python3, which adds roughly 90 minutes to every CI job and pushed 8 of the 10 test-build targets there over the 6 hour limit. `openzwave` joins them because it is a domoticz dependency and is therefore built and tested alongside it.