### PR TITLE
pillow: make pybind11 an optional build dependency + pybind11: drop package (no more users)

### DIFF
--- a/lang/python/pillow/Makefile
+++ b/lang/python/pillow/Makefile
@@ -8,13 +8,13 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pillow
 PKG_VERSION:=12.2.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=Pillow
 PYPI_SOURCE_NAME:=pillow
 PKG_HASH:=a830b1a40919539d07806aa58e1b114df53ddd43213d9c8b75847eee6c0182b5
 
-PKG_BUILD_DEPENDS:=python-setuptools/host python-pybind11/host
+PKG_BUILD_DEPENDS:=python-setuptools/host
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=HPND

--- a/lang/python/pillow/patches/010-drop-pybind11-parallelcompile.patch
+++ b/lang/python/pillow/patches/010-drop-pybind11-parallelcompile.patch
@@ -1,0 +1,46 @@
+From 3fabaeec684fae934055b85c2f91c1bd700c71b0 Mon Sep 17 00:00:00 2001
+From: Alexandru Ardelean <alex@shruggie.ro>
+Date: Tue, 11 Aug 2026 10:30:00 +0300
+Subject: [PATCH] setup.py: drop the pybind11 build dependency
+
+pybind11 is only used for pybind11.setup_helpers.ParallelCompile, a
+build-time helper that parallelises the C extension compilation. Pillow
+ships no pybind11 bindings, so remove the import, the ParallelCompile
+call and the pybind11 build-system requirement; the C extensions are
+then compiled serially.
+
+Signed-off-by: Alexandru Ardelean <alex@shruggie.ro>
+---
+ pyproject.toml | 1 -
+ setup.py       | 3 ---
+ 2 files changed, 4 deletions(-)
+
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,7 +1,6 @@
+ [build-system]
+ build-backend = "backend"
+ requires = [
+-  "pybind11",
+   "setuptools>=77",
+ ]
+ backend-path = [
+--- a/setup.py
++++ b/setup.py
+@@ -17,7 +17,6 @@ import sys
+ import warnings
+ from collections.abc import Iterator
+ 
+-from pybind11.setup_helpers import ParallelCompile
+ from setuptools import Extension, setup
+ from setuptools.command.build_ext import build_ext
+ 
+@@ -32,8 +31,6 @@ while sys.argv[-1].startswith("--pillow-
+     _, key, value = sys.argv.pop().split("=", 2)
+     configuration.setdefault(key, []).append(value)
+ 
+-default = int(configuration.get("parallel", ["0"])[-1])
+-ParallelCompile("MAX_CONCURRENCY", default).install()
+ 
+ 
+ def get_version() -> str:


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:**  me

**Description:**

Add a patch (submitted upstream) that wraps Pillow's use of pybind11.setup_helpers.ParallelCompile in try/except ImportError and drops pybind11 from build-system.requires. pybind11 ships no runtime bindings here; it only parallelises the C extension build, so Pillow builds fine without it (compiling serially). Drop python-pybind11/host from PKG_BUILD_DEPENDS accordingly, removing the extra host build dependency.


---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [ ] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
