### PR TITLE
python-{pyproject-hooks,installer}: allow flit_core 4.x as the build backend

### DIFF
--- a/lang/python/python-installer/Makefile
+++ b/lang/python/python-installer/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-installer
 PKG_VERSION:=1.0.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=installer
 PKG_HASH:=052c7fc3721d54c696e2dea019be67539d7b144e924f559f54beb3121831c364

--- a/lang/python/python-installer/patches/010-relax-flit-core-constraint.patch
+++ b/lang/python/python-installer/patches/010-relax-flit-core-constraint.patch
@@ -1,0 +1,25 @@
+From 0896005b967075612dc66f98d33b46b9c1e689dd Mon Sep 17 00:00:00 2001
+From: Alexandru Ardelean <alex@shruggie.ro>
+Date: Mon, 10 Aug 2026 15:15:26 +0300
+Subject: [PATCH] python-installer: allow flit_core 4.x as the build backend
+
+installer caps its flit_core build requirement below 4, so python-installer/host fails
+with "Missing dependencies: flit_core<4" now that the feed ships flit-core
+4.0.2. flit_core 4 builds it unchanged; relax the upper bound.
+
+Signed-off-by: Alexandru Ardelean <alex@shruggie.ro>
+---
+ pyproject.toml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,7 +1,7 @@
+ [build-system]
+ build-backend = "flit_core.buildapi"
+ requires = [
+-    "flit_core<4,>=3.11",
++    "flit_core>=3.11",
+ ]
+ 
+ [project]

--- a/lang/python/python-pyproject-hooks/Makefile
+++ b/lang/python/python-pyproject-hooks/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-pyproject-hooks
 PKG_VERSION:=1.2.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=pyproject_hooks
 PKG_HASH:=1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8

--- a/lang/python/python-pyproject-hooks/patches/010-relax-flit-core-constraint.patch
+++ b/lang/python/python-pyproject-hooks/patches/010-relax-flit-core-constraint.patch
@@ -1,0 +1,24 @@
+From df6f6542c6a1caf2d8b91d9b27b27767df8b7bd3 Mon Sep 17 00:00:00 2001
+From: Alexandru Ardelean <alex@shruggie.ro>
+Date: Mon, 10 Aug 2026 15:15:26 +0300
+Subject: [PATCH] python-pyproject-hooks: allow flit_core 4.x as the build
+ backend
+
+pyproject-hooks caps its flit_core build requirement below 4, so python-pyproject-hooks/host fails
+with "Missing dependencies: flit_core<4" now that the feed ships flit-core
+4.0.2. flit_core 4 builds it unchanged; relax the upper bound.
+
+Signed-off-by: Alexandru Ardelean <alex@shruggie.ro>
+---
+ pyproject.toml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,5 +1,5 @@
+ [build-system]
+-requires = ["flit_core >=3.2,<4"]
++requires = ["flit_core >=3.2"]
+ build-backend = "flit_core.buildapi"
+ 
+ [project]


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me

**Description:**


---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [ ] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
