### PR TITLE
rust: build soft-float on soft-float PowerPC subtargets

### DIFF
--- a/lang/rust/Makefile
+++ b/lang/rust/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rust
 PKG_VERSION:=1.94.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=rustc-$(PKG_VERSION)-src.tar.xz
 PKG_SOURCE_URL:=https://static.rust-lang.org/dist/
@@ -88,6 +88,7 @@ define Host/Compile
 	$(RUST_SCCACHE_VARS) \
 	CARGO_HOME=$(CARGO_HOME) \
 	TARGET_CFLAGS="$(TARGET_CFLAGS)" \
+	$(if $(RUSTC_TARGET_RUSTFLAGS),$(RUSTC_TARGET_CARGO_RUSTFLAGS)="$(RUSTC_TARGET_RUSTFLAGS)") \
 	$(PYTHON) $(HOST_BUILD_DIR)/x.py \
 		--build-dir $(HOST_BUILD_DIR)/build \
 		dist build-manifest rustc rust-std cargo llvm-tools rust-src

--- a/lang/rust/rust-values.mk
+++ b/lang/rust/rust-values.mk
@@ -52,6 +52,24 @@ else ifeq ($(ARCH),riscv64)
   RUSTC_TARGET_ARCH:=$(subst riscv64,riscv64gc,$(RUSTC_TARGET_ARCH))
 endif
 
+# 32-bit PowerPC has both soft-float and hard-float subtargets: mpc85xx is an
+# e500v2 with no floating-point unit at all, while apm821xx (powerpc_464fp)
+# has one. They share the powerpc-unknown-linux-musl triple, which is the
+# hard-float one, so on the soft-float subtarget rustc emits lfd, stfd and
+# fdiv for a core with no floating-point registers, and passes doubles in
+# registers nothing else in the image uses.
+#
+# CONFIG_SOFT_FLOAT already carries this: it defaults to y when the target has
+# no fpu feature, and it is what puts --with-float=soft into the toolchain and
+# -msoft-float into TARGET_CFLAGS.
+ifeq ($(ARCH),powerpc)
+  ifeq ($(CONFIG_SOFT_FLOAT),y)
+    RUSTC_TARGET_RUSTFLAGS+=-Ctarget-feature=-hard-float
+  endif
+endif
+
+CARGO_RUSTFLAGS+=$(RUSTC_TARGET_RUSTFLAGS)
+
 # ARM Logic
 ifeq ($(ARCH),arm)
   ifeq ($(CONFIG_arm_v6)$(CONFIG_arm_v7),)
@@ -69,6 +87,16 @@ endif
 ifeq ($(ARCH),aarch64)
     RUSTC_CFLAGS:=-mno-outline-atomics
 endif
+
+# The same flags have to reach the std that rust/host builds for the target,
+# or std and the packages linked against it disagree about how a double is
+# passed. Bootstrap sets RUSTFLAGS itself on the cargo invocations it spawns,
+# so setting that would be overwritten; it does however read
+# CARGO_TARGET_<TRIPLE>_RUSTFLAGS and fold it in, scoped to that triple, which
+# leaves the host artifacts built in the same run untouched.
+# Deferred, because the blocks above still rewrite RUSTC_TARGET_ARCH.
+RUSTC_TARGET_UPPER = $(subst -,_,$(call toupper,$(RUSTC_TARGET_ARCH)))
+RUSTC_TARGET_CARGO_RUSTFLAGS = CARGO_TARGET_$(RUSTC_TARGET_UPPER)_RUSTFLAGS
 
 # Support only a subset for now.
 RUST_ARCH_DEPENDS:=@(aarch64||arm||i386||loongarch64||mips||mips64||mips64el||mipsel||powerpc||powerpc64||riscv64||x86_64)
@@ -100,7 +128,7 @@ CARGO_PKG_CONFIG_VARS= \
 	CARGO_PROFILE_RELEASE_OVERFLOW_CHECKS=true \
 	CARGO_PROFILE_RELEASE_PANIC=unwind \
 	CARGO_PROFILE_RELEASE_RPATH=false \
-	CARGO_TARGET_$(subst -,_,$(call toupper,$(RUSTC_TARGET_ARCH)))_LINKER=$(TARGET_CC_NOCACHE) \
+	CARGO_TARGET_$(RUSTC_TARGET_UPPER)_LINKER=$(TARGET_CC_NOCACHE) \
 	RUSTFLAGS="$(CARGO_RUSTFLAGS)" \
 	TARGET_CC=$(TARGET_CC_NOCACHE) \
 	TARGET_CFLAGS="$(TARGET_CFLAGS) $(RUSTC_CFLAGS)"


### PR DESCRIPTION
Backport of #30196.

Verified on powerpc_8548: 0 floating-point instructions in the resulting
binary, which links against `ld-musl-powerpc-sf.so.1`.
