### PR TITLE
checksec: drop the hardcoded version from the version check override

### DIFF
--- a/utils/checksec/test-version.sh
+++ b/utils/checksec/test-version.sh
@@ -2,11 +2,19 @@
 
 # shellcheck shell=busybox
 
-# checksec reported version doesn't match package version as of 3.1.0
+# checksec.bash reports a version unrelated to the release it ships in:
+# SCRIPT_MAJOR, SCRIPT_MINOR and SCRIPT_REVISION have not been bumped since
+# before 3.0.0, so 3.2.0 still prints "checksec v2.7.1". Upstream will not fix
+# it, the bash implementation is legacy and is being replaced by a Go rewrite:
+# https://github.com/slimm609/checksec.sh/issues/352
+#
+# Matching that hardcoded string asserts nothing about the installed package,
+# so only require that the tool runs. The override itself has to stay: without
+# it the generic probe fails the package for not reporting $PKG_VERSION.
 
 case "$PKG_NAME" in
 checksec)
-	checksec --version 2>&1 | grep -qF "2.7.1"
+	checksec --version
 	;;
 
 *)


### PR DESCRIPTION
`checksec.bash` reports a version unrelated to the release it ships in: `SCRIPT_MAJOR`, `SCRIPT_MINOR` and `SCRIPT_REVISION` have not been bumped since before 3.0.0, so 3.2.0 still prints `checksec v2.7.1`.

I reported this upstream and it was closed with the answer that the bash implementation is legacy and is being replaced by a Go rewrite: https://github.com/slimm609/checksec.sh/issues/352 — so the reported version will not start matching the package version.

Grepping for the hardcoded `2.7.1` therefore asserts nothing about the installed package and only breaks once the rewrite lands. Run the tool instead and keep the override, which is what stops the generic probe from failing the package for not reporting `PKG_VERSION`.

Split out of #29912, where this was previously carried as part of the tree-wide `grep -q` cleanup.