### PR TITLE
prosody: add test-version.sh

### DIFF
--- a/net/prosody/test-version.sh
+++ b/net/prosody/test-version.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#
+# Version check override for the prosody package.
+#
+# Neither prosody nor prosodyctl reports its version on any of the flags the
+# generic tests probe; the version is only recorded in prosody.version.
+
+case "$1" in
+prosody)
+	grep -F "$2" /usr/lib/prosody/prosody.version
+	;;
+
+*)
+	echo "test-version.sh: unknown subpackage '$1' — refusing to silently pass" >&2
+	echo "test-version.sh: update net/prosody/test-version.sh to cover it" >&2
+	exit 1
+	;;
+esac

--- a/net/prosody/test.sh
+++ b/net/prosody/test.sh
@@ -16,10 +16,6 @@ TEST_PASS="s3cr3t-ci-passphrase"
 
 case "$1" in
 prosody)
-	# Verify the installed version file matches the apk version arg the
-	# runner passes, so a stale .apk from an earlier batch fails fast.
-	grep -qF "$2" "$PROSODY_LIB/prosody.version"
-
 	# loader.lua installs the "prosody.*" -> "*" module searcher that every
 	# require() in 13.x goes through. It is the first thing prosodyctl looks
 	# for, and the package is dead on arrival if it was not installed.


### PR DESCRIPTION
Neither prosody nor prosodyctl reports its version on any flag the generic tests probe, so the version check fails without an override. Drop the now duplicate check from the functional test.sh.