### PR TITLE
crowdsec-firewall-bouncer: update to 0.0.36

### DIFF
--- a/net/crowdsec-firewall-bouncer/Makefile
+++ b/net/crowdsec-firewall-bouncer/Makefile
@@ -6,16 +6,16 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=crowdsec-firewall-bouncer
-PKG_VERSION:=0.0.34
+PKG_VERSION:=0.0.36
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/crowdsecurity/cs-firewall-bouncer/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=5bd62250f40fc0a05d2431f3ea1cb211d7fc4cc755b53a23585aa2cede8ff985
+PKG_HASH:=46c41cce09df0be41ca091499fffd3ca2e61f85fb66e4f82060043e0894290cf
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
-PKG_MAINTAINER:=Gerald Kerma <gandalf@gk2.net>
+PKG_MAINTAINER:=S. Brusch <ne20002@gmx.ch>
 
 PKG_BUILD_DEPENDS:=golang/host
 PKG_BUILD_PARALLEL:=1

--- a/net/crowdsec-firewall-bouncer/test-version.sh
+++ b/net/crowdsec-firewall-bouncer/test-version.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# shellcheck shell=busybox
+
+# cs-firewall-bouncer does not recognize -? for version test
+
+case "$PKG_NAME" in
+crowdsec-firewall-bouncer)
+	exit 0
+	;;
+
+*)
+	echo "Untested package: $PKG_NAME" >&2
+	exit 1
+	;;
+esac


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** S. Brusch <ne20002@gmx.ch>

**Description:**
updated to new upstream release version 0.0.36
changed maintainer to me based on the comment of the last update (https://github.com/openwrt/packages/pull/27163)

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12.5
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** BPI-R4

---

## ✅ Formalities

- [ x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.