### PR TITLE
[24.10] openvpn: update to 2.6.22 and ovpn-dco: update to 0.2.20260804

### DIFF
--- a/kernel/ovpn-dco/Makefile
+++ b/kernel/ovpn-dco/Makefile
@@ -9,14 +9,14 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=ovpn-dco
-PKG_VERSION:=0.2.20251017
+PKG_VERSION:=0.2.20260804
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL= \
 	https://build.openvpn.net/downloads/releases \
 	https://codeload.github.com/OpenVPN/ovpn-dco/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=af88c9bc73b350e0cada9aa5b21c5d4b598f9a9868f0b78b2d06026183a67032
+PKG_HASH:=f7677ab0e6ae962d8d356dcf98cd2682af1fe13a6929fda205e7ad0e037b9d7f
 
 PKG_MAINTAINER:=Jianhui Zhao <zhaojh329@gmail.com>
 PKG_LICENSE:=GPL-2.0-only

--- a/net/openvpn/Makefile
+++ b/net/openvpn/Makefile
@@ -9,14 +9,14 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openvpn
 
-PKG_VERSION:=2.6.20
+PKG_VERSION:=2.6.22
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=\
 	https://build.openvpn.net/downloads/releases/ \
 	https://swupdate.openvpn.net/community/releases/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=952ecee5b911a5353c0a6d40af62a7076c6dea1481ef204ce6d3f10481531315
+PKG_HASH:=f46df740f05f86020137a41cfc8814352391cf861ed57f57b4e815cb97c1d2cf
 
 PKG_MAINTAINER:=
 


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @commodo @LGA1150 

**Description:**
`main` and `25.12` have moved to 2.7.x with the new DCO implementation. Let's keep 24.10 on the previous 2.6.x branch as to not introduce too many changes to the old-stable 24.10 branch.

For changes, see:
https://github.com/OpenVPN/openvpn/blob/v2.6.21/Changes.rst

---

## 🧪 Run Testing Details

- **OpenWrt Version:** x86-64
- **OpenWrt Target/Subtarget:** generic

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
