### PR TITLE
ddns-scripts: add gandi pat support

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.4
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_LICENSE:=GPL-2.0
 
@@ -264,15 +264,29 @@ endef
 
 define Package/ddns-scripts-gandi
   $(call Package/ddns-scripts/Default)
-  TITLE:=Gandi API
+  TITLE:=Gandi API (Deprecated)
   DEPENDS:=ddns-scripts +curl
 endef
 
 define Package/ddns-scripts-gandi/description
-  Dynamic DNS Client scripts extension for 'gandi.net'.
+  Deprecated Dynamic DNS Client scripts extension for 'gandi.net'. This version
+  uses the deprecated API key authentication; use ddns-scripts-gandi-v2 instead.
   It requires:
   'option username' to be a valid subdomain for gandi.net
   'option password' to be a valid API key for gandi.net
+endef
+
+define Package/ddns-scripts-gandi-v2
+  $(call Package/ddns-scripts/Default)
+  TITLE:=Gandi API v2 (PAT)
+  DEPENDS:=ddns-scripts +curl
+endef
+
+define Package/ddns-scripts-gandi-v2/description
+  Dynamic DNS Client scripts extension for 'gandi.net' using Personal Access Tokens
+  It requires:
+  'option username' to be a valid subdomain for gandi.net
+  'option password' to be a valid Personal Access Token for gandi.net
 endef
 
 
@@ -488,6 +502,7 @@ define Package/ddns-scripts-services/install
 	rm $(1)/usr/share/ddns/default/route53-v1.json
 	rm $(1)/usr/share/ddns/default/cnkuai.cn.json
 	rm $(1)/usr/share/ddns/default/gandi.net.json
+	rm $(1)/usr/share/ddns/default/gandi.net-v2.json
 	rm $(1)/usr/share/ddns/default/beget.com.json
 	rm $(1)/usr/share/ddns/default/pdns.json
 	rm $(1)/usr/share/ddns/default/scaleway.com.json
@@ -819,7 +834,25 @@ define Package/ddns-scripts-gandi/install
 		$(1)/usr/share/ddns/default
 endef
 
+define Package/ddns-scripts-gandi-v2/install
+	$(INSTALL_DIR) $(1)/usr/lib/ddns
+	$(INSTALL_BIN) ./files/usr/lib/ddns/update_gandi_net_v2.sh \
+		$(1)/usr/lib/ddns
+
+	$(INSTALL_DIR) $(1)/usr/share/ddns/default
+	$(INSTALL_DATA) ./files/usr/share/ddns/default/gandi.net-v2.json \
+		$(1)/usr/share/ddns/default
+endef
+
 define Package/ddns-scripts-gandi/prerm
+#!/bin/sh
+if [ -z "$${IPKG_INSTROOT}" ]; then
+	/etc/init.d/ddns stop
+fi
+exit 0
+endef
+
+define Package/ddns-scripts-gandi-v2/prerm
 #!/bin/sh
 if [ -z "$${IPKG_INSTROOT}" ]; then
 	/etc/init.d/ddns stop
@@ -1032,6 +1065,7 @@ $(eval $(call BuildPackage,ddns-scripts-nsupdate))
 $(eval $(call BuildPackage,ddns-scripts-route53))
 $(eval $(call BuildPackage,ddns-scripts-cnkuai))
 $(eval $(call BuildPackage,ddns-scripts-gandi))
+$(eval $(call BuildPackage,ddns-scripts-gandi-v2))
 $(eval $(call BuildPackage,ddns-scripts-beget))
 $(eval $(call BuildPackage,ddns-scripts-blazingfast))
 $(eval $(call BuildPackage,ddns-scripts-pdns))

--- a/net/ddns-scripts/files/usr/lib/ddns/update_gandi_net_v2.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/update_gandi_net_v2.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+# Thanks goes to Alex Griffin who provided this script.
+
+. /usr/share/libubox/jshn.sh
+
+local __TTL=600
+local __RRTYPE
+local __ENDPOINT="https://api.gandi.net/v5/livedns"
+local __STATUS
+
+[ -z "$username" ] && write_log 14 "Service section not configured correctly! Missing subdomain as 'username'"
+[ -z "$password" ] && write_log 14 "Service section not configured correctly! Missing PAT as 'password'"
+
+[ $use_ipv6 -ne 0 ] && __RRTYPE="AAAA" || __RRTYPE="A"
+
+# Construct JSON payload
+json_init
+json_add_int rrset_ttl "$__TTL"
+json_add_array rrset_values
+json_add_string "" "$__IP"
+json_close_array
+
+# Log the curl command
+write_log 7 "curl -s -X PUT \"$__ENDPOINT/domains/$domain/records/$username/$__RRTYPE\" \
+	-H \"Authorization: Bearer $password\" \
+	-H \"Content-Type: application/json\" \
+	-d \"$(json_dump)\" \
+	--connect-timeout 30"
+
+__STATUS=$(curl -s -X PUT "$__ENDPOINT/domains/$domain/records/$username/$__RRTYPE" \
+	-H "Authorization: Bearer $password" \
+	-H "Content-Type: application/json" \
+	-d "$(json_dump)" \
+	--connect-timeout 30 \
+	-w "%{http_code}\n" -o $DATFILE 2>$ERRFILE)
+
+local __ERRNO=$?
+if [ $__ERRNO -ne 0 ]; then
+	write_log 14 "Curl failed with $__ERRNO: $(cat $ERRFILE)"
+	return 1
+elif [ -z $__STATUS ] || [ $__STATUS != 201 ]; then
+	write_log 14 "LiveDNS failed: $__STATUS \ngandi.net answered: $(cat $DATFILE)"
+	return 1
+fi
+
+write_log 7 "gandi.net answered: $(cat $DATFILE)"
+
+return 0

--- a/net/ddns-scripts/files/usr/share/ddns/default/gandi.net-v2.json
+++ b/net/ddns-scripts/files/usr/share/ddns/default/gandi.net-v2.json
@@ -1,0 +1,9 @@
+{
+	"name": "gandi.net-v2",
+	"ipv4": {
+		"url": "update_gandi_net_v2.sh"
+	},
+	"ipv6": {
+		"url": "update_gandi_net_v2.sh"
+	}
+}


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** ddns-scripts declares no PKG_MAINTAINER; the most recent Makefile activity is from @systemcrash and @feckert.

**Description:**
Gandi has deprecated API Key for authentication and replaced it with Personal Access Tokens. This adds a v2 gandi script to use the new authentication scheme keeping the old version intact for any existing API Key users.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12.5
- **OpenWrt Target/Subtarget:** x86/x86_64, MediaTek RaLink ARM/Mt7622 
- **OpenWrt Device:** Generic x86/64, Linksys E8450 UBI

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.