### PR TITLE
CONTRIBUTING: document what a patch has to look like

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,39 @@ guidelines:
 - Avoid reuse of <strong>PKG_NAME</strong> in call, define and eval lines to improve
   readability.
 
+### Patches
+
+Patches live in `<package>/patches/` and are applied with quilt. Always
+generate and update them with the buildroot's `refresh` target rather than by
+hand or with a plain `git diff`:
+
+```
+make package/foopkg/refresh
+```
+
+That target runs quilt as
+`QUILT_DIFF_OPTS="-p" quilt refresh -p ab --no-index --no-timestamps`, which is
+what produces the expected form:
+
+- `-p ab` gives the usual `a/` and `b/` path prefixes.
+- `--no-index` drops the `Index:` line, which carries no information here.
+- `--no-timestamps` drops the timestamps from the `---` and `+++` lines. They
+  are the working copy's mtimes, so leaving them in makes an otherwise
+  unchanged patch differ between contributors and produces noisy diffs on
+  every refresh.
+- `QUILT_DIFF_OPTS="-p"` passes `-p` to `diff`, so each `@@` hunk header names
+  the enclosing function or section. This is what makes a patch readable in
+  review and is the difference most often missed.
+
+A patch produced by `git diff` or `git format-patch` will carry index lines and
+timestamps and will lack the hunk context, so it will be sent back for a
+refresh even when it applies cleanly.
+
+Each patch should also carry a short description of what it changes and why,
+and a `Signed-off-by` line, above the diff. Anything that is not upstreamable —
+a workaround, a local-only build fix — should say so there, since the patch is
+the only place a later maintainer will look.
+
 ### Commits in your pull-requests should
 
 - Have a useful commit subject prefixed with the package name (E.g.: `foopkg:


### PR DESCRIPTION
Three things are expected of a patch under `<package>/patches/`, and none
of them were written down anywhere a contributor would look.

**The header.** `check_patch_headers` in `formalities.json` requires a
`git am` compatible header — `From <hash> Mon Sep 17 00:00:00 2001`,
`From:`, `Date:`, `Subject:`. `Date:` is the one people leave out, and
the failure only shows up after the pull request is opened.

**Upstream status.** `llm-review-rules.md` asks for an upstream
reference or `Upstream-Status`, with the sensible carve-out that
OpenWrt-specific hacks have nowhere to go. That reasoning was only ever
visible to the review bot.

**The diff itself.** Patches are refreshed with
`make package/<pkg>/refresh`, which runs
`QUILT_DIFF_OPTS="-p" quilt refresh -p ab --no-index --no-timestamps`.
A `git diff` carries `Index:` lines and timestamps and, because it lacks
`diff -p`, has no function name in the `@@` hunk headers. It applies
cleanly, so nothing fails until a reviewer notices.

This adds a `### Patches` section covering all three, and says what each
quilt option is for rather than just naming the command — so the next
person who wonders whether the timestamps actually matter can find out
without reading `include/quilt.mk`.

`llm-review-rules.md` already states the refresh target and the upstream
reference, but that file is the review bot's instructions and it opens by
pointing contributors at CONTRIBUTING.md, so this is where the
requirement belongs.

Documentation only, no packages touched.