### PR TITLE
librespeed-cli-rust: update to 0.1.1

### DIFF
--- a/utils/librespeed-cli-rust/Makefile
+++ b/utils/librespeed-cli-rust/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=librespeed-cli-rust
-PKG_VERSION:=0.1.0
+PKG_VERSION:=0.1.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/BKPepe/speedtest-cli-rust/tar.gz/refs/tags/v$(PKG_VERSION)?
-PKG_HASH:=d6b88befe573a9d2f93656fadeb69c194c6aa0027749662e2f0dafd972cee8f5
+PKG_HASH:=fb658ea4e988c6d60cf4d01df6a3e4a7ed1b55192217a4a712d089584da5c9ec
 PKG_BUILD_DIR:=$(BUILD_DIR)/speedtest-cli-rust-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>


### PR DESCRIPTION
Built and run tested on Turris 1.1, powerpc_8548, Turris OS 9.1.1
Release notes: https://github.com/BKPepe/speedtest-cli-rust/releases/tag/v0.1.1
