### PR TITLE
zabbix80: add beta test version of next LTS (8.0.x)

### DIFF
--- a/admin/zabbix80/Config.in
+++ b/admin/zabbix80/Config.in
@@ -1,0 +1,28 @@
+menu "Modify features for non-core variants"
+	config ZABBIX80_CURL
+		bool "cURL support (default SSL)"
+		default y
+		depends on !ZABBIX80_NOSSL
+
+	config ZABBIX80_LDAP
+		bool "LDAP support"
+		depends on ZABBIX80_OPENSSL
+		default y
+
+	config ZABBIX80_NETSNMP
+		bool "NetSNMP support (OpenSSL)"
+		depends on ZABBIX80_OPENSSL
+		default y
+endmenu
+
+choice
+	prompt "Select SSL Library"
+
+	default ZABBIX80_OPENSSL
+
+	config ZABBIX80_NOSSL
+		bool "NoSSL"
+
+	config ZABBIX80_OPENSSL
+		bool "OpenSSL"
+endchoice

--- a/admin/zabbix80/Makefile
+++ b/admin/zabbix80/Makefile
@@ -1,0 +1,506 @@
+#
+# Copyright (C) 2006-2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=zabbix80
+# to fit APK package version syntax
+PKG_VERSION:=8.0.0_beta2
+PKG_SRC_NAME:=zabbix
+PKG_SRC_VERSION:=8.0.0beta2
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_SRC_NAME)-$(PKG_SRC_VERSION).tar.gz
+PKG_SOURCE_URL:=https://cdn.zabbix.com/zabbix/sources/development/$(basename $(PKG_SRC_VERSION))/
+PKG_HASH:=034fd030adeb08596f15702a94fa733a1d9a9822997e5dec2fe56594f9ca9a64
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_SRC_NAME)-$(PKG_SRC_VERSION)/
+
+PKG_MAINTAINER:=Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>
+PKG_LICENSE:=AGPL-3.0-only
+PKG_LICENSE_FILES:=COPYING
+PKG_CPE_ID:=cpe:/a:zabbix:zabbix
+
+PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
+
+PKG_CONFIG_DEPENDS:= \
+  CONFIG_ZABBIX80_CURL \
+  CONFIG_ZABBIX80_LDAP \
+  CONFIG_ZABBIX80_MYSQL \
+  CONFIG_ZABBIX80_NETSNMP \
+  CONFIG_ZABBIX80_OPENSSL \
+  CONFIG_ZABBIX80_POSTGRESQL \
+  CONFIG_ZABBIX80_SQLITE
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/nls.mk
+
+define Package/zabbix80-agentd/config
+	source "$(SOURCE)/Config.in"
+endef
+
+define Package/zabbix80-proxy/config
+	choice
+		prompt "Select Database Software for Zabbix"
+		default ZABBIX80_POSTGRESQL
+
+		config ZABBIX80_MYSQL
+			bool "MySQL/MariaDB"
+
+		config ZABBIX80_POSTGRESQL
+			bool "PostgreSQL"
+
+		config ZABBIX80_SQLITE
+			bool "SQLite3"
+	endchoice
+endef
+
+define Package/zabbix80-get/config
+	config ZABBIX80_BUILD_SUPPORT_BIN
+		bool
+		depends on PACKAGE_zabbix80-agentd
+		default y
+		help
+			This option exists to prevent trying to build get and/or sender when the
+			of agent is not being built. In that case get and sender are not built by
+			the Zabbix build system. This is not a dependency DEPENDS because the
+			binaries do not require the agent to function.
+endef
+
+define Package/zabbix80/Default
+  SECTION:=admin
+  CATEGORY:=Administration
+  SUBMENU:=Zabbix80
+  TITLE:=Zabbix80 (BETA)
+  URL:=https://www.zabbix.com/
+endef
+
+define Package/zabbix80/description/Default
+  Zabbix is a software that monitors numerous parameters of a network and the
+  health and integrity of servers, virtual machines, applications, services,
+  databases, websites, the cloud and more. Zabbix offers excellent reporting and
+  data visualization features based on the stored data.
+  .
+  Only one variant may be installed per binary (e.g. agent and agentd-basic cannot
+  both be installed on the same system).
+  .
+  This is a pre-release beta of the next LTS series of Zabbix (8.0.x). It cannot
+  be installed alongside the current LTS (7.0.x).
+endef
+
+define Package/zabbix80-basic/description/Default
+  $(call Package/zabbix80/description/Default)
+  .
+  Provides only basic functionality with SSL/TLS.
+endef
+
+define Package/zabbix80-basic-sqlite/description/Default
+  $(call Package/zabbix80/description/Default)
+  .
+  Provides only the basic functionality with SSL/TLS.
+  Uses SQLite3 for the database.
+endef
+
+define Package/zabbix80-full/description/Default
+  $(call Package/zabbix80/description/Default)
+  .
+  Provides the full functionality available in OpenWrt with OpenSSL.
+  Includes NetSNMP, cURL, and OpenLDAP support.
+  Requires a database server.
+endef
+
+define Package/zabbix80-agentd/Default
+  $(call Package/zabbix80/Default)
+  TITLE+= agentd
+  DEPENDS+= \
+    $(ICONV_DEPENDS) \
+    +libevent2-pthreads \
+    +libpcre2 \
+    +zlib
+  CONFLICTS:= \
+    zabbix-agentd \
+    zabbix-agentd-basic \
+    zabbix-agentd-ssl \
+    zabbix-agentd-openssl
+  USERID:=zabbix-agent=53:zabbix-agent=53
+endef
+
+define Package/zabbix80-agentd
+  $(call Package/zabbix80-agentd/Default)
+  TITLE+= (full/with TLS)
+  DEPENDS+= \
+    +ZABBIX80_CURL:libcurl \
+    +ZABBIX80_LDAP:libopenldap \
+    +ZABBIX80_NETSNMP:libnetsnmp-ssl \
+    +ZABBIX80_OPENSSL:libopenssl
+  VARIANT:=full
+  DEFAULT_VARIANT:=1
+endef
+
+define Package/zabbix80-agentd/description
+  $(call Package/zabbix80-full/description/Default)
+  .
+  Provides 'Zabbix Agent'.
+  .
+  Note that 'Zabbix Agent' does not directly use the database, but sends data to
+  a 'Zabbix Server' or a 'Zabbix Proxy', which writes to a database.
+endef
+
+define Package/zabbix80-agentd-basic
+  $(call Package/zabbix80-agentd/Default)
+  TITLE+= (basic/with TLS)
+  DEPENDS += +libopenssl
+  VARIANT:=basic
+endef
+
+define Package/zabbix80-agentd-basic/description
+  $(call Package/zabbix80-basic/description/Default)
+  .
+  Provides 'Zabbix Agent'.
+endef
+
+define Package/zabbix80-get
+  $(call Package/zabbix80/Default)
+  TITLE+= get (with TLS)
+  DEPENDS+= \
+    @(ZABBIX80_BUILD_SUPPORT_BIN) \
+    $(ICONV_DEPENDS) \
+    +ZABBIX80_OPENSSL:libopenssl \
+    +libpcre2 \
+    +zlib
+  CONFLICTS:= \
+    zabbix-get \
+    zabbix-get-ssl \
+    zabbix-get-openssl
+  VARIANT:=full
+endef
+
+define Package/zabbix80-get/description
+  $(call Package/zabbix80-basic/description/Default)
+  .
+  Provides 'Zabbix Get'.
+endef
+
+
+define Package/zabbix80-server-or-proxy/Default
+  $(call Package/zabbix80/Default)
+  DEPENDS+= \
+    $(ICONV_DEPENDS) \
+    +fping \
+    +libevent2 \
+    +libevent2-pthreads \
+    +libevent2-extra \
+    +libpcre2 \
+    +zlib
+endef
+
+define Package/zabbix80-proxy/Default
+  $(call Package/zabbix80-server-or-proxy/Default)
+  TITLE+= proxy
+  CONFLICTS:= \
+    zabbix-proxy \
+    zabbix-proxy-basic-sqlite \
+    zabbix-proxy-ssl \
+    zabbix-proxy-openssl
+  USERID:=zabbix-proxy=71:zabbix-proxy=71
+endef
+
+define Package/zabbix80-proxy
+  $(call Package/zabbix80-proxy/Default)
+  TITLE+= (full/with OpenSSL)
+  DEPENDS+= \
+    +ZABBIX80_CURL:libcurl \
+    +ZABBIX80_LDAP:libopenldap \
+    +ZABBIX80_MYSQL:libmariadbclient \
+    +ZABBIX80_NETSNMP:libnetsnmp-ssl \
+    +ZABBIX80_OPENSSL:libopenssl \
+    +ZABBIX80_POSTGRESQL:libpq \
+    +ZABBIX80_SQLITE:libsqlite3
+  VARIANT:=full
+  DEFAULT_VARIANT:=1
+endef
+
+define Package/zabbix80-proxy/description
+  $(call Package/zabbix80-full/description/Default)
+  .
+  Provides 'Zabbix Proxy'.
+endef
+
+define Package/zabbix80-proxy-basic-sqlite
+  $(call Package/zabbix80-proxy/Default)
+  TITLE+= sqlite3 (basic/with TLS)
+  DEPENDS+= \
+    +libopenssl \
+    +libsqlite3
+  VARIANT:=basic
+endef
+
+define Package/zabbix80-proxy-basic-sqlite/description
+  $(call Package/zabbix80-basic/description/Default)
+  .
+  Provides 'Zabbix Proxy' using sqlite3 for
+  the database.
+endef
+
+define Package/zabbix80-sender
+  $(call Package/zabbix80/Default)
+  TITLE+= sender (with TLS)
+  DEPENDS+= \
+    @(ZABBIX80_BUILD_SUPPORT_BIN) \
+    $(ICONV_DEPENDS) \
+    +ZABBIX80_OPENSSL:libopenssl \
+    +libpcre2 \
+    +zlib
+  CONFLICTS:= \
+    zabbix-sender \
+    zabbix-sender-ssl \
+    zabbix-sender-openssl
+  VARIANT:=full
+endef
+
+define Package/zabbix80-sender/description
+  $(call Package/zabbix80-basic/description/Default)
+  .
+  Provides 'Zabbix Sender'.
+endef
+
+define Package/zabbix80-server
+  $(call Package/zabbix80-server-or-proxy/Default)
+  TITLE+= server (full/with OpenSSL)
+  DEPENDS+= \
+    @(!ZABBIX80_SQLITE) \
+    +ZABBIX80_CURL:libcurl \
+    +ZABBIX80_LDAP:libopenldap \
+    +ZABBIX80_MYSQL:libmariadbclient \
+    +ZABBIX80_OPENSSL:libopenssl \
+    +ZABBIX80_NETSNMP:libnetsnmp-ssl \
+    +ZABBIX80_POSTGRESQL:libpq
+  CONFLICTS:= \
+    zabbix-server \
+    zabbix-server-ssl \
+    zabbix-server-openssl
+  USERID:=zabbix-server=70:zabbix-server=70
+  VARIANT:=full
+endef
+
+define Package/zabbix80-server/description
+  $(call Package/zabbix80-full/description/Default)
+  .
+  Provides 'Zabbix Server'.
+endef
+
+define Package/zabbix80-frontend-server
+  $(call Package/zabbix80/Default)
+  TITLE+= frontend server
+  PKGARCH:=all
+  DEPENDS+= \
+    php8 \
+    @(!ZABBIX80_SQLITE) \
+    +ZABBIX80_MYSQL:php8-mod-mysqli \
+    +ZABBIX80_POSTGRESQL:php8-mod-pgsql \
+    +php8-cgi \
+    +php8-mod-gd \
+    +php8-mod-bcmath \
+    +php8-mod-ctype \
+    +php8-mod-curl \
+    +php8-mod-filter \
+    +php8-mod-gettext \
+    +php8-mod-ldap \
+    +php8-mod-mbstring \
+    +php8-mod-openssl \
+    +php8-mod-session \
+    +php8-mod-simplexml \
+    +php8-mod-sockets \
+    +php8-mod-xmlreader \
+    +php8-mod-xmlwriter
+  CONFLICTS:= \
+    zabbix-server-frontend \
+    zabbix-frontend-server
+  VARIANT:=no-configure
+endef
+
+define Package/zabbix80-frontend-server/description
+  $(call Package/zabbix80/description/Default)
+  .
+  Provides the Web UI (frontend server) for Zabbix.
+endef
+
+ifneq ($(BUILD_VARIANT),no-configure)
+CONFIGURE_ARGS+= \
+  $(call autoconf_bool,CONFIG_IPV6,ipv6) \
+  --disable-java \
+  --with-libevent=$(STAGING_DIR)/usr/include \
+  --with-libpcre2=$(STAGING_DIR)/usr/include \
+  --with-zlib=$(STAGING_DIR)/usr/include
+endif
+
+ifeq ($(BUILD_VARIANT),basic)
+CONFIGURE_ARGS+= \
+  $(if $(CONFIG_PACKAGE_zabbix80-agentd-basic),--enable-agent,--disable-agent) \
+  $(if $(CONFIG_PACKAGE_zabbix80-proxy-basic-sqlite),--enable-proxy --with-sqlite3,--disable-proxy) \
+  --with-openssl="$(STAGING_DIR)/usr" \
+  --disable-server
+endif
+
+ifeq ($(BUILD_VARIANT),full)
+
+CONFIGURE_ARGS+= \
+  $(if $(CONFIG_PACKAGE_zabbix80-agentd),--enable-agent,--disable-agent) \
+  $(if $(CONFIG_PACKAGE_zabbix80-proxy),--enable-proxy,--disable-proxy) \
+  $(if $(CONFIG_PACKAGE_zabbix80-server),--enable-server,--disable-server) \
+  $(if $(CONFIG_ZABBIX80_LDAP),--with-ldap="$(STAGING_DIR)/usr",--with-ldap="no") \
+  $(if $(CONFIG_ZABBIX80_MYSQL),--with-mysql,--with-mysql="no") \
+  $(if $(CONFIG_ZABBIX80_NETSNMP),--with-net-snmp="$(STAGING_DIR)/usr",--with-net-snmp="no") \
+  $(if $(CONFIG_ZABBIX80_OPENSSL),--with-openssl="$(STAGING_DIR)/usr",--with-openssl="no") \
+  $(if $(CONFIG_ZABBIX80_POSTGRESQL),--with-postgresql,--with-postgresql="no") \
+  $(if $(CONFIG_ZABBIX80_SQLITE),--with-sqlite3,--with-sqlite3="no") \
+  $(if $(CONFIG_ZABBIX80_CURL),--with-libcurl,--with-libcurl="no") \
+  --enable-year2038
+endif
+
+ifeq ($(BUILD_VARIANT),no-configure)
+
+define Build/Configure
+	true
+endef
+define Build/Compile
+	true
+endef
+define Build/Install
+	true
+endef
+
+endif
+
+MAKE_FLAGS += ARCH="linux"
+
+define Package/zabbix80/install/sbin
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/zabbix_$(2) $(1)/usr/sbin/
+endef
+
+define Package/zabbix80/install/bin
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/zabbix_$(2) $(1)/usr/bin/
+endef
+
+define Package/zabbix80/install/etc
+	$(INSTALL_DIR) $(1)/etc
+	$(INSTALL_CONF) $(PKG_INSTALL_DIR)/etc/zabbix_$(2).conf $(1)/etc/
+endef
+
+define Package/zabbix80/install/init.d
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/zabbix_$(2).init $(1)/etc/init.d/zabbix_$(2)
+endef
+
+define Package/zabbix80-agentd/conffiles
+/etc/zabbix_agentd.conf
+/etc/zabbix_agentd.conf.d/
+/etc/config/zabbix_agentd
+endef
+
+define Package/zabbix80-agentd/postinst
+#!/bin/sh
+[ -n "$${IPKG_INSTROOT}" ] || (. /etc/uci-defaults/90_zabbix_agentd) && rm -f /etc/uci-defaults/90_zabbix_agentd
+exit 0
+endef
+
+define Package/zabbix80-agentd/install
+	$(INSTALL_DIR) $(1)/etc/zabbix_agentd.conf.d
+	$(call Package/zabbix80/install/sbin,$(1),agentd)
+	$(call Package/zabbix80/install/etc,$(1),agentd)
+	$(call Package/zabbix80/install/init.d,$(1),agentd)
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_CONF) ./files/zabbix_agentd.config $(1)/etc/config/zabbix_agentd
+	$(INSTALL_DIR) $(1)/etc/uci-defaults
+	$(INSTALL_BIN) ./files/zabbix_agentd.defaults $(1)/etc/uci-defaults/90_zabbix_agentd
+endef
+
+Package/zabbix80-agentd-basic/conffiles=$(call Package/zabbix80-agentd/conffiles)
+Package/zabbix80-agentd-basic/postinst=$(call Package/zabbix80-agentd/postinst)
+
+define Package/zabbix80-agentd-basic/install
+	$(call Package/zabbix80-agentd/install,$(1))
+endef
+
+define Package/zabbix80-proxy/conffiles
+/etc/zabbix_proxy.conf
+/etc/zabbix_proxy.conf.d/
+/etc/config/zabbix_proxy
+endef
+
+define Package/zabbix80-proxy/postinst
+#!/bin/sh
+[ -n "$${IPKG_INSTROOT}" ] || (. /etc/uci-defaults/90_zabbix_proxy) && rm -f /etc/uci-defaults/90_zabbix_proxy
+exit 0
+endef
+
+define Package/zabbix80-proxy/install
+	$(INSTALL_DIR) $(1)/etc/zabbix_proxy.conf.d
+	$(call Package/zabbix80/install/sbin,$(1),proxy)
+	$(call Package/zabbix80/install/etc,$(1),proxy)
+	$(call Package/zabbix80/install/init.d,$(1),proxy)
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_CONF) ./files/zabbix_proxy.config $(1)/etc/config/zabbix_proxy
+	$(INSTALL_DIR) $(1)/etc/uci-defaults
+	$(INSTALL_BIN) ./files/zabbix_proxy.defaults $(1)/etc/uci-defaults/90_zabbix_proxy
+endef
+
+Package/zabbix80-proxy-basic-sqlite/conffiles=$(call Package/zabbix80-proxy/conffiles)
+Package/zabbix80-proxy-basic-sqlite/postinst=$(call Package/zabbix80-proxy/postinst)
+
+define Package/zabbix80-proxy-basic-sqlite/install
+	$(call Package/zabbix80-proxy/install,$(1))
+endef
+
+define Package/zabbix80-server/conffiles
+/etc/zabbix_server.conf
+/etc/zabbix_server.conf.d/
+/etc/config/zabbix_server
+endef
+
+define Package/zabbix80-server/install
+	$(INSTALL_DIR) $(1)/etc/zabbix_server.conf.d
+	$(call Package/zabbix80/install/sbin,$(1),server)
+	$(call Package/zabbix80/install/etc,$(1),server)
+	$(call Package/zabbix80/install/init.d,$(1),server)
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_CONF) ./files/zabbix_server.config $(1)/etc/config/zabbix_server
+	$(INSTALL_DIR) $(1)/etc/uci-defaults
+	$(INSTALL_BIN) ./files/zabbix_server.defaults $(1)/etc/uci-defaults/90_zabbix_server
+endef
+
+define Package/zabbix80-server/postinst
+#!/bin/sh
+[ -n "$${IPKG_INSTROOT}" ] || (. /etc/uci-defaults/90_zabbix_server) && rm -f /etc/uci-defaults/90_zabbix_server
+exit 0
+endef
+
+define Package/zabbix80-get/install
+	$(call Package/zabbix80/install/bin,$(1),get)
+endef
+
+define Package/zabbix80-sender/install
+	$(call Package/zabbix80/install/bin,$(1),sender)
+endef
+
+define Package/zabbix80-frontend-server/install
+	$(INSTALL_DIR) $(1)/www/zabbix
+	$(CP) $(PKG_BUILD_DIR)/ui/* $(1)/www/zabbix
+endef
+
+# zabbix compiled variants (configured)
+$(eval $(call BuildPackage,zabbix80-agentd))
+$(eval $(call BuildPackage,zabbix80-agentd-basic))
+$(eval $(call BuildPackage,zabbix80-get))
+$(eval $(call BuildPackage,zabbix80-sender))
+$(eval $(call BuildPackage,zabbix80-server))
+$(eval $(call BuildPackage,zabbix80-proxy))
+$(eval $(call BuildPackage,zabbix80-proxy-basic-sqlite))
+# no-configure packages
+$(eval $(call BuildPackage,zabbix80-frontend-server))

--- a/admin/zabbix80/files/zabbix_agentd.config
+++ b/admin/zabbix80/files/zabbix_agentd.config
@@ -1,0 +1,4 @@
+
+config zabbix_agentd 'general'
+    option enabled 0
+    # option never_root 1

--- a/admin/zabbix80/files/zabbix_agentd.defaults
+++ b/admin/zabbix80/files/zabbix_agentd.defaults
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+chown zabbix-agent:zabbix-agent /etc/zabbix_agentd.conf

--- a/admin/zabbix80/files/zabbix_agentd.init
+++ b/admin/zabbix80/files/zabbix_agentd.init
@@ -1,0 +1,52 @@
+#!/bin/sh /etc/rc.common
+# Copyright (C) 2008-2011 OpenWrt.org
+
+# shellcheck shell=busybox
+
+# shellcheck disable=SC2034
+START=60
+
+# shellcheck disable=SC2034
+USE_PROCD=1
+NAME=zabbix_agentd
+PROG=/usr/sbin/${NAME}
+CONFIG=/etc/${NAME}.conf
+UCI_CONFIG=/etc/config/${NAME}
+USER=zabbix-agent
+
+start_service() {
+	local enabled never_root
+
+	# Sometimes the agentd config was installed in /etc/zabbix/zabbix_agentd.conf
+	[ -f /etc/zabbix/zabbix_agentd.conf ] && mv /etc/zabbix/zabbix_agentd.conf ${CONFIG}
+
+	if [ ! -f "${CONFIG}" ]; then
+		logger "Configuration file not found: '${CONFIG}'"
+		return 1
+	fi
+
+	# Get enabled config option
+	config_load "$NAME"
+	config_get_bool enabled general enabled 0
+	config_get_bool never_root general never_root 1
+
+	# shellcheck disable=SC2154
+	if [ "$enabled" -eq 0 ]; then
+		logger "service not enabled in $UCI_CONFIG"
+		return 1
+	fi
+
+	mkdir -p "/var/run/$USER"
+	chown $USER:$USER "/var/run/$USER"
+
+	procd_open_instance
+	procd_set_param command ${PROG} -c ${CONFIG} -f
+	if [ "$never_root" -eq 1 ]; then
+		procd_set_param user ${USER}
+	fi
+	procd_set_param file ${CONFIG}
+	procd_set_param respawn
+	procd_set_param stdout 1
+	procd_set_param stderr 1
+	procd_close_instance
+}

--- a/admin/zabbix80/files/zabbix_proxy.config
+++ b/admin/zabbix80/files/zabbix_proxy.config
@@ -1,0 +1,4 @@
+
+config zabbix_proxy 'general'
+    option enabled 0
+    # option never_root 1

--- a/admin/zabbix80/files/zabbix_proxy.defaults
+++ b/admin/zabbix80/files/zabbix_proxy.defaults
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+chown zabbix-proxy:zabbix-proxy /etc/zabbix_proxy.conf

--- a/admin/zabbix80/files/zabbix_proxy.init
+++ b/admin/zabbix80/files/zabbix_proxy.init
@@ -1,0 +1,50 @@
+#!/bin/sh /etc/rc.common
+# Copyright (C) 2008-2025 OpenWrt.org
+
+# shellcheck shell=busybox
+
+# shellcheck disable=SC2034
+START=59
+
+# shellcheck disable=SC2034
+USE_PROCD=1
+
+NAME=zabbix_proxy
+PROG=/usr/sbin/${NAME}
+CONFIG=/etc/${NAME}.conf
+UCI_CONFIG=/etc/config/${NAME}
+USER=zabbix-proxy
+
+start_service() {
+	local enabled never_root
+
+	if [ ! -f "${CONFIG}" ]; then
+		logger "Configuration file not found: '${CONFIG}'"
+		return 1
+	fi
+
+	# Get enabled config option
+	config_load "$NAME"
+	config_get_bool enabled general enabled 0
+	config_get_bool never_root general never_root 1
+
+	# shellcheck disable=SC2154
+	if [ "$enabled" -eq 0 ]; then
+		logger "service not enabled in $UCI_CONFIG"
+		return 1
+	fi
+
+	mkdir -p "/var/run/$USER"
+	chown $USER:$USER "/var/run/$USER"
+
+	procd_open_instance
+	procd_set_param command ${PROG} -c ${CONFIG} -f
+	if [ "$never_root" -eq 1 ]; then
+		procd_set_param user ${USER}
+	fi
+	procd_set_param file ${CONFIG}
+	procd_set_param respawn
+	procd_set_param stdout 1
+	procd_set_param stderr 1
+	procd_close_instance
+}

--- a/admin/zabbix80/files/zabbix_server.config
+++ b/admin/zabbix80/files/zabbix_server.config
@@ -1,0 +1,4 @@
+
+config zabbix_server 'general'
+    option enabled 0
+    # option never_root 1

--- a/admin/zabbix80/files/zabbix_server.defaults
+++ b/admin/zabbix80/files/zabbix_server.defaults
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+chown zabbix-server:zabbix-server /etc/zabbix_server.conf

--- a/admin/zabbix80/files/zabbix_server.init
+++ b/admin/zabbix80/files/zabbix_server.init
@@ -1,0 +1,51 @@
+#!/bin/sh /etc/rc.common
+# Copyright (C) 2008-2025 OpenWrt.org
+
+# shellcheck shell=busybox
+
+# shellcheck disable=SC2034
+START=59
+
+# shellcheck disable=SC2034
+USE_PROCD=1
+
+NAME=zabbix_server
+PROG=/usr/sbin/${NAME}
+CONFIG=/etc/${NAME}.conf
+UCI_CONFIG=/etc/config/${NAME}
+USER=zabbix-server
+
+start_service() {
+	local enabled never_root
+
+	if [ ! -f "${CONFIG}" ]; then
+		logger "Configuration file not found: '${CONFIG}'"
+		return 1
+	fi
+
+	# Get enabled config option
+	config_load "$NAME"
+	config_get_bool enabled general enabled 0
+	config_get_bool never_root general never_root 1
+
+	# shellcheck disable=SC2154
+	if [ "$enabled" -eq 0 ]; then
+		logger "service not enabled in $UCI_CONFIG"
+		return 1
+	fi
+
+	mkdir -p "/var/run/$USER"
+	chown $USER:$USER "/var/run/$USER"
+
+	procd_open_instance
+	procd_set_param command ${PROG} -c ${CONFIG} -f
+	if [ "$never_root" -eq 1 ]; then
+		procd_set_param user ${USER}
+	fi
+	procd_set_param limits nofile="16384 100000"
+	procd_set_param file ${CONFIG}
+	procd_set_param respawn
+	procd_set_param stdout 1
+	procd_set_param stderr 1
+	procd_close_instance
+}

--- a/admin/zabbix80/patches/010-zabbix_agentd-tweak-config-file-for-openwrt.patch
+++ b/admin/zabbix80/patches/010-zabbix_agentd-tweak-config-file-for-openwrt.patch
@@ -1,0 +1,97 @@
+From 502248599bfc0b36daf0f8dd83bee5bc6e1b24e4 Mon Sep 17 00:00:00 2001
+From: "Daniel F. Dickinson" <dfdpublic@wildtechgarden.ca>
+Date: Wed, 17 Dec 2025 18:28:37 -0500
+Subject: zabbix_agentd: tweak config file for OpenWrt
+
+Note: original patch had no header, header added 2025-12-16, while
+bumping package version. Modified 2025-12-25. Modified 2026-01-21.
+Tweaked further 2026-07-16.
+
+1. Use syslog not a file for logging.
+2. Place PidFile under /var/run/zabbix-agent.
+3. Only start 1 passive agent by default.
+4. Do not do active checks by default.
+5. Use the system hostname as hostname.
+6. If started as root, drop privileges to the zabbix-agent user, not
+   a shared (with server and proxy) zabbix user or root, per upstream
+   recommendation:
+   https://www.zabbix.com/documentation/8.0/en/manual/installation/install/sources#security-recommendation
+7. Include configuration files under /etc/zabbix_agentd.conf.d/.
+8. Require configurations under /etc/zabbix_agentd.conf.d/ end in .conf.
+   (other files are ignored for configuration purposes).
+
+Signed-off-by: Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>
+---
+ conf/zabbix_agentd.conf | 15 ++++++++++++---
+ 1 file changed, 12 insertions(+), 3 deletions(-)
+
+--- a/conf/zabbix_agentd.conf
++++ b/conf/zabbix_agentd.conf
+@@ -10,6 +10,9 @@
+ # Default:
+ # PidFile=/tmp/zabbix_agentd.pid
+ 
++# Zabbix always creates a PidFile. Make sure it is where we want it.
++PidFile=/var/run/zabbix-agent/zabbix_agentd.pid
++
+ ### Option: LogType
+ #	Specifies where log messages are written to:
+ #		system  - syslog
+@@ -20,6 +23,9 @@
+ # Default:
+ # LogType=file
+ 
++# Use syslog
++LogType=system
++
+ ### Option: LogFile
+ #	Log file name for LogType 'file' parameter.
+ #
+@@ -27,7 +33,7 @@
+ # Default:
+ # LogFile=
+ 
+-LogFile=/tmp/zabbix_agentd.log
++# LogFile=/tmp/zabbix_agentd.log
+ 
+ ### Option: LogFileSize
+ #	Maximum size of log file in MB.
+@@ -167,6 +173,7 @@ Server=127.0.0.1
+ # Range: 0-100
+ # Default:
+ # StartAgents=10
++StartAgents=1
+ 
+ ##### Active checks related
+ 
+@@ -197,7 +204,7 @@ Server=127.0.0.1
+ # Default:
+ # ServerActive=
+ 
+-ServerActive=127.0.0.1
++# ServerActive=127.0.0.1
+ 
+ ### Option: Hostname
+ #	List of comma delimited unique, case sensitive hostnames.
+@@ -208,7 +215,7 @@ ServerActive=127.0.0.1
+ # Default:
+ # Hostname=
+ 
+-Hostname=Zabbix server
++# Hostname=Zabbix server
+ 
+ ### Option: HostnameItem
+ #	Item used for generating Hostname if it is undefined. Ignored if Hostname is defined.
+@@ -349,6 +356,7 @@ Hostname=Zabbix server
+ # Mandatory: no
+ # Default:
+ # User=zabbix
++User=zabbix-agent
+ 
+ ####### USER-DEFINED MONITORED PARAMETERS #######
+ 
+@@ -580,3 +588,4 @@ Hostname=Zabbix server
+ # Include=/usr/local/etc/zabbix_agentd.userparams.conf
+ # Include=/usr/local/etc/zabbix_agentd.conf.d/
+ # Include=/usr/local/etc/zabbix_agentd.conf.d/*.conf
++Include=/etc/zabbix_agentd.conf.d/*.conf

--- a/admin/zabbix80/patches/020-zabbix_server-tweak-config-file-for-openwrt.patch
+++ b/admin/zabbix80/patches/020-zabbix_server-tweak-config-file-for-openwrt.patch
@@ -1,0 +1,94 @@
+From 6655a1f2e5bff8d0082f41cf2711339f0d75d788 Mon Sep 17 00:00:00 2001
+From: "Daniel F. Dickinson" <dfdpublic@wildtechgarden.ca>
+Date: Wed, 17 Dec 2025 06:39:16 -0500
+Subject: zabbix_server: tweak config file for OpenWrt
+
+Created 2025-12-17. Updated 2026-07-16.
+
+1. Log to syslog, not a file.
+2. Update PidFile path so correct permissions can be set for access by
+   Zabbix server running without privileges.
+3. If started as root, drop privileges to zabbix-server user (instead of
+   zabbix user shared with agent and proxy, or root) per upstream
+   recommendation:
+   https://www.zabbix.com/documentation/8.0/en/manual/installation/install/sources#security-recommendation
+4. Set the fping location properly for OpenWrt (/usr/bin not /usr/sbin).
+5. Configure fping as the ipv6 fping as well.
+6. For privacy, disable the public API call to check Zabbix version.
+7. Include configurations under /etc/zabbix_server.conf.d/.
+8. Require configurations under /etc/zabbix_server.conf.d/ end in .conf
+   (other files are ignored for configuration purposes).
+
+Signed-off-by: Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>
+---
+ conf/zabbix_server.conf | 13 +++++++++++--
+ 1 file changed, 11 insertions(+), 2 deletions(-)
+
+--- a/conf/zabbix_server.conf
++++ b/conf/zabbix_server.conf
+@@ -27,6 +27,7 @@
+ # Mandatory: no
+ # Default:
+ # LogType=file
++LogType=system
+ 
+ ### Option: LogFile
+ #	Log file name for LogType 'file' parameter.
+@@ -35,7 +36,7 @@
+ # Default:
+ # LogFile=
+ 
+-LogFile=/tmp/zabbix_server.log
++# LogFile=/tmp/zabbix_server.log
+ 
+ ### Option: LogFileSize
+ #	Maximum size of log file in MB.
+@@ -67,6 +68,10 @@ LogFile=/tmp/zabbix_server.log
+ # Default:
+ # PidFile=/tmp/zabbix_server.pid
+ 
++# Although procd does not require a pid file, zabbix uses the pidfile to
++# shut down correctly on receipt of a TERM or INT signal.
++PidFile=/var/run/zabbix-server/zabbix_server.pid
++
+ ### Option: SocketDir
+ #	IPC socket directory.
+ #		Directory to store IPC sockets used by internal Zabbix services.
+@@ -631,6 +636,7 @@ Timeout=4
+ # Mandatory: no
+ # Default:
+ # FpingLocation=/usr/sbin/fping
++FpingLocation=/usr/bin/fping
+ 
+ ### Option: Fping6Location
+ #	Location of fping6.
+@@ -640,6 +646,7 @@ Timeout=4
+ # Mandatory: no
+ # Default:
+ # Fping6Location=/usr/sbin/fping6
++Fping6Location=
+ 
+ ### Option: SSHKeyLocation
+ #	Location of public and private keys for SSH checks and actions.
+@@ -719,6 +726,7 @@ LogSlowQueries=3000
+ # Mandatory: no
+ # Default:
+ # User=zabbix
++User=zabbix-server
+ 
+ ### Option: SSLCertLocation
+ #	Location of SSL client certificates.
+@@ -1117,7 +1125,7 @@ EnableGlobalScripts=0
+ #
+ # Mandatory: no
+ # Default:
+-# AllowSoftwareUpdateCheck=1
++AllowSoftwareUpdateCheck=0
+ 
+ ### Option: SMSDevices
+ #	List of comma delimited modem files allowed to use Zabbix server
+@@ -1192,3 +1200,4 @@ EnableGlobalScripts=0
+ # Include=/usr/local/etc/zabbix_server.general.conf
+ # Include=/usr/local/etc/zabbix_server.conf.d/
+ # Include=/usr/local/etc/zabbix_server.conf.d/*.conf
++Include=/etc/zabbix_server.conf.d/*.conf

--- a/admin/zabbix80/patches/030-zabbix_proxy-tweak-config-file-for-openwrt.patch
+++ b/admin/zabbix80/patches/030-zabbix_proxy-tweak-config-file-for-openwrt.patch
@@ -1,0 +1,100 @@
+From c03db1c64e218fb2ef469ddb9705eff9f9d493e1 Mon Sep 17 00:00:00 2001
+From: "Daniel F. Dickinson" <dfdpublic@wildtechgarden.ca>
+Date: Thu, 16 Jul 2026 18:58:26 -0400
+Subject: zabbix_proxy: tweak config file for OpenWrt
+
+Created 2026-07-16.
+
+1. Use passive proxy mode by default (in keeping with agentd defaults).
+2. Use system hostname as system hostname not 'Zabbix proxy'.
+3. Log to syslog, not a file.
+4. Update PidFile path so correct permissions can be set for access by
+   Zabbix proxy running without privileges.
+5. Set the fping location properly for OpenWrt (/usr/bin not /usr/sbin).
+6. Configure fping as the ipv6 fping as well.
+7. If started as root, drop privileges to zabbix-proxy user (instead of
+   zabbix user shared with agent and server, or root) per upstream
+   recommendation:
+   https://www.zabbix.com/documentation/8.0/en/manual/installation/install/sources#security-recommendation
+8. Include configurations under /etc/zabbix_proxy.conf.d/.
+9. Require configurations under /etc/zabbix_proxy.conf.d/ end in .conf
+   (other files are ignored for configuration purposes).
+
+Signed-off-by: Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>
+---
+ conf/zabbix_proxy.conf | 11 +++++++++--
+ 1 file changed, 9 insertions(+), 2 deletions(-)
+
+--- a/conf/zabbix_proxy.conf
++++ b/conf/zabbix_proxy.conf
+@@ -11,6 +11,7 @@
+ # Mandatory: no
+ # Default:
+ # ProxyMode=0
++ProxyMode=1
+ 
+ ### Option: Server
+ #	If ProxyMode is set to active mode:
+@@ -39,7 +40,7 @@ Server=127.0.0.1
+ # Default:
+ # Hostname=
+ 
+-Hostname=Zabbix proxy
++# Hostname=Zabbix proxy
+ 
+ ### Option: HostnameItem
+ #	Item used for generating Hostname if it is undefined.
+@@ -73,6 +74,7 @@ Hostname=Zabbix proxy
+ # Mandatory: no
+ # Default:
+ # LogType=file
++LogType=system
+ 
+ ### Option: LogFile
+ #	Log file name for LogType 'file' parameter.
+@@ -81,7 +83,7 @@ Hostname=Zabbix proxy
+ # Default:
+ # LogFile=
+ 
+-LogFile=/tmp/zabbix_proxy.log
++# LogFile=/tmp/zabbix_proxy.log
+ 
+ ### Option: LogFileSize
+ #	Maximum size of log file in MB.
+@@ -130,6 +132,7 @@ LogFile=/tmp/zabbix_proxy.log
+ # Mandatory: no
+ # Default:
+ # PidFile=/tmp/zabbix_proxy.pid
++PidFile=/var/run/zabbix-proxy/zabbix_proxy.pid
+ 
+ ### Option: SocketDir
+ #	IPC socket directory.
+@@ -608,6 +611,7 @@ Timeout=4
+ # Mandatory: no
+ # Default:
+ # FpingLocation=/usr/sbin/fping
++FpingLocation=/usr/bin/fping
+ 
+ ### Option: Fping6Location
+ #	Location of fping6.
+@@ -617,6 +621,7 @@ Timeout=4
+ # Mandatory: no
+ # Default:
+ # Fping6Location=/usr/sbin/fping6
++Fping6Location=
+ 
+ ### Option: SSHKeyLocation
+ #	Location of public and private keys for SSH checks and actions.
+@@ -662,6 +667,7 @@ LogSlowQueries=3000
+ # Mandatory: no
+ # Default:
+ # User=zabbix
++User=zabbix-proxy
+ 
+ ### Option: SSLCertLocation
+ #	Location of SSL client certificates.
+@@ -1054,3 +1060,4 @@ StatsAllowedIP=127.0.0.1
+ # Include=/usr/local/etc/zabbix_proxy.general.conf
+ # Include=/usr/local/etc/zabbix_proxy.conf.d/
+ # Include=/usr/local/etc/zabbix_proxy.conf.d/*.conf
++Include=/etc/zabbix_proxy.conf.d/*.conf

--- a/admin/zabbix80/test-version.sh
+++ b/admin/zabbix80/test-version.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# PKG_SRC_VERSION is not exported by the CI harness; derive the upstream
+# version string (8.0.0beta2) from PKG_VERSION (8.0.0_beta2).
+PKG_SRC_VERSION="$(echo "$PKG_VERSION" | tr -d '_')"
+
+case "$PKG_NAME" in
+zabbix80-frontend-server)
+	exit 0
+	;;
+zabbix80-agentd-basic)
+	zabbix_agentd -V 2>&1 | grep -F "${PKG_SRC_VERSION}"
+	;;
+zabbix80-proxy-basic-sqlite)
+	zabbix_proxy -V 2>&1 | grep -F "${PKG_SRC_VERSION}"
+	;;
+*)
+	# We use tr as parameter string replace is undefined in POSIX
+	"$(echo "$PKG_NAME" | sed -e 's/zabbix80/zabbix/' | tr '-' '_')" -V 2>&1 | grep -F "${PKG_SRC_VERSION}"
+	;;
+esac


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @danielfdickinson 

**Description:**

Add initial work on adding the beta version of Zabbix 8.0.0.

This will be the next LTS version of Zabbix, and will the main (or only) supported version on OpenWrt once 7.0.x is end of service.

Not all features present in the 7.0.x package have been ported to new version of Zabbix, in the interests of first getting something that works.

At present the 8.0.0 beta version CANNOT be installed on the same device as the 7.0.x version.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** OpenWrt SNAPSHOT r35708-2991205555
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** OpenWrt One (with NVME SSD)

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- N/A It is structured in a way that it is potentially upstreamable
