### PR TITLE
prosody: do not drive the service through prosodyctl

### DIFF
--- a/net/prosody/Makefile
+++ b/net/prosody/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=prosody
 PKG_VERSION:=13.0.6
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://prosody.im/downloads/source

--- a/net/prosody/files/prosody.init
+++ b/net/prosody/files/prosody.init
@@ -5,7 +5,7 @@ START=99
 
 USE_PROCD=1
 
-BIN=/usr/bin/prosodyctl
+BIN=/usr/bin/prosody
 
 start_service() {
 	[ -d /var/run/prosody ] || {
@@ -25,17 +25,13 @@ start_service() {
 	}
 
 	procd_open_instance
-	procd_set_param command "$BIN" start
+	procd_set_param command "$BIN" -F
 	procd_set_param file /etc/prosody/prosody.cfg.lua
 	procd_set_param user prosody
 	procd_set_param group prosody
 	procd_close_instance
 }
 
-stop_service() {
-	${BIN} stop
-}
-
 reload_service() {
-	${BIN} reload
+	procd_send_signal prosody
 }


### PR DESCRIPTION
`prosodyctl` refuses to run `start`, `stop`, `restart` and `reload` once it
detects an init system, and the refusal is fatal rather than advisory:

```lua
local function has_init_system() --> which
	if lfs.attributes("/etc/systemd") then
		return "systemd";
	elseif lfs.attributes("/etc/init.d/prosody") then
		return "rc.d";
	end
end

local function service_command_warning(service_command)
	if prosody.installed and configmanager.get("*", "prosodyctl_service_warnings") ~= false then
		show_warning("ERROR: Use of 'prosodyctl %s' is disabled in this installation because", service_command);
		...
		os.exit(1);
	end
end
```

The package always installs `/etc/init.d/prosody`, so the detection always
matches, and `service_command_warning()` is called from all four commands.
Our init script drove every one of them through `prosodyctl`, so neither
starting nor stopping the service worked:

```sh
BIN=/usr/bin/prosodyctl
procd_set_param command "$BIN" start
stop_service()   { ${BIN} stop; }
reload_service() { ${BIN} reload; }
```

This shows up in the CI logs on package removal, where the prerm runs
`/etc/init.d/prosody stop`:

```
* ERROR: Use of 'prosodyctl stop' is disabled in this installation because
*        we detected that this system uses rc.d for managing services.
*
*        To avoid problems, use that directly instead. For example:
*
*           /etc/init.d/prosody stop
```

It is only visible for `stop` there because the tests deliberately never
start the daemon, which would block under QEMU emulation.

This is not a regression from the 13.0.6 update; 0.12.6 carries the same
guard.

Let procd supervise the daemon directly with `-F` instead, drop
`stop_service()` so procd stops the process it supervises, and reload the
configuration with SIGHUP.

Tested on Turris 1.x (mpc85xx/p2020, powerpc_8548, OpenWrt SNAPSHOT), the
same package and session for both runs, the only variable being the
contents of `/etc/init.d/prosody`.

With the current init script, `start` reports success but nothing runs,
and nothing is logged:

```
start_exit=0
ps:     no prosody process
ubus:   "running": false, "command": [ "/usr/bin/prosodyctl", "start" ]
logread: (empty)
```

That silent failure is the more harmful half: procd registers the
instance, `prosodyctl` exits 1 immediately, and the init script still
returns 0. It only becomes visible on `stop`, which runs in the
foreground rather than under procd:

```
ERROR: Use of 'prosodyctl stop' is disabled in this installation because
       we detected that this system uses rc.d for managing services.
```

With this patch applied:

```
ps:   8946 prosody  lua5.4 /usr/bin/prosody -F
ubus: "running": true, "pid": 8946, "user": "prosody", "group": "prosody"
stop_exit=0, no process left
```

Install and removal are clean, including the prerm that produced the
error above.

Not covered: `reload` was only checked as "SIGHUP delivered, process
survived" — I did not verify that a changed config value is actually
picked up. No XMPP traffic was exercised either; without a configured
VirtualHost and certificates this is a running process, not a working
server.

@commodo you did the recent work on this package, so tagging you rather
than the address in `PKG_MAINTAINER`. Happy to rework it if a different
approach fits the package better.
