### PR TITLE
radicale3: cherry-pick to v3.7.8

### DIFF
--- a/net/radicale3/Makefile
+++ b/net/radicale3/Makefile
@@ -4,7 +4,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=radicale3
-PKG_VERSION:=3.7.6
+PKG_VERSION:=3.7.7
 PKG_RELEASE:=1
 
 PKG_LICENSE:=GPL-3.0-or-later
@@ -13,7 +13,7 @@ PKG_CPE_ID:=cpe:/a:radicale:radicale
 
 PYPI_NAME:=Radicale
 PYPI_SOURCE_NAME:=radicale
-PKG_HASH:=366e8337588267e9b7af189f3ac527c5f9a8d7dd6d2e3e5796b49933bc72609c
+PKG_HASH:=46c58d0340bc70a1219a46ca9c6a88b97293b555e15d41d66110c5e236243b64
 
 PKG_MAINTAINER:=Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>
 

--- a/net/radicale3/Makefile
+++ b/net/radicale3/Makefile
@@ -4,7 +4,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=radicale3
-PKG_VERSION:=3.7.7
+PKG_VERSION:=3.7.8
 PKG_RELEASE:=1
 
 PKG_LICENSE:=GPL-3.0-or-later
@@ -13,7 +13,7 @@ PKG_CPE_ID:=cpe:/a:radicale:radicale
 
 PYPI_NAME:=Radicale
 PYPI_SOURCE_NAME:=radicale
-PKG_HASH:=46c58d0340bc70a1219a46ca9c6a88b97293b555e15d41d66110c5e236243b64
+PKG_HASH:=8b7345606bf13ded08dc81d4fddefbbe3461baa11b2fe77caba355a0978f8e9c
 
 PKG_MAINTAINER:=Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>
 


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @danielfdickinson

**Description:**
Cherry-pick the Radicale v3.7.7 and v3.7.8 bugfix and enhancement releases from master to 25.12

---

## 🧪 Run Testing Details

- **OpenWrt Version:** OpenWrt 25.12-SNAPSHOT r33143-d78c0fd16d
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** OpenWrt One

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
