### PR TITLE
tcpoptimizer-edge: add package

### DIFF
--- a/net/tcpoptimizer-edge/Makefile
+++ b/net/tcpoptimizer-edge/Makefile
@@ -1,0 +1,56 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=tcpoptimizer-edge
+PKG_VERSION:=0.3.0
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/honvl/tcpoptimizer-edge/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=07d8a57cc09a23eded25c1978b61e41a3a98d9cd50de4f16c774f1498a0f3b45
+
+PKG_MAINTAINER:=Honver Lam <hl337@cornell.edu>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_DEPENDS:=rust/host
+PKG_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/rust/rust-package.mk
+
+# rustls-ring depends on ring, which supports these OpenWrt architectures.
+# Its 32-bit x86 backend requires SSE/SSE2, and OpenWrt builds every i386
+# subtarget for the i586 rustc target (lang/rust/rust-values.mk), which has
+# neither.
+define Package/tcpoptimizer-edge
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=Paired TCP transport optimizer over WireGuard
+  URL:=https://github.com/honvl/tcpoptimizer-edge
+  DEPENDS:=$(RUST_ARCH_DEPENDS) @(aarch64||arm||x86_64)
+endef
+
+define Package/tcpoptimizer-edge/description
+  Authenticated split-TCP edge that multiplexes proxied TCP connections over
+  a persistent QUIC transport between WireGuard-connected networks.
+endef
+
+define Package/tcpoptimizer-edge/conffiles
+/etc/config/tcpoptimizer
+endef
+
+define Package/tcpoptimizer-edge/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/bin/tcpoptimizer-edge $(1)/usr/sbin/
+	$(INSTALL_BIN) $(CURDIR)/files/tcpoptimizer-intercept $(1)/usr/sbin/
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) $(CURDIR)/files/tcpoptimizer-edge.init \
+		$(1)/etc/init.d/tcpoptimizer-edge
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_CONF) $(CURDIR)/files/tcpoptimizer.config \
+		$(1)/etc/config/tcpoptimizer
+	$(INSTALL_DIR) $(1)/etc/tcpoptimizer
+endef
+
+$(eval $(call RustBinPackage,tcpoptimizer-edge))
+$(eval $(call BuildPackage,tcpoptimizer-edge))

--- a/net/tcpoptimizer-edge/files/tcpoptimizer-edge.init
+++ b/net/tcpoptimizer-edge/files/tcpoptimizer-edge.init
@@ -1,0 +1,131 @@
+#!/bin/sh /etc/rc.common
+
+START=95
+STOP=10
+USE_PROCD=1
+
+PROG=/usr/sbin/tcpoptimizer-edge
+CONFIG=/var/run/tcpoptimizer-edge.toml
+
+toml_string() {
+	printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
+}
+
+emit_string() {
+	key="$1"
+	value="$2"
+	[ -n "$value" ] || return 1
+	printf '%s = "' "$key"
+	toml_string "$value"
+	printf '"\n'
+}
+
+emit_number() {
+	case "$2" in ''|*[!0-9]*) return 1 ;; esac
+	printf '%s = %s\n' "$1" "$2"
+}
+
+get_required() {
+	value="$(uci -q get "tcpoptimizer.main.$1")" || {
+		logger -t tcpoptimizer-edge "missing UCI option $1"
+		return 1
+	}
+	[ -n "$value" ] || return 1
+	printf '%s' "$value"
+}
+
+append_allowed_cidr() {
+	[ "$CIDR_COUNT" -eq 0 ] || printf ', '
+	printf '"'
+	toml_string "$1"
+	printf '"'
+	CIDR_COUNT=$((CIDR_COUNT + 1))
+}
+
+write_config() {
+	role="$1"
+	emit_string mode "$role" || return 1
+	for key in token_file health_listen; do
+		emit_string "$key" "$(get_required "$key")" || return 1
+	done
+	for key in stream_window_mib connection_window_mib tcp_buffer_mib max_streams expected_rtt_ms idle_timeout_seconds keepalive_seconds initial_mtu connect_timeout_seconds; do
+		emit_number "$key" "$(get_required "$key")" || return 1
+	done
+	emit_string congestion "$(get_required congestion)" || return 1
+
+	if [ "$role" = ingress ]; then
+		emit_string tcp_listen "$(get_required tcp_listen)" || return 1
+		transparent="$(uci -q get tcpoptimizer.main.transparent || printf 1)"
+		case "$transparent" in 1|true|yes|on) printf 'transparent = true\n' ;; *) printf 'transparent = false\n' ;; esac
+		if [ "$transparent" != 1 ] && [ "$transparent" != true ] && uci -q get tcpoptimizer.main.fixed_target >/dev/null; then
+			emit_string fixed_target "$(get_required fixed_target)" || return 1
+		fi
+		for key in quic_peer server_name ca_cert; do
+			emit_string "$key" "$(get_required "$key")" || return 1
+		done
+	else
+		for key in quic_listen tls_cert tls_key; do
+			emit_string "$key" "$(get_required "$key")" || return 1
+		done
+		printf 'allowed_cidrs = ['
+		CIDR_COUNT=0
+		config_list_foreach main allowed_cidr append_allowed_cidr
+		printf ']\n'
+		allow_loopback="$(uci -q get tcpoptimizer.main.allow_loopback || printf 0)"
+		case "$allow_loopback" in 1|true|yes|on) printf 'allow_loopback = true\n' ;; *) printf 'allow_loopback = false\n' ;; esac
+	fi
+}
+
+render_config() {
+	. /lib/functions.sh
+	config_load tcpoptimizer
+	role="$(get_required role)" || return 1
+	case "$role" in
+		ingress|egress) ;;
+		*) return 1 ;;
+	esac
+
+	umask 077
+	tmp="$(mktemp /var/run/tcpoptimizer-edge.XXXXXX)" || return 1
+	write_config "$role" >"$tmp" || {
+		rm -f "$tmp"
+		return 1
+	}
+	chmod 0600 "$tmp" || {
+		rm -f "$tmp"
+		return 1
+	}
+	mv "$tmp" "$CONFIG" || {
+		rm -f "$tmp"
+		return 1
+	}
+}
+
+start_service() {
+	enabled="$(uci -q get tcpoptimizer.main.enabled || printf 0)"
+	case "$enabled" in 1|true|yes|on) ;; *) return 0 ;; esac
+
+	render_config || {
+		logger -t tcpoptimizer-edge "could not render /etc/config/tcpoptimizer"
+		return 1
+	}
+	"$PROG" --config "$CONFIG" check || return 1
+
+	procd_open_instance
+	procd_set_param command "$PROG" --config "$CONFIG" run
+	procd_set_param respawn 3600 5 5
+	procd_set_param file /etc/config/tcpoptimizer /etc/tcpoptimizer/token.hex
+	procd_set_param stdout 1
+	procd_set_param stderr 1
+	procd_set_param limits nofile="4096 4096"
+	procd_close_instance
+}
+
+reload_service() {
+	stop
+	start
+}
+
+service_triggers() {
+	procd_add_reload_trigger tcpoptimizer
+}

--- a/net/tcpoptimizer-edge/files/tcpoptimizer-intercept
+++ b/net/tcpoptimizer-edge/files/tcpoptimizer-intercept
@@ -1,0 +1,142 @@
+#!/bin/sh
+
+# Packaged form of scripts/openwrt-intercept.sh.
+
+set -u
+
+ACTION="${1:-}"
+[ "$#" -eq 0 ] || shift
+NFT_ROOT="${TCPO_NFT_ROOT:-/usr/share/nftables.d}"
+BACKUP_ROOT="${TCPO_INTERCEPT_BACKUPS:-/etc/tcpoptimizer/firewall-backups}"
+FW_INIT="${TCPO_FIREWALL_INIT:-/etc/init.d/firewall}"
+DNAT_FILE="$NFT_ROOT/chain-pre/dstnat/50-tcpoptimizer-edge.nft"
+INPUT_FILE="$NFT_ROOT/chain-pre/input/50-tcpoptimizer-edge.nft"
+FW3_SCRIPT="${TCPO_FW3_SCRIPT:-/etc/tcpoptimizer/firewall3-intercept.sh}"
+STATE_FILE="${TCPO_INTERCEPT_STATE:-/etc/tcpoptimizer/intercept.state}"
+FW3_SECTION="tcpoptimizer_edge"
+
+usage() {
+	cat <<'EOF'
+Usage:
+  tcpoptimizer-intercept install --lan-device DEV --destination-cidr CIDR [--destination-cidr CIDR ...] [--listen-port 18080]
+  tcpoptimizer-intercept remove
+  tcpoptimizer-intercept status
+
+Only TCP from the specified LAN device to the explicit destination CIDRs is
+redirected to the split-proxy listener. UDP, including HTTP/3 and RDP UDP,
+continues over the normal WireGuard route. Both firewall4/nftables and
+firewall3/iptables OpenWrt are supported.
+EOF
+}
+
+die() { printf 'error: %s\n' "$*" >&2; exit 1; }
+is_uint() { case "$1" in ''|*[!0-9]*) return 1 ;; *) return 0 ;; esac; }
+valid_name() { case "$1" in ''|*[!A-Za-z0-9_.-]*) return 1 ;; *) return 0 ;; esac; }
+valid_cidr() {
+	case "$1" in */*) ;; *) return 1 ;; esac
+	case "$1" in ''|*[!A-Fa-f0-9:./]*) return 1 ;; *) return 0 ;; esac
+}
+
+reload_firewall() {
+	[ -x "$FW_INIT" ] || return 1
+	if command -v fw4 >/dev/null 2>&1; then fw4 check >/dev/null 2>&1 || return 1; fi
+	"$FW_INIT" reload
+}
+
+write_state() {
+	mode="$1"
+	umask 077
+	{
+		printf 'mode=%s\n' "$mode"
+		printf 'lan_device=%s\n' "$LAN_DEVICE"
+		printf 'listen_port=%s\n' "$LISTEN_PORT"
+		for cidr in $DESTINATION_CIDRS; do printf 'destination_cidr=%s\n' "$cidr"; done
+	} >"$STATE_FILE"
+}
+
+install_fw4() {
+	mkdir -p "${DNAT_FILE%/*}" "${INPUT_FILE%/*}"
+	: >"$DNAT_FILE"
+	for cidr in $DESTINATION_CIDRS; do
+		case "$cidr" in *:*) family=ip6 ;; *) family=ip ;; esac
+		printf 'iifname "%s" %s daddr %s meta l4proto tcp redirect to :%s comment "tcpoptimizer-edge scoped TCP"\n' "$LAN_DEVICE" "$family" "$cidr" "$LISTEN_PORT" >>"$DNAT_FILE"
+	done
+	printf 'iifname "%s" meta l4proto tcp th dport %s accept comment "tcpoptimizer-edge local listener"\n' "$LAN_DEVICE" "$LISTEN_PORT" >"$INPUT_FILE"
+	chmod 0644 "$DNAT_FILE" "$INPUT_FILE"
+	write_state fw4
+}
+
+install_fw3() {
+	mkdir -p "${FW3_SCRIPT%/*}"
+	{
+		printf '%s\n' '#!/bin/sh' 'iptables -t nat -N TCPOPTIMIZER 2>/dev/null || iptables -t nat -F TCPOPTIMIZER' 'while iptables -t nat -D PREROUTING -j TCPOPTIMIZER 2>/dev/null; do :; done' 'iptables -t nat -I PREROUTING 1 -j TCPOPTIMIZER'
+		v6_init=0
+		for cidr in $DESTINATION_CIDRS; do
+			case "$cidr" in
+				*:*)
+					if [ "$v6_init" -eq 0 ]; then
+						printf '%s\n' 'ip6tables -t nat -S >/dev/null 2>&1 || exit 1' 'ip6tables -t nat -N TCPOPTIMIZER 2>/dev/null || ip6tables -t nat -F TCPOPTIMIZER' 'while ip6tables -t nat -D PREROUTING -j TCPOPTIMIZER 2>/dev/null; do :; done' 'ip6tables -t nat -I PREROUTING 1 -j TCPOPTIMIZER'
+						v6_init=1
+					fi
+					printf 'ip6tables -t nat -A TCPOPTIMIZER -i %s -d %s -p tcp -j REDIRECT --to-ports %s\n' "$LAN_DEVICE" "$cidr" "$LISTEN_PORT"
+					;;
+				*) printf 'iptables -t nat -A TCPOPTIMIZER -i %s -d %s -p tcp -j REDIRECT --to-ports %s\n' "$LAN_DEVICE" "$cidr" "$LISTEN_PORT" ;;
+			esac
+		done
+		printf '%s\n' 'iptables -N TCPOPTIMIZER_INPUT 2>/dev/null || iptables -F TCPOPTIMIZER_INPUT' 'while iptables -D INPUT -j TCPOPTIMIZER_INPUT 2>/dev/null; do :; done' 'iptables -I INPUT 1 -j TCPOPTIMIZER_INPUT'
+		printf 'iptables -A TCPOPTIMIZER_INPUT -i %s -p tcp --dport %s -j ACCEPT\n' "$LAN_DEVICE" "$LISTEN_PORT"
+	} >"$FW3_SCRIPT"
+	chmod 0700 "$FW3_SCRIPT"
+	uci -q delete "firewall.$FW3_SECTION"
+	uci set "firewall.$FW3_SECTION=include"
+	uci set "firewall.$FW3_SECTION.path=$FW3_SCRIPT"
+	uci set "firewall.$FW3_SECTION.reload=1"
+	uci commit firewall
+	write_state fw3
+}
+
+remove_files() {
+	rm -f "$DNAT_FILE" "$INPUT_FILE" "$FW3_SCRIPT" "$STATE_FILE"
+	if command -v uci >/dev/null 2>&1; then uci -q delete "firewall.$FW3_SECTION" && uci commit firewall || true; fi
+}
+
+case "$ACTION" in
+	install)
+		LAN_DEVICE=""; LISTEN_PORT=18080; DESTINATION_CIDRS=""
+		while [ "$#" -gt 0 ]; do
+			case "$1" in
+				--lan-device) [ "$#" -ge 2 ] || die "--lan-device needs a value"; LAN_DEVICE="$2"; shift ;;
+				--destination-cidr) [ "$#" -ge 2 ] || die "--destination-cidr needs a value"; valid_cidr "$2" || die "invalid destination CIDR"; DESTINATION_CIDRS="$DESTINATION_CIDRS $2"; shift ;;
+				--listen-port) [ "$#" -ge 2 ] || die "--listen-port needs a value"; LISTEN_PORT="$2"; shift ;;
+				*) die "unknown option: $1" ;;
+			esac
+			shift
+		done
+		valid_name "$LAN_DEVICE" || die "invalid LAN device"
+		[ -n "$DESTINATION_CIDRS" ] || die "at least one --destination-cidr is required"
+		is_uint "$LISTEN_PORT" && [ "$LISTEN_PORT" -ge 1024 ] && [ "$LISTEN_PORT" -le 65535 ] || die "invalid listener port"
+		[ "$(id -u)" -eq 0 ] || die "install must run as root"
+		if ! command -v fw4 >/dev/null 2>&1; then
+			for cidr in $DESTINATION_CIDRS; do
+				case "$cidr" in *:*) ip6tables -t nat -S >/dev/null 2>&1 || die "IPv6 destination CIDRs require ip6tables NAT support (ip6tables-mod-nat)" ;; esac
+			done
+		fi
+		[ ! -e "$STATE_FILE" ] && [ ! -e "$DNAT_FILE" ] && [ ! -e "$INPUT_FILE" ] && [ ! -e "$FW3_SCRIPT" ] || die "interception already installed; remove it first"
+		command -v fw4 >/dev/null 2>&1 || ! uci -q get "firewall.$FW3_SECTION" >/dev/null || die "firewall UCI section $FW3_SECTION already exists"
+		timestamp="$(date -u +%Y%m%dT%H%M%SZ)"; backup="$BACKUP_ROOT/$timestamp"; umask 077
+		mkdir -p "$backup" "${STATE_FILE%/*}"; : >"$backup/previously-absent"
+		if command -v fw4 >/dev/null 2>&1; then install_fw4; else install_fw3; fi
+		if ! reload_firewall; then remove_files; "$FW_INIT" reload >/dev/null 2>&1 || true; die "interception was not installed"; fi
+		printf 'installed destination-scoped transparent TCP interception\nbackup marker: %s\n' "$backup"
+		;;
+	remove)
+		[ "$#" -eq 0 ] || die "remove takes no options"; [ "$(id -u)" -eq 0 ] || die "remove must run as root"
+		remove_files; reload_firewall || die "files were removed, but firewall validation or reload failed"; printf 'removed transparent TCP interception\n'
+		;;
+	status)
+		[ "$#" -eq 0 ] || die "status takes no options"
+		if [ -f "$STATE_FILE" ]; then printf 'installed\n'; sed 's/^/  /' "$STATE_FILE"; else printf 'not installed\n'; exit 1; fi
+		;;
+	help|-h|--help|'') usage ;;
+	*) usage >&2; die "unknown action: $ACTION" ;;
+esac

--- a/net/tcpoptimizer-edge/files/tcpoptimizer.config
+++ b/net/tcpoptimizer-edge/files/tcpoptimizer.config
@@ -1,0 +1,30 @@
+config edge 'main'
+	# Enable only after configuring the selected role below.
+	option enabled '0'
+	option role 'egress'
+	option token_file '/etc/tcpoptimizer/token.hex'
+	option health_listen '127.0.0.1:9900'
+	option stream_window_mib '8'
+	option connection_window_mib '32'
+	option tcp_buffer_mib '4'
+	option max_streams '128'
+	option expected_rtt_ms '180'
+	option idle_timeout_seconds '60'
+	option keepalive_seconds '10'
+	option initial_mtu '1200'
+	option congestion 'bbr'
+	option connect_timeout_seconds '10'
+
+	# Ingress only. Configure these after changing role to 'ingress'.
+	# option tcp_listen '0.0.0.0:18080'
+	# option transparent '1'
+	# option quic_peer '192.0.2.1:7443'
+	# option server_name 'tcpoptimizer-edge'
+	# option ca_cert '/etc/tcpoptimizer/server-cert.pem'
+
+	# Egress only. Set a specific WireGuard address and authorize destinations.
+	option allow_loopback '0'
+	# option quic_listen '192.0.2.1:7443'
+	# option tls_cert '/etc/tcpoptimizer/server-cert.pem'
+	# option tls_key '/etc/tcpoptimizer/server-key.pem'
+	# list allowed_cidr '198.51.100.0/24'


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @honvl

**Description:**
Add `tcpoptimizer-edge` 0.3.0, an authenticated split-TCP edge daemon that
multiplexes proxied TCP connections over a persistent QUIC transport between
WireGuard-connected networks. The package builds the tagged Rust release with
the OpenWrt Rust toolchain and installs its procd service, UCI configuration,
and destination-scoped interception helper.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** current main (`29912055552480e5aedc9b81facc82709f1cf7d7`)
- **OpenWrt Target/Subtarget:** mediatek/filogic (`aarch64_cortex-a53`)
- **OpenWrt Device:** OpenWrt One

Additional checks:

- `make package/feeds/packages/tcpoptimizer-edge/check V=s`
- `make package/feeds/packages/tcpoptimizer-edge/download V=s`
- tagged `v0.3.0` release archive verified against `PKG_HASH`
- `cargo fmt --all -- --check`
- `cargo test --locked --offline` (3 tests)
- `sh tests/run.sh` (32 tests)
- `sh tests/e2e.sh` (accelerated echo and invalid-token rejection)
- isolated regression checks for required UCI strings, temporary-file cleanup,
  multiple IPv6 CIDRs, and missing `ip6tables`

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

This PR does not contain downstream patches.
