### PR TITLE
python-cffi: fix cross-compilation on macOS hosts

### DIFF
--- a/lang/python/python-cffi/Makefile
+++ b/lang/python/python-cffi/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-cffi
 PKG_VERSION:=1.16.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=cffi
 PKG_HASH:=bcb3ef43e58665bbda2fb198698fcae6776483e0c4a631aa5647806c25e02cc0

--- a/lang/python/python-cffi/patches/002-fix-cross-compilation-on-macos-hosts.patch
+++ b/lang/python/python-cffi/patches/002-fix-cross-compilation-on-macos-hosts.patch
@@ -1,0 +1,41 @@
+From 7a3b39e2fbbaa0511789a3231964f61f77fb28a9 Mon Sep 17 00:00:00 2001
+From: Josef Schlehofer <pepe.schlehofer@gmail.com>
+Date: Tue, 9 Jun 2026 04:33:35 +0000
+Subject: [PATCH] setup.py: fix cross-compilation on macOS hosts
+
+Backport of https://github.com/python-cffi/cffi/pull/247, merged upstream on
+2026-06-09 and not yet in the 1.16.0 release OpenWrt 24.10 carries.
+
+When cross-compiling for a non-macOS target (such as Linux) on a macOS host,
+setup.py incorrectly detects the host platform as 'darwin' using sys.platform.
+This adds the macOS-specific flag -iwithsysroot/usr/include/ffi to the compiler
+arguments, which causes the cross-compiler to fail with:
+
+  powerpc-openwrt-linux-musl-gcc: error: unrecognized command-line option
+  '-iwithsysroot/usr/include/ffi'
+
+By using sysconfig.get_platform().startswith('macosx') instead of 'darwin' in
+sys.platform, we correctly check the target platform rather than the build host.
+
+The import is part of the backport: upstream already imports sysconfig for
+FREE_THREADED_BUILD, which 1.16.0 predates.
+
+Signed-off-by: Josef Schlehofer <pepe.schlehofer@gmail.com>
+---
+--- a/setup.py
++++ b/setup.py
+@@ -1,4 +1,4 @@
+-import sys, os, platform
++import sys, sysconfig, os, platform
+ import subprocess
+ import errno
+ 
+@@ -148,7 +148,7 @@ else:
+     ask_supports_thread()
+     ask_supports_sync_synchronize()
+ 
+-if 'darwin' in sys.platform:
++if sysconfig.get_platform().startswith('macosx'):
+     # priority is given to `pkg_config`, but always fall back on SDK's libffi.
+     extra_compile_args += ['-iwithsysroot/usr/include/ffi']
+ 


### PR DESCRIPTION
Cross-compiling python-cffi on a macOS build host fails:

```
powerpc-openwrt-linux-musl-gcc: error: unrecognized command-line option '-iwithsysroot/usr/include/ffi'
```

setup.py selects that macOS-only flag from `sys.platform`, which is the platform of the interpreter running the build rather than the platform being built for. `sysconfig.get_platform()` honours `_PYTHON_HOST_PLATFORM`, which python3-package.mk already exports, so it reports the target when cross-compiling and the host otherwise. A native macOS build keeps the SDK libffi fallback.

Backport of python-cffi/cffi#247, merged upstream 2026-06-09.

Tested on mpc85xx/p2020 (powerpc_8548) from a macOS host: python3-cffi builds and packages cleanly.