### PR TITLE
cryptsetup: add OPENSSL_WITH_BLAKE2 dependency

### DIFF
--- a/utils/cryptsetup/Makefile
+++ b/utils/cryptsetup/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cryptsetup
 PKG_VERSION:=2.8.7
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/linux/utils/cryptsetup/v$(subst $(space),.,$(wordlist 1, 2, $(subst .,$(space),$(PKG_VERSION))))
@@ -35,7 +35,8 @@ define Package/cryptsetup
   SUBMENU:=Encryption
   TITLE:=Cryptsetup
   DEPENDS:=$(ICONV_DEPENDS) $(INTL_DEPENDS) +libblkid +libuuid +libpopt +lvm2 \
-           +libdevmapper +libjson-c +@KERNEL_DIRECT_IO +kmod-crypto-user +libopenssl
+           +libdevmapper +libjson-c +@KERNEL_DIRECT_IO +kmod-crypto-user +libopenssl \
+           +@OPENSSL_WITH_BLAKE2
   URL:=https://gitlab.com/cryptsetup/cryptsetup/
 endef
 


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @danwrt

**Description:**
Without OPENSSL_WITH_BLAKE2 there is no support for Argon2 and cryptsetup is unable to open LUKS partitions created with default settings.

Fixes: fbac2e7861fb30661eef52a45223bb3a3a0d6d17

---

## 🧪 Run Testing Details

- **OpenWrt Version:** compiled from master
- **OpenWrt Target/Subtarget:** x86/x86_64
- **OpenWrt Device:** x64 PC

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
