### PR TITLE
rsync: update to 3.5.0

### DIFF
--- a/net/rsync/Makefile
+++ b/net/rsync/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rsync
-PKG_VERSION:=3.4.4
+PKG_VERSION:=3.5.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://download.samba.org/pub/$(PKG_NAME)/src
-PKG_HASH:=bd88cf82fa653da32314fb229136407c5c90f80d1758d8f4b091767877d8fa96
+PKG_HASH:=c7ffd1ef653e99540f661e47cb00b7f9cad1ee6b972399b16f93d672656e0d33
 
 PKG_MAINTAINER:=Maxim Storchak <m.storchak@gmail.com>
 PKG_LICENSE:=GPL-3.0-or-later


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @mstorchak
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

Changelog: https://download.samba.org/pub/rsync/NEWS#3.5.0


33 security fixes to call out in this bump:
CVE-2026-53802, CVE-2026-53803, CVE-2026-53785, CVE-2026-53784, CVE-2026-53793, CVE-2026-53795, CVE-2026-53796, CVE-2026-53797, CVE-2026-53799, CVE-2026-53800, CVE-2026-53801, CVE-2026-53783, CVE-2026-53786, CVE-2026-53798, CVE-2026-53788, CVE-2026-53789, CVE-2026-53791, CVE-2026-53790, CVE-2026-53792, CVE-2026-53794, CVE-2026-70461, CVE-2026-70458, CVE-2026-70456, CVE-2026-70457, CVE-2026-70459, CVE-2026-70464, CVE-2026-70455, CVE-2026-70453, CVE-2026-70452, CVE-2026-70463, CVE-2026-70460, CVE-2026-70462, CVE-2026-70454


---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** x86/64-glibc
- **OpenWrt Device:** Intel N150

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
