### PR TITLE
net-snmp: fix linking issue on libnetsnmptrapd

### DIFF
--- a/net/net-snmp/Makefile
+++ b/net/net-snmp/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=net-snmp
 PKG_VERSION:=5.9.5.2
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/net-snmp

--- a/net/net-snmp/patches/140-debian-makefile_trap_needs_agent.patch
+++ b/net/net-snmp/patches/140-debian-makefile_trap_needs_agent.patch
@@ -1,0 +1,18 @@
+Description: Add libnetsnmpagent link to libnetsnmptrapd
+ Causes a linking issue otherwise
+ https://github.com/net-snmp/net-snmp/issues/434
+Author: Craig Small <csmall@debian.org>
+Reviewed-by: Craig Small <csmall@debian.org>
+Last-Update: 2023-08-19
+---
+--- a/apps/Makefile.in
++++ b/apps/Makefile.in
+@@ -235,7 +235,7 @@ snmppcap$(EXEEXT):    snmppcap.$(OSUFFIX
+ 	$(LINK) ${CFLAGS} -o $@ snmppcap.$(OSUFFIX) ${LDFLAGS} ${USEAGENTLIBS} ${LIBS} -lpcap
+ 
+ libnetsnmptrapd.$(LIB_EXTENSION)$(LIB_VERSION): $(LLIBTRAPD_OBJS)
+-	$(LIB_LD_CMD) $@ ${LLIBTRAPD_OBJS} $(MIBLIB) $(MYSQL_LIBS) $(USELIBS) $(PERLLDOPTS_FOR_LIBS) $(LDFLAGS)
++	$(LIB_LD_CMD) $@ ${LLIBTRAPD_OBJS} $(MIBLIB) $(MYSQL_LIBS) $(USELIBS) $(USEAGENTLIBS) $(PERLLDOPTS_FOR_LIBS) $(LDFLAGS)
+ 	$(RANLIB) $@
+ 
+ snmpinforminstall:

--- a/net/net-snmp/patches/140-debian-makefile_trap_needs_agent.patch
+++ b/net/net-snmp/patches/140-debian-makefile_trap_needs_agent.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Craig Small <csmall@debian.org>
+Date: Sat, 19 Aug 2023 00:00:00 +0000
+Subject: [PATCH] Add libnetsnmpagent link to libnetsnmptrapd
+
+Add libnetsnmpagent link to libnetsnmptrapd. Causes a linking issue otherwise
+https://github.com/net-snmp/net-snmp/issues/434
+---
+--- a/apps/Makefile.in
++++ b/apps/Makefile.in
+@@ -235,7 +235,7 @@ snmppcap$(EXEEXT):    snmppcap.$(OSUFFIX
+ 	$(LINK) ${CFLAGS} -o $@ snmppcap.$(OSUFFIX) ${LDFLAGS} ${USEAGENTLIBS} ${LIBS} -lpcap
+ 
+ libnetsnmptrapd.$(LIB_EXTENSION)$(LIB_VERSION): $(LLIBTRAPD_OBJS)
+-	$(LIB_LD_CMD) $@ ${LLIBTRAPD_OBJS} $(MIBLIB) $(MYSQL_LIBS) $(USELIBS) $(PERLLDOPTS_FOR_LIBS) $(LDFLAGS)
++	$(LIB_LD_CMD) $@ ${LLIBTRAPD_OBJS} $(MIBLIB) $(MYSQL_LIBS) $(USELIBS) $(USEAGENTLIBS) $(PERLLDOPTS_FOR_LIBS) $(LDFLAGS)
+ 	$(RANLIB) $@
+ 
+ snmpinforminstall:


### PR DESCRIPTION

## 📦 Package Details

**Maintainer:** @stintel 

**Description:**
The new version of the compiler imposes stricter requirements — specifically, it disallows linking against undefined functions. Consequently, the build fails when using the new version. A patch from Debian repository has been added 
to fix this issue.

Discussion on main repository: https://github.com/net-snmp/net-snmp/issues/434

---

## 🧪 Run Testing Details

- **OpenWrt Version:** trunk
- **OpenWrt Target/Subtarget:** mediatek/mt7622, ramips/mt76x8
- **OpenWrt Device:** Xiaomi Redmi AX6s, Zyxel Keenetic Extra II

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [x] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
