### PR TITLE
[25.12] openvpn: update to 2.7.6 and ovpn-dco: update to 7.1.0.2026080300

### DIFF
--- a/kernel/ovpn-dco/Makefile
+++ b/kernel/ovpn-dco/Makefile
@@ -9,14 +9,14 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=ovpn-backports
-PKG_VERSION:=7.0.0.2026032400
-PKG_RELEASE:=2
+PKG_VERSION:=7.1.0.2026080300
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL= \
 	https://build.openvpn.net/downloads/releases \
 	https://swupdate.openvpn.net/community/releases
-PKG_HASH:=509ca84cf2bb7b9300b282c11869fc1607b09339b562087e535d070d4c0d26a8
+PKG_HASH:=b612261015b75fcb52a364d7bedc1e5fd70656e26ba388f1d88f58fc5fbb9560
 PKG_BUILD_PARALLEL:=1
 
 PKG_MAINTAINER:=Jianhui Zhao <zhaojh329@gmail.com>

--- a/kernel/ovpn-dco/patches/0001-do-not-use-EIP-197.patch
+++ b/kernel/ovpn-dco/patches/0001-do-not-use-EIP-197.patch
@@ -69,8 +69,8 @@ cryptographic engine [1]. Disable async until this is fixed.
  		pr_err("%s crypto_alloc_aead failed, err=%d\n", title, ret);
 --- a/drivers/net/ovpn/io.c
 +++ b/drivers/net/ovpn/io.c
-@@ -98,6 +98,9 @@ static void ovpn_netdev_write(struct ovp
- 	}
+@@ -105,6 +105,9 @@ static void ovpn_netdev_write(struct ovp
+ 	local_bh_enable();
  }
  
 +#if IS_ENABLED(CONFIG_CRYPTO_DEV_SAFEXCEL)
@@ -79,7 +79,7 @@ cryptographic engine [1]. Disable async until this is fixed.
  void ovpn_decrypt_post(void *data, int ret)
  {
  	struct ovpn_crypto_key_slot *ks;
-@@ -108,11 +111,13 @@ void ovpn_decrypt_post(void *data, int r
+@@ -115,11 +118,13 @@ void ovpn_decrypt_post(void *data, int r
  	__be16 proto;
  	__be32 *pid;
  
@@ -93,7 +93,7 @@ cryptographic engine [1]. Disable async until this is fixed.
  
  	payload_offset = ovpn_skb_cb(skb)->payload_offset;
  	ks = ovpn_skb_cb(skb)->ks;
-@@ -228,6 +233,9 @@ void ovpn_recv(struct ovpn_peer *peer, s
+@@ -235,6 +240,9 @@ void ovpn_recv(struct ovpn_peer *peer, s
  	ovpn_decrypt_post(skb, ovpn_aead_decrypt(peer, ks, skb));
  }
  
@@ -103,7 +103,7 @@ cryptographic engine [1]. Disable async until this is fixed.
  void ovpn_encrypt_post(void *data, int ret)
  {
  	struct ovpn_crypto_key_slot *ks;
-@@ -236,11 +244,13 @@ void ovpn_encrypt_post(void *data, int r
+@@ -243,11 +251,13 @@ void ovpn_encrypt_post(void *data, int r
  	struct ovpn_peer *peer;
  	unsigned int orig_len;
  

--- a/net/openvpn/Makefile
+++ b/net/openvpn/Makefile
@@ -9,14 +9,14 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openvpn
 
-PKG_VERSION:=2.7.4
-PKG_RELEASE:=3
+PKG_VERSION:=2.7.6
+PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=\
 	https://build.openvpn.net/downloads/releases/ \
 	https://swupdate.openvpn.net/community/releases/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=18db05f3d5eee3663db1914590044e5f96ff5cd47b6e7846c6a350806c23dbce
+PKG_HASH:=10e24a9385f23cc38cc5cf448f3ca0769f939bc4cbecc4f4647d7e006e52db74
 
 PKG_MAINTAINER:=
 


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @commodo @LGA1150 

**Description:**
Update the OpenVPN package to 2.7.6 and corresponding ovpn-dco to 7.1.0.2026080300

For changes, see:
https://github.com/OpenVPN/openvpn/blob/v2.7.6/Changes.rst

---

## 🧪 Run Testing Details

- **OpenWrt Version:** x86-64
- **OpenWrt Target/Subtarget:** generic

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.