### PR TITLE
[25.12] telegraf: update to 1.39.3

### DIFF
--- a/utils/telegraf/Makefile
+++ b/utils/telegraf/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=telegraf
-PKG_VERSION:=1.39.2
+PKG_VERSION:=1.39.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/influxdata/telegraf/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=bfd06e36ae049464c71a936e758aa15d7de007221682bab335ba1fa7c351c0b1
+PKG_HASH:=13b4186fac9a9d29858c532b73efc41e0a1ac8ce93a615b59d5a6e589e71ab2f
 
 PKG_MAINTAINER:=Niklas Thorild <niklas@thorild.se>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me

**Description:**
- Update Telegraf to v1.39.3

Release notes: https://github.com/influxdata/telegraf/releases/tag/v1.39.3

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12.5
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** LXC container

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.