### PR TITLE
uradvd: fix the version check override

### DIFF
--- a/net/uradvd/test-version.sh
+++ b/net/uradvd/test-version.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+case "$1" in
+uradvd)
+	# The binary is built with VERSION=$(PKG_SOURCE_DATE) and prints
+	# "uradvd 2025-09-20", while PKG_VERSION is 2025.09.20~<short hash>.
+	version=$(echo "${2%%~*}" | tr . -)
+	uradvd --version | grep -Fx "uradvd $version"
+	;;
+
+*)
+	echo "Untested package: $1" >&2
+	exit 1
+	;;
+esac

--- a/net/uradvd/test.sh
+++ b/net/uradvd/test.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-uradvd --version | grep -Fx "uradvd $PKG_SOURCE_DATE"


### PR DESCRIPTION
Maintainer: @mwarning 

The script greps for `uradvd $PKG_SOURCE_DATE`, but [`test_entrypoint.sh`](https://github.com/openwrt/actions-shared-workflows/blob/main/.github/scripts/test_entrypoint.sh) only exports `PKG_NAME`, `PKG_VERSION` and `CI_HELPERS`. `PKG_SOURCE_DATE` is a build time Makefile variable and is empty in the test container, so the `grep -Fx` pattern is `uradvd ` and never matches.

The binary is built with `VERSION=$(PKG_SOURCE_DATE)` and prints `uradvd 2025-09-20`, while `PKG_VERSION` is `2025.09.20~<short hash>`, so derive the date from the version instead.

Renamed to `test-version.sh` in the process: the generic probe looks for `PKG_VERSION` verbatim and cannot match the dashed date either, and `uradvd` is the only executable in the package, so without an override the whole package fails. The shebang goes back to `/bin/sh`, which is what the harness runs the script with.

Split out of #30112, where the plain rename surfaced this:

```
uradvd: [skip] Version check (/usr/sbin/uradvd)
uradvd: [fail] Version check override
uradvd: Generic tests failed
```