### PR TITLE
packages/perl: fix build with gcc15 and glibc

### DIFF
--- a/lang/perl/Makefile
+++ b/lang/perl/Makefile
@@ -36,6 +36,9 @@ HOST_PERL_PREFIX:=$(STAGING_DIR_HOSTPKG)/usr
 ifneq ($(CONFIG_USE_MUSL),)
   TARGET_CFLAGS += -D_LARGEFILE64_SOURCE
 endif
+ifneq ($(CONFIG_LIBC_USE_GLIBC),)
+  TARGET_CFLAGS += -D_GNU_SOURCE
+endif
 
 # Filter -g3, it will break Compress-Raw-Zlib
 TARGET_CFLAGS_PERL:=$(patsubst -g3,-g,$(TARGET_CFLAGS))


### PR DESCRIPTION
glibc apparently needs the _GNU_SOURCE feature test macro before exposing the dup3() and accept4() system calls. Otherwise it fails as below:

mipsel_24kc_gcc-15.2.0_glibc/include -O2 -Wall -Werror=pointer-arith -Werror=vla -Wextra -Wno-long-long -Wno-declaration-after-statement -Wc++-compat -Wwrite-strings -fPIC doop.c In file included from perl.h:6225,
                 from op.c:163:
op.c: In function 'Perl_ck_entersub_args_core':
op.c:14605:41: warning: spurious trailing '%' in format [-Wformat=]
14605 |                     Perl_newSVpvf(aTHX_ "%" LINE_Tf, CopLINE(PL_curcop)));
      |                                         ^~~
embed.h:427:72: note: in definition of macro 'newSVOP'
  427 | # define newSVOP(a,b,c)                         Perl_newSVOP(aTHX_ a,b,c)
      |                                                                        ^
op.c:14605:41: warning: too many arguments for format [-Wformat-extra-args]
14605 |                     Perl_newSVpvf(aTHX_ "%" LINE_Tf, CopLINE(PL_curcop)));
      |                                         ^~~
embed.h:427:72: note: in definition of macro 'newSVOP'
  427 | # define newSVOP(a,b,c)                         Perl_newSVOP(aTHX_ a,b,c)
      |                                                                        ^
doio.c: In function 'Perl_PerlLIO_dup2_cloexec':
doio.c:218:9: error: implicit declaration of function 'dup3'; did you mean 'dup2'? [-Wimplicit-function-declaration]
  218 |         dup3(oldfd, newfd, O_CLOEXEC),
      |         ^~~~
doio.c:125:32: note: in definition of macro 'DO_GENOPEN_EXPERIMENTING_CLOEXEC'
  125 |                     int res = (GENOPEN_CLOEXEC), eno; \
      |                                ^~~~~~~~~~~~~~~
doio.c:216:5: note: in expansion of macro 'DO_ONEOPEN_EXPERIMENTING_CLOEXEC'
  216 |     DO_ONEOPEN_EXPERIMENTING_CLOEXEC(
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
doio.c: In function 'Perl_my_mkstemp_cloexec':
util.h:275:45: error: implicit declaration of function 'mkostemp'; did you mean 'mkstemp'? [-Wimplicit-function-declaration]
  275 | #   define Perl_my_mkostemp(templte, flags) mkostemp(templte, flags)
      |                                             ^~~~~~~~
doio.c:125:32: note: in definition of macro 'DO_GENOPEN_EXPERIMENTING_CLOEXEC'
  125 |                     int res = (GENOPEN_CLOEXEC), eno; \
      |                                ^~~~~~~~~~~~~~~
doio.c:336:5: note: in expansion of macro 'DO_ONEOPEN_EXPERIMENTING_CLOEXEC'
  336 |     DO_ONEOPEN_EXPERIMENTING_CLOEXEC(
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
doio.c:338:9: note: in expansion of macro 'Perl_my_mkostemp'
  338 |         Perl_my_mkostemp(templte, O_CLOEXEC),
      |         ^~~~~~~~~~~~~~~~
doio.c: In function 'Perl_PerlProc_pipe_cloexec':
doio.c:372:9: error: implicit declaration of function 'pipe2'; did you mean 'pipe'? [-Wimplicit-function-declaration]
  372 |         pipe2(pipefd, O_CLOEXEC),
      |         ^~~~~
doio.c:125:32: note: in definition of macro 'DO_GENOPEN_EXPERIMENTING_CLOEXEC'
  125 |                     int res = (GENOPEN_CLOEXEC), eno; \
      |                                ^~~~~~~~~~~~~~~
doio.c:371:5: note: in expansion of macro 'DO_PIPEOPEN_EXPERIMENTING_CLOEXEC'
  371 |     DO_PIPEOPEN_EXPERIMENTING_CLOEXEC(PL_strategy_pipe, pipefd,
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
doio.c: In function 'Perl_PerlSock_accept_cloexec':
doio.c:408:9: error: implicit declaration of function 'accept4'; did you mean 'accept'? [-Wimplicit-function-declaration]
  408 |         accept4(listenfd, addr, addrlen, SOCK_CLOEXEC),
      |         ^~~~~~~
doio.c:125:32: note: in definition of macro 'DO_GENOPEN_EXPERIMENTING_CLOEXEC'
  125 |                     int res = (GENOPEN_CLOEXEC), eno; \
      |                                ^~~~~~~~~~~~~~~
doio.c:406:5: note: in expansion of macro 'DO_ONEOPEN_EXPERIMENTING_CLOEXEC'
  406 |     DO_ONEOPEN_EXPERIMENTING_CLOEXEC(
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

## 📦 Package Details

**Maintainer:** @BKPepe 

**Description:**Compilation fix for glibc (slightly unusual libc choice)

---

## 🧪 Run Testing Details

- **OpenWrt Version:** master
- **OpenWrt Target/Subtarget:** no runtime testing
- **OpenWrt Device:** no runtime testing

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>