### PR TITLE
watchcat: add per-instance 'enabled' option (default 1)

### DIFF
--- a/utils/watchcat/Makefile
+++ b/utils/watchcat/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=watchcat
 PKG_VERSION:=1
-PKG_RELEASE:=25
+PKG_RELEASE:=26
 
 PKG_MAINTAINER:=Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>, Dharmik Parmar <dharmikparmar2004@yahoo.com>
 PKG_LICENSE:=GPL-2.0

--- a/utils/watchcat/files/watchcat.config
+++ b/utils/watchcat/files/watchcat.config
@@ -6,3 +6,5 @@ config watchcat
 	# For restart_iface and run_script, start a fresh failure window after
 	# each recovery action finishes before allowing another restart.
 	# option reset_failure_timer '1'
+	# 'enabled' allows disabling individual watchcat instances without removing them, default 1
+	# option enabled '1'

--- a/utils/watchcat/files/watchcat.init
+++ b/utils/watchcat/files/watchcat.init
@@ -32,6 +32,9 @@ time_to_seconds() {
 
 config_watchcat() {
 	# Read config
+	config_get_bool enabled "$1" enabled 1
+	[ "$enabled" -eq 1 ] || return 0
+
 	config_get period "$1" period "120"
 	config_get mode "$1" mode "ping_reboot"
 	config_get pinghosts "$1" pinghosts "8.8.8.8"


### PR DESCRIPTION
Allows disabling individual watchcat instances without removing them.

## 📦 Package Details

**Maintainer:** @danielfdickinson & @dhrm1k

**Description:**
The new "enabled" option defaults to "1", so existing configurations
continue to work without any changes. No config migration is required.

Related luci PR: https://github.com/openwrt/luci/pull/8930

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12.5
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** Xiaomi Mi Router AX3000T

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

