### PR TITLE
radicale3: bump to v3.7.8

### DIFF
--- a/net/radicale3/Makefile
+++ b/net/radicale3/Makefile
@@ -4,7 +4,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=radicale3
-PKG_VERSION:=3.7.7
+PKG_VERSION:=3.7.8
 PKG_RELEASE:=1
 
 PKG_LICENSE:=GPL-3.0-or-later
@@ -13,7 +13,7 @@ PKG_CPE_ID:=cpe:/a:radicale:radicale
 
 PYPI_NAME:=Radicale
 PYPI_SOURCE_NAME:=radicale
-PKG_HASH:=46c58d0340bc70a1219a46ca9c6a88b97293b555e15d41d66110c5e236243b64
+PKG_HASH:=8b7345606bf13ded08dc81d4fddefbbe3461baa11b2fe77caba355a0978f8e9c
 
 PKG_MAINTAINER:=Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>
 


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @danielfdickinson 
**Also notify:** @BKPepe

**Description:**
This is a bugfix and enhancement release: https://github.com/Kozea/Radicale/releases/tag/v3.7.8

It is intended to be the last of the 3.7.x series.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** OpenWrt SNAPSHOT r35713-652b2e90b3
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** OpenWrt One

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
