### PR TITLE
[25.12] hev-socks5-tunnel: allow multiple instances

### DIFF
--- a/net/hev-socks5-tunnel/Makefile
+++ b/net/hev-socks5-tunnel/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=hev-socks5-tunnel
 PKG_VERSION:=2.17.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/heiher/hev-socks5-tunnel/releases/download/$(PKG_VERSION)
@@ -48,6 +48,9 @@ define Package/hev-socks5-tunnel/install
 
 	$(INSTALL_DIR) $(1)/etc/init.d/
 	$(INSTALL_BIN) ./files/hev-socks5-tunnel.init $(1)/etc/init.d/hev-socks5-tunnel
+
+	$(INSTALL_DIR) $(1)/etc/uci-defaults
+	$(INSTALL_BIN) ./files/90-hev-socks5-tunnel $(1)/etc/uci-defaults/90-hev-socks5-tunnel
 endef
 
 $(eval $(call BuildPackage,hev-socks5-tunnel))

--- a/net/hev-socks5-tunnel/files/90-hev-socks5-tunnel
+++ b/net/hev-socks5-tunnel/files/90-hev-socks5-tunnel
@@ -1,0 +1,26 @@
+#!/bin/sh
+# Upgrade single-instance configuration to multi-instance format.
+
+if [ -f /etc/config/hev-socks5-tunnel ] && \
+	! uci -q get hev-socks5-tunnel.@instance[0] >/dev/null 2>&1 && \
+	uci -q get hev-socks5-tunnel.config >/dev/null 2>&1
+then
+	printf "Upgrading hev-socks5-tunnel configuration... "
+	conf_enabled="$(uci -q get hev-socks5-tunnel.config.enabled)"
+	conf_conffile="$(uci -q get hev-socks5-tunnel.config.conffile)"
+
+	if ! uci -q batch <<-EOF
+		delete hev-socks5-tunnel.config
+		add hev-socks5-tunnel instance
+		set hev-socks5-tunnel.@instance[-1].enabled='${conf_enabled:-0}'
+		set hev-socks5-tunnel.@instance[-1].conffile='${conf_conffile:-/etc/hev-socks5-tunnel/main.yml}'
+		commit hev-socks5-tunnel
+	EOF
+	then
+		printf "failed.\n"
+		exit 1
+	fi
+	printf "done.\n"
+fi
+
+exit 0

--- a/net/hev-socks5-tunnel/files/hev-socks5-tunnel.config
+++ b/net/hev-socks5-tunnel/files/hev-socks5-tunnel.config
@@ -1,3 +1,3 @@
-config hev-socks5-tunnel 'config'
+config instance
 	option enabled '0'
 	option conffile '/etc/hev-socks5-tunnel/main.yml'

--- a/net/hev-socks5-tunnel/files/hev-socks5-tunnel.init
+++ b/net/hev-socks5-tunnel/files/hev-socks5-tunnel.init
@@ -6,27 +6,31 @@ START=99
 CONF="hev-socks5-tunnel"
 PROG="/usr/bin/hev-socks5-tunnel"
 
-start_service() {
-	config_load "$CONF"
+start_instance() {
+	local enabled conffile
+	config_get_bool enabled "$1" enabled 0
+	[ "$enabled" -eq 1 ] || return 0
+	config_get conffile "$1" conffile
 
-	local enabled
-	config_get_bool enabled "config" "enabled" "0"
-	[ "$enabled" -eq "1" ] || return 1
+	if [ ! -f "$conffile" ]; then
+		logger -t "$CONF" -p daemon.err "instance '$1' not started, conffile not found: '$conffile'"
+		return 1
+	fi
 
-	local conffile
-	config_get conffile "config" "conffile"
-
-	procd_open_instance "$CONF"
+	procd_open_instance "$1"
 	procd_set_param command "$PROG" "$conffile"
 	procd_set_param file "$conffile"
-
 	procd_set_param limits core="unlimited"
 	procd_set_param limits nofile="1000000 1000000"
 	procd_set_param stdout 1
 	procd_set_param stderr 1
 	procd_set_param respawn
-
 	procd_close_instance
+}
+
+start_service() {
+	config_load "$CONF"
+	config_foreach start_instance instance
 }
 
 service_triggers() {


### PR DESCRIPTION
Add support for running multiple service instances.
- switch UCI config from a single named section to "instance" sections
- update the procd init script to start multiple instances
- migrate existing single-instance configurations during package upgrade (uci-defaults script)
- bump PKG_RELEASE


(cherry picked from commit d04b36bbba607e65072ecd0abfae5a89af468607)

## 📦 Package Details

**Maintainer:** @heiher
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12.5
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** Xiaomi Mi Router AX3000T
