### PR TITLE
libdht: give the shared library a soname; rebuild transmission

### DIFF
--- a/libs/libdht/Makefile
+++ b/libs/libdht/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libdht
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/jech/dht
@@ -10,33 +10,44 @@ PKG_SOURCE_VERSION:=0bbb8f4a5bd914b60de5e9fbb51573aa33a1cf18
 PKG_MIRROR_HASH:=4a24bd406dd0ac9e69d75f062b45bc0d660f1f8bed9672afc35a7afe4b13acf4
 
 PKG_LICENSE:=MIT
-PKG_LICENSE_FILES:=LICENSE
+PKG_LICENSE_FILES:=LICENCE
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 
 include $(INCLUDE_DIR)/package.mk
+
+# Upstream ships a plain Makefile that builds only a test binary, so the
+# shared object is built here -- and given a soname, since a bare libdht.so
+# leaves no way to express an ABI break. jech/dht offers no ABI guarantee of
+# its own, so this is a packaged ABI epoch: bump PKG_ABI_VERSION if the
+# exported surface changes.
+PKG_ABI_VERSION:=0
 
 define Package/libdht
   SECTION:=libs
   CATEGORY:=Libraries
   TITLE:=Kademlia Distributed Hash Table (DHT) library
   DEPENDS:= +USE_GLIBC:libcrypt-compat
+  ABI_VERSION:=$(PKG_ABI_VERSION)
 endef
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include/dht $(1)/usr/lib
 	$(CP) $(PKG_BUILD_DIR)/dht.h $(1)/usr/include/dht
-	$(CP) $(PKG_BUILD_DIR)/libdht.so $(1)/usr/lib/
+	$(CP) $(PKG_BUILD_DIR)/libdht.so* $(1)/usr/lib/
 endef
 
 define Package/libdht/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_BUILD_DIR)/libdht.so $(1)/usr/lib/
+	$(CP) $(PKG_BUILD_DIR)/libdht.so.$(PKG_ABI_VERSION) $(1)/usr/lib/
 endef
 
 define Build/Compile
-	$(TARGET_CC) $(FPIC) -Wall -c -o $(PKG_BUILD_DIR)/dht.o $(PKG_BUILD_DIR)/dht.c
-	$(TARGET_CC) -shared -lcrypt -o $(PKG_BUILD_DIR)/libdht.so $(PKG_BUILD_DIR)/dht.o
+	$(TARGET_CC) $(FPIC) $(TARGET_CFLAGS) $(TARGET_CPPFLAGS) -Wall \
+		-c -o $(PKG_BUILD_DIR)/dht.o $(PKG_BUILD_DIR)/dht.c
+	$(TARGET_CC) $(TARGET_LDFLAGS) -shared -Wl,-soname,libdht.so.$(PKG_ABI_VERSION) \
+		-o $(PKG_BUILD_DIR)/libdht.so.$(PKG_ABI_VERSION) $(PKG_BUILD_DIR)/dht.o -lcrypt
+	ln -sf libdht.so.$(PKG_ABI_VERSION) $(PKG_BUILD_DIR)/libdht.so
 endef
 
 $(eval $(call BuildPackage,libdht))

--- a/net/transmission/Makefile
+++ b/net/transmission/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=transmission
 PKG_VERSION:=4.1.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/transmission/transmission/releases/download/$(PKG_VERSION)/


### PR DESCRIPTION
### Maintainer
Myself (maintainer of both packages).

### Description
`libdht` installed a bare `libdht.so` with no `SONAME`, so consumers
recorded the plain filename in `DT_NEEDED` and there was no way to
express an ABI break. This builds it as `libdht.so.0` with a matching
soname and declares `ABI_VERSION:=0`, so it is versioned like any other
shared library in the feed.

jech/dht makes no ABI promise of its own, so 0 is a packaged ABI epoch,
to be bumped if the exported surface changes. That epoch is now a single
`PKG_ABI_VERSION` variable referenced from `ABI_VERSION`, the soname, the
output filename and the symlink target, so a future bump is a one-line
edit instead of four matching edits (thanks to the review nit pointing at
`libcurl-gnutls` for the pattern).

Two smaller fixes ride along in the same commit:

* `TARGET_CFLAGS` / `TARGET_CPPFLAGS` / `TARGET_LDFLAGS` are now passed
  to the hand-written compile and link rules, which had skipped them.
* `PKG_LICENSE_FILES` said `LICENSE`, but jech/dht ships `LICENCE`, so
  the declared licence file was never actually found.

`transmission` is the only consumer in the feed. It needs no source
change -- `DHT_LIBRARY` still points at the `libdht.so` development
symlink -- but its `PKG_RELEASE` is bumped so it is rebuilt against the
versioned library.

### Testing
Built for `aarch64_cortex-a53` (mediatek/filogic):

* `libdht0-2023.03.18~0bbb8f4a-r3.apk`, `SONAME: libdht.so.0`

CI (x86_64 run on this branch) built and generic-tested the rebuilt
`transmission-daemon-4.1.3-r2.apk` (master had moved from 4.1.2 to 4.1.3
by the time CI ran, correcting the mismatch an earlier revision of this
description had against the actual 4.1.3-r2 build): it depends on
`libdht0`, "All linked libraries for /usr/lib/libdht.so.0 are present",
and "SONAME link for /usr/lib/libdht.so.0 is correct".
https://github.com/openwrt/packages/actions/runs/31609574985/job/94157294230

Not built for other architectures or libcs.
