### PR TITLE
librespeed-cli-rust: add new package

### DIFF
--- a/utils/librespeed-cli-rust/Makefile
+++ b/utils/librespeed-cli-rust/Makefile
@@ -1,0 +1,62 @@
+#
+# Copyright (C) 2026 Josef Schlehofer
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=librespeed-cli-rust
+PKG_VERSION:=0.1.0
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/BKPepe/speedtest-cli-rust/tar.gz/refs/tags/v$(PKG_VERSION)?
+PKG_HASH:=d6b88befe573a9d2f93656fadeb69c194c6aa0027749662e2f0dafd972cee8f5
+PKG_BUILD_DIR:=$(BUILD_DIR)/speedtest-cli-rust-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
+PKG_LICENSE:=LGPL-3.0-only
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_DEPENDS:=rust/host
+PKG_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/rust/rust-package.mk
+
+define Package/librespeed-cli-rust
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=Command line client for LibreSpeed (Rust)
+  URL:=https://github.com/BKPepe/speedtest-cli-rust
+  DEPENDS:=$(RUST_ARCH_DEPENDS) +libopenssl
+  PROVIDES:=librespeed-cli
+  CONFLICTS:=librespeed-cli
+endef
+
+define Package/librespeed-cli-rust/description
+  LibreSpeed client for measuring internet speed from command line.
+
+  This is a Rust port of librespeed/speedtest-cli. The original is written
+  in Go, whose toolchain targets only ppc64 and ppc64le, so librespeed-cli
+  is unavailable on 32-bit PowerPC devices. Both packages install
+  /usr/bin/librespeed-cli, hence the conflict.
+endef
+
+# rustls' default crypto backend, ring, does build here, but it has no assembly
+# for big-endian PowerPC and falls back to its portable C: on mpc85xx its
+# AES-GCM measured under half of libopenssl's throughput. libopenssl is in the
+# image anyway, so linking against it is both faster and one TLS stack fewer.
+RUST_PKG_FEATURES:=native-tls
+CARGO_PKG_ARGS+= --no-default-features
+
+CARGO_PKG_VARS+= \
+	OPENSSL_NO_VENDOR=1 \
+	OPENSSL_INCLUDE_DIR=$(STAGING_DIR)/usr/include \
+	OPENSSL_LIB_DIR=$(STAGING_DIR)/usr/lib \
+	PKG_CONFIG_ALLOW_CROSS=1
+
+$(eval $(call RustBinPackage,librespeed-cli-rust))
+$(eval $(call BuildPackage,librespeed-cli-rust))

--- a/utils/librespeed-cli-rust/test.sh
+++ b/utils/librespeed-cli-rust/test.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+set -e
+
+# Everything here runs without network access, so it works the same in the
+# build matrix as on a device.
+
+# Help and the report header, which touch no I/O at all.
+librespeed-cli --help > /dev/null
+librespeed-cli --csv-header | grep '^Timestamp,Server Name,Address,Ping,Jitter,Download,Upload,Share,IP$'
+
+# The version banner carries more than the version the generic check looks
+# for; make sure the rest of it survives too.
+librespeed-cli --version | grep 'github.com/BKPepe/speedtest-cli-rust'
+librespeed-cli --version | grep 'GNU Lesser General Public License'
+
+cat > /tmp/librespeed-servers.json <<'EOF'
+[{"id":7,"name":"Example","server":"https://example.invalid","dlURL":"garbage.php","ulURL":"empty.php","pingURL":"empty.php","getIpURL":"getIP.php"}]
+EOF
+
+# Server list parsing and selection, offline.
+librespeed-cli --local-json /tmp/librespeed-servers.json --list | grep '^7: Example'
+
+# A malformed list has to be rejected rather than silently ignored.
+echo 'nonsense' > /tmp/librespeed-bad.json
+if librespeed-cli --local-json /tmp/librespeed-bad.json --list > /dev/null 2>&1; then
+	echo "a malformed server list was accepted"
+	exit 1
+fi
+
+cat > /tmp/librespeed-unreachable.json <<'EOF'
+[{"id":1,"name":"local","server":"http://127.0.0.1:1","dlURL":"garbage.php","ulURL":"empty.php","pingURL":"empty.php","getIpURL":"getIP.php"}]
+EOF
+
+# Exercise the async runtime: pointed at a port nothing listens on, the client
+# has to come back. What is being tested is that it returns at all — reaching
+# the "not responding" verdict means the reactor delivered the connection
+# error. One that never delivers readiness sits here forever, which is what
+# the timeout catches. This found a real stall on powerpc_8548.
+rc=0
+timeout 30 librespeed-cli --local-json /tmp/librespeed-unreachable.json \
+	--server 1 --no-icmp --timeout 5 > /tmp/librespeed-test.out 2>&1 || rc=$?
+
+if [ "$rc" = 124 ]; then
+	echo "librespeed-cli did not return within 30s against an unreachable server"
+	cat /tmp/librespeed-test.out
+	exit 1
+fi
+grep 'not responding' /tmp/librespeed-test.out
+
+rm -f /tmp/librespeed-servers.json /tmp/librespeed-bad.json \
+	/tmp/librespeed-unreachable.json /tmp/librespeed-test.out


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @BKPepe

**Description:**
A Rust port of `librespeed-cli`. The Go implementation targets only `ppc64` and `ppc64le`, so `librespeed-cli` cannot be built for 32-bit PowerPC devices such as CZ.NIC Turris 1.x. This one can.

It implements the same command line surface — all ~40 flags, including telemetry/`--share`, JSON and CSV reports, ICMP and HTTP ping, IPv4/IPv6 forcing, `--source`/`--interface`/`--fwmark` socket binding and custom CA bundles. `--list` and `--csv-header` output is byte-identical to the Go client, so it can stand in for it. `--version` names this implementation and its own version number, so that one differs. Both install `/usr/bin/librespeed-cli`, hence `PROVIDES`/`CONFLICTS`.

Built against `libopenssl` rather than rustls. `ring` does build for this target, falling back to portable C where it has no assembly, but that costs throughput on a core with no crypto instructions: measured on the e500v2, AES-128-GCM runs at 8.5 MB/s against 18.8 MB/s for OpenSSL, and an HTTPS run negotiating AES-256-GCM measured 37 Mbps against 138 Mbps. Linking against the libopenssl already in the image also avoids carrying a second TLS stack.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 24.10
- **OpenWrt Target/Subtarget:** mpc85xx/p2020
- **OpenWrt Device:** CZ.NIC Turris 1.1 (powerpc_8548)

Cross-built from a macOS host and run on the device: `--version`, `--help`, `--list` and a full download/upload/ping run against a LibreSpeed backend. Also exercised on aarch64 and x86_64 during development.

Only powerpc_8548 has been verified on real hardware; feedback from anyone able to try aarch64, arm or mips is welcome.

Fixes: https://github.com/librespeed/speedtest-cli/issues/105

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
- [x] This PR only includes a package version or release update, or a new package.
- [x] Sending a pull request against the correct branch: `master`