### PR TITLE
btrfs-progs: remove no-mold flag as it builds fine with mold 2.42.0

### DIFF
--- a/utils/btrfs-progs/Makefile
+++ b/utils/btrfs-progs/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=btrfs-progs
 PKG_VERSION:=6.11
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-v$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/linux/kernel/people/kdave/btrfs-progs
@@ -21,7 +21,7 @@ PKG_LICENSE_FILES:=COPYING
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
 PKG_BUILD_DEPENDS:=acl
-PKG_BUILD_FLAGS:=gc-sections no-mold
+PKG_BUILD_FLAGS:=gc-sections
 
 include $(INCLUDE_DIR)/package.mk
 


### PR DESCRIPTION
btrfs-progs have a no-mold flag since 2025. With latest mold 2.42.0 released a few days ago and PR https://github.com/openwrt/openwrt/pull/24672 from openwrt main repo, the changes from https://github.com/openwrt/packages/issues/26541 can be reverted as btrfs-progs compiles fine with mold.