### PR TITLE
hev-socks5-tproxy: update to 2.13.0

### DIFF
--- a/net/hev-socks5-tproxy/Makefile
+++ b/net/hev-socks5-tproxy/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=hev-socks5-tproxy
-PKG_VERSION:=2.12.0
+PKG_VERSION:=2.13.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/heiher/hev-socks5-tproxy/releases/download/$(PKG_VERSION)
-PKG_HASH:=b5fb0265f8d3a5f16d6c5ebc0094cb214afbe5b6d27e12c137f4a5da70c25a54
+PKG_HASH:=4cc74958221b3d40803ef9e597af1510110b6e674ceea729e470b808a257ba31
 
 PKG_MAINTAINER:=Ray Wang <git@hev.cc>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @heiher

**Description:** update to 2.13.0

Upstream changelog:
https://github.com/heiher/hev-socks5-tproxy/releases/tag/2.13.0

---

## 🧪 Run Testing Details

- **OpenWrt Version:** snapshot
- **OpenWrt Target/Subtarget:** armv8
- **OpenWrt Device:** armsr

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
