### PR TITLE
linuxptp: add config & init scripts for ptp4l and phc2sys

### DIFF
--- a/net/linuxptp/Makefile
+++ b/net/linuxptp/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=linuxptp
 PKG_VERSION:=4.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tgz
 PKG_SOURCE_URL:=https://downloads.nwtime.org/linuxptp/
@@ -38,6 +38,10 @@ define Package/linuxptp/description
  computers.
 endef
 
+define Package/linuxptp/conffiles
+/etc/config/linuxptp
+endef
+
 EXTRA_CFLAGS += -DHAVE_CLOCK_ADJTIME -DHAVE_POSIX_SPAWN -DHAVE_ONESTEP_SYNC
 
 MAKE_VARS += \
@@ -45,8 +49,23 @@ MAKE_VARS += \
 	KBUILD_OUTPUT="$(LINUX_DIR)" \
 	NO_AUTODETECT_SAD_MAC_LIB="y"
 
+define Build/Compile/sysclock-discipline-check
+	$(TARGET_CC) $(TARGET_CFLAGS) -o $(PKG_BUILD_DIR)/sysclock-discipline-check $(CURDIR)/files/sysclock-discipline-check.c $(TARGET_LDFLAGS)
+endef
+
+define Build/Compile
+	$(call Build/Compile/Default)
+	$(call Build/Compile/sysclock-discipline-check)
+endef
+
 define Package/linuxptp/install
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_DATA) $(CURDIR)/files/linuxptp.config $(1)/etc/config/linuxptp
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) $(CURDIR)/files/phc2sys.init $(1)/etc/init.d/phc2sys
+	$(INSTALL_BIN) $(CURDIR)/files/ptp4l.init $(1)/etc/init.d/ptp4l
 	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/sysclock-discipline-check $(1)/usr/sbin/
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/hwstamp_ctl $(1)/usr/sbin/
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/phc2sys $(1)/usr/sbin/
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/phc_ctl $(1)/usr/sbin/

--- a/net/linuxptp/files/linuxptp.config
+++ b/net/linuxptp/files/linuxptp.config
@@ -11,23 +11,27 @@ config ptp4l 'ptp4l' # configures the ptp4l daemon
 	#option clock_sync_check_interval '15'	# Seconds between clock discipline checks (default: 15).
 						# Only used when require_clock_sync is 1.
 
+	#option clock_sync_max_tries '8'	# Max attempts before giving up clock sync wait (default: 8, ~2 min).
+						# Set to 0 to wait indefinitely (blocks boot until clock disciplines).
+
 	# For global lines in ptp4l.conf - Each item is one line like "key value" for the [global] section
 	#list global_opts 'clockClass 6'
 
 	# For extra ptp4l command line options
 	#list extra_args ''
 
-config ptp_interface # repeat multiple times for each interface ptp4l should work on
-	#option interface 'lan'			# required - UCI's interface name, init-script looks up kernel ifname as needed
-	#option transport 'UDPv4'		# Network transport: UDPv4 (default), UDPv6, L2.
-	#option delay_mechanism 'E2E'		# PTP delay mechanism: E2E (End-to-End, default), P2P (Peer-to-Peer).
-
-	# For interface-specific sections in ptp4l.conf
-	#list interface_opts 'logSyncInterval -3'
+# At least one ptp_interface section is required for ptp4l to start.
+# Repeat this block for each interface ptp4l should listen on.
+#config ptp_interface
+#	option interface 'lan'			# required - UCI's interface name, init-script looks up kernel ifname as needed
+#	#option transport 'UDPv4'		# Network transport: UDPv4 (default), UDPv6, L2.
+#	#option delay_mechanism 'E2E'		# PTP delay mechanism: E2E (End-to-End, default), P2P (Peer-to-Peer).
+#	#list interface_opts 'logSyncInterval -3'
 
 config phc2sys 'phc2sys' # configures the phc2sys daemon, which syncs either system clock from PHC in NIC (as a client, or vice versa as a server)
-	#option phc_device '/dev/ptp0'		# PTP Hardware Clock device
-						# User should verify this is the correct PHC for their PTP interface
+	#option phc_device '/dev/ptp0'		# PTP Hardware Clock device - required, no default.
+						# Verify this matches the PHC for your PTP interface (e.g. /dev/ptp0).
+						# phc2sys will not start until this is set.
 	# specifies clock sync'ing direction 	# 'phc_to_sys': PHC (sync'd by ptp4l) disciplines system clock (default unless ptp4l role is 'server')
 	#option sync_direction 'phc_to_sys'	# 'sys_to_phc': System clock disciplines PHC (default if ptp4l's role is 'server')
 

--- a/net/linuxptp/files/linuxptp.config
+++ b/net/linuxptp/files/linuxptp.config
@@ -1,0 +1,34 @@
+config ptp4l 'ptp4l' # configures the ptp4l daemon
+	#option role 'auto'			# role to use: 'auto' (default) - BMCA algo determines role
+						# 'client' - will never attempt to be a server
+						# 'server' - will never attempt to be a client
+
+	#option loglevel '6'			# Logging verbosity for ptp4l (0-7). 6=INFO (default), 7=DEBUG.
+
+	#option require_clock_sync '0'		# 0 - skip waiting for kernel to report clock is sync'd (default unless server)
+						# 1 - require clock-in-sync check before starting (default if server)
+
+	# For global lines in ptp4l.conf - Each item is one line like "key value" for the [global] section
+	#list global_opts 'clockClass 6'
+
+config ptp_interface # repeat multiple times for each interface ptp4l should work on
+	option interface 'lan'			# required - UCI's interface name, init-script looks up kernel ifname as needed
+	#option transport 'UDPv4'		# Network transport: UDPv4 (default), UDPv6, L2.
+	#option delay_mechanism 'E2E'		# PTP delay mechanism: E2E (End-to-End, default), P2P (Peer-to-Peer).
+
+	# For interface-specific sections in ptp4l.conf
+	#list interface_opts 'logSyncInterval -3'
+
+config phc2sys 'phc2sys' # configures the phc2sys daemon, which syncs either system clock from PHC in NIC (as a client, or vice versa as a server)
+	#option phc_device '/dev/ptp0'		# PTP Hardware Clock device
+						# User should verify this is the correct PHC for their PTP interface
+	# specifies clock sync'ing direction 	# 'phc_to_sys': PHC (sync'd by ptp4l) disciplines system clock (default unless ptp4l role is 'server')
+	#option sync_direction 'phc_to_sys'	# 'sys_to_phc': System clock disciplines PHC (default if ptp4l's role is 'server')
+
+	#option loglevel '5'			# Logging verbosity for phc2sys, 5 by default, 6 if stats_interval is set
+
+	#option stats_interval '0'		# Log status updates every N seconds (N defaults to 1 when -R param (by-default) is 1Hz).
+						# By default/if unset, log-level (above) will be set to 5 and these messages will not be seen
+
+	list extra_args ''			# For other phc2sys command line options.
+						# Example: list extra_args '-O 0'

--- a/net/linuxptp/files/linuxptp.config
+++ b/net/linuxptp/files/linuxptp.config
@@ -11,7 +11,8 @@ config ptp4l 'ptp4l' # configures the ptp4l daemon
 	#option clock_sync_check_interval '15'	# Seconds between clock discipline checks (default: 15).
 						# Only used when require_clock_sync is 1.
 
-	#option clock_sync_max_tries '8'	# Max attempts before giving up clock sync wait (default: 8, ~2 min).
+	#option clock_sync_max_tries '8'	# Max attempts before giving up clock sync wait (default: 8).
+						# Total wait = clock_sync_check_interval x (tries - 1), ~105s at defaults.
 						# Set to 0 to wait indefinitely (blocks boot until clock disciplines).
 
 	# For global lines in ptp4l.conf - Each item is one line like "key value" for the [global] section

--- a/net/linuxptp/files/linuxptp.config
+++ b/net/linuxptp/files/linuxptp.config
@@ -8,11 +8,17 @@ config ptp4l 'ptp4l' # configures the ptp4l daemon
 	#option require_clock_sync '0'		# 0 - skip waiting for kernel to report clock is sync'd (default unless server)
 						# 1 - require clock-in-sync check before starting (default if server)
 
+	#option clock_sync_check_interval '15'	# Seconds between clock discipline checks (default: 15).
+						# Only used when require_clock_sync is 1.
+
 	# For global lines in ptp4l.conf - Each item is one line like "key value" for the [global] section
 	#list global_opts 'clockClass 6'
 
+	# For extra ptp4l command line options
+	#list extra_args ''
+
 config ptp_interface # repeat multiple times for each interface ptp4l should work on
-	option interface 'lan'			# required - UCI's interface name, init-script looks up kernel ifname as needed
+	#option interface 'lan'			# required - UCI's interface name, init-script looks up kernel ifname as needed
 	#option transport 'UDPv4'		# Network transport: UDPv4 (default), UDPv6, L2.
 	#option delay_mechanism 'E2E'		# PTP delay mechanism: E2E (End-to-End, default), P2P (Peer-to-Peer).
 
@@ -30,5 +36,5 @@ config phc2sys 'phc2sys' # configures the phc2sys daemon, which syncs either sys
 	#option stats_interval '0'		# Log status updates every N seconds (N defaults to 1 when -R param (by-default) is 1Hz).
 						# By default/if unset, log-level (above) will be set to 5 and these messages will not be seen
 
-	list extra_args ''			# For other phc2sys command line options.
+	#list extra_args ''			# For other phc2sys command line options.
 						# Example: list extra_args '-O 0'

--- a/net/linuxptp/files/phc2sys.init
+++ b/net/linuxptp/files/phc2sys.init
@@ -19,7 +19,8 @@ make_cmdline() {
 
 	echo $PROG
 
-	config_get dev $cfg "phc_device" "/dev/ptp0"
+	config_get dev $cfg "phc_device" ""
+	[ -z "$dev" ] && { log err "phc_device not configured. Set 'option phc_device' in /etc/config/linuxptp."; return 1; }
 	! [ -c "$dev" ] && { log crit "PHC device '$dev' not found!"; return 1; }
 
 	dir='phc_to_sys'

--- a/net/linuxptp/files/phc2sys.init
+++ b/net/linuxptp/files/phc2sys.init
@@ -1,0 +1,68 @@
+#!/bin/sh /etc/rc.common
+# Init script for phc2sys from linuxptp
+
+START=55
+USE_PROCD=1
+PROG=/usr/sbin/phc2sys
+
+ID=phc2sys
+ID_PTP4L=ptp4l
+
+log() {
+	local loglevel=$1; shift; local msg="$*"
+	logger -t phc2sys-init -p daemon.$loglevel "$msg"
+}
+
+make_cmdline() {
+	local cfg=$1
+	local args dev dir loglevel ptp4l_role stats_set syncdir
+
+	echo $PROG
+
+	config_get dev $cfg "phc_device" "/dev/ptp0"
+	! [ -c "$dev" ] && { log crit "PHC device '$dev' not found!"; return 1; }
+
+	dir='phc_to_sys'
+	config_get ptp4l_role $ID_PTP4L "role" "auto"
+	[ "$ptp4l_role" = "server" ] && dir='sys_to_phc'
+
+	config_get syncdir $cfg "sync_direction" "$dir"
+	if [ "$syncdir" = "phc_to_sys" ]; then
+		echo "-s $dev -w"
+	elif [ "$syncdir" = "sys_to_phc" ]; then
+		echo "-s CLOCK_REALTIME -c $dev -w -O 0"
+	else
+		log err "Invalid sync_direction '$syncdir'! valid values: 'sys_to_phc', 'phc_to_sys'"; return 1
+	fi
+
+	echo "-m"
+	echo "-q"
+
+	config_get stats_set $cfg "stats_interval" "0"
+	[ "$stats_set" -ge 1 ] && echo "-u $stats_set"
+
+	config_get loglevel $cfg "loglevel" "5"
+	[ "$stats_set" -ge 1 ] && config_get loglevel $cfg "loglevel" "6"
+	echo "-l $loglevel"
+
+	config_list_foreach $cfg "extra_args" echo
+}
+
+start_service() {
+	local cmdline
+
+	config_load linuxptp
+
+	cmdline=$(make_cmdline $ID)
+	log info "Starting phc2sys: $cmdline"
+
+	procd_open_instance phc2sys
+	procd_set_param command $cmdline
+	procd_set_param stdout 1
+	procd_set_param stderr 1
+	procd_close_instance
+}
+
+stop_service() {
+	log info "phc2sys exitting (if running)."
+}

--- a/net/linuxptp/files/phc2sys.init
+++ b/net/linuxptp/files/phc2sys.init
@@ -20,7 +20,7 @@ make_cmdline() {
 	echo $PROG
 
 	config_get dev $cfg "phc_device" ""
-	[ -z "$dev" ] && { log err "phc_device not configured. Set 'option phc_device' in /etc/config/linuxptp."; return 1; }
+	[ -z "$dev" ] && { log notice "phc_device not configured, phc2sys not starting. Set 'option phc_device' in /etc/config/linuxptp."; return 1; }
 	! [ -c "$dev" ] && { log crit "PHC device '$dev' not found!"; return 1; }
 
 	dir='phc_to_sys'

--- a/net/linuxptp/files/phc2sys.init
+++ b/net/linuxptp/files/phc2sys.init
@@ -48,12 +48,16 @@ make_cmdline() {
 	config_list_foreach $cfg "extra_args" echo
 }
 
+service_triggers() {
+	procd_add_reload_trigger "linuxptp"
+}
+
 start_service() {
 	local cmdline
 
 	config_load linuxptp
 
-	cmdline=$(make_cmdline $ID)
+	cmdline=$(make_cmdline $ID) || return 1
 	log info "Starting phc2sys: $cmdline"
 
 	procd_open_instance phc2sys
@@ -64,5 +68,5 @@ start_service() {
 }
 
 stop_service() {
-	log info "phc2sys exitting (if running)."
+	log info "phc2sys exiting (if running)."
 }

--- a/net/linuxptp/files/ptp4l.init
+++ b/net/linuxptp/files/ptp4l.init
@@ -152,8 +152,8 @@ start_service() {
 
 	# Fast pre-check: fail immediately if no ptp_interface sections exist in UCI,
 	# before potentially spending minutes in the clock-sync wait.
-	if ! uci -q get linuxptp.@ptp_interface[0] >/dev/null 2>&1; then
-		log notice "No ptp_interface sections configured in /etc/config/linuxptp. ptp4l will not start."
+	if ! uci -q get linuxptp.@ptp_interface[0].interface >/dev/null 2>&1; then
+		log notice "No ptp_interface section with an 'interface' option configured in /etc/config/linuxptp. ptp4l will not start."
 		return 1
 	fi
 

--- a/net/linuxptp/files/ptp4l.init
+++ b/net/linuxptp/files/ptp4l.init
@@ -54,7 +54,11 @@ wait_disciplined() {
 				log err "Increase 'clock_sync_max_tries' or set 'require_clock_sync 0' to skip."
 				return 1
 			fi
-			log info "sysclock-discipline-check: $check_msg. Waiting... ($tries/$max_tries)"
+			if [ "$max_tries" -gt 0 ]; then
+				log info "sysclock-discipline-check: $check_msg. Waiting... ($tries/$max_tries)"
+			else
+				log info "sysclock-discipline-check: $check_msg. Waiting... (attempt $tries, unlimited)"
+			fi
 		else
 			log crit "Clock sync check FAILED: $check_msg."
 			log err "ptp4l will NOT start. Resolve issue, or set 'require_clock_sync' to 0"
@@ -118,7 +122,7 @@ make_configfile() {
 	# Require at least one [interface] section beyond [global]
 	iface_count=$(grep -c '^\[' "$CONFIGFILE" 2>/dev/null)
 	if [ "${iface_count:-0}" -lt 2 ]; then
-		log err "No PTP interfaces configured. Add a 'config ptp_interface' section to /etc/config/linuxptp."
+		log notice "No PTP interfaces configured. Add a 'config ptp_interface' section to /etc/config/linuxptp."
 		return 1
 	fi
 }
@@ -145,6 +149,13 @@ start_service() {
 	local clocksync_wanted cmdline rc role should_have_disciplined_clock=0
 
 	config_load linuxptp
+
+	# Fast pre-check: fail immediately if no ptp_interface sections exist in UCI,
+	# before potentially spending minutes in the clock-sync wait.
+	if ! uci -q get linuxptp.@ptp_interface[0] >/dev/null 2>&1; then
+		log notice "No ptp_interface sections configured in /etc/config/linuxptp. ptp4l will not start."
+		return 1
+	fi
 
 	config_get role $ID "role" "auto"
 	[ "$role" = "server" ] && should_have_disciplined_clock=1

--- a/net/linuxptp/files/ptp4l.init
+++ b/net/linuxptp/files/ptp4l.init
@@ -150,9 +150,9 @@ start_service() {
 
 	config_load linuxptp
 
-	# Fast pre-check: fail immediately if no ptp_interface sections exist in UCI,
-	# before potentially spending minutes in the clock-sync wait.
-	if ! uci -q get linuxptp.@ptp_interface[0].interface >/dev/null 2>&1; then
+	# Fast pre-check: fail immediately if no ptp_interface section carries a
+	# non-empty 'interface' option, before spending minutes in the clock-sync wait below.
+	if [ -z "$(uci -q get linuxptp.@ptp_interface[0].interface)" ]; then
 		log notice "No ptp_interface section with an 'interface' option configured in /etc/config/linuxptp. ptp4l will not start."
 		return 1
 	fi

--- a/net/linuxptp/files/ptp4l.init
+++ b/net/linuxptp/files/ptp4l.init
@@ -38,7 +38,7 @@ wait_disciplined() {
 	config_get role $ID "role" ""
 	config_get interval $ID "clock_sync_check_interval" "15"
 
-	log info "Preparing to start with role:$role -> first checking if system clock is disciplined (has been syncronized)..."
+	log info "Preparing to start with role:$role -> first checking if system clock is disciplined (has been synchronized)..."
 	while [ $is_synced -eq 0 ]; do
 		check_msg=$(is_clock_disciplined); rc=$?
 
@@ -61,18 +61,18 @@ handle_interface() {
 	local cfg=$1 delay_mechanism interface ifname transport
 
 	config_get interface $cfg "interface" ""
-	[ -z $interface ] && { log err "Required 'interface' option missing in 'ptp_interface' section"; exit 1; }
+	[ -z "$interface" ] && { log err "Required 'interface' option missing in 'ptp_interface' section"; exit 1; }
 
-	network_get_device ifname $interface
-	[ -z $ifname ] && { log err "Cannot resolve UCI interface '$interface' to kernel-compatible ifname."; exit 1; }
+	network_get_device ifname "$interface"
+	[ -z "$ifname" ] && { log err "Cannot resolve UCI interface '$interface' to kernel-compatible ifname."; exit 1; }
 
 	config_get transport $cfg "transport" "UDPv4"
 	config_get delay_mechanism $cfg "delay_mechanism" "E2E"
 
 	echo ""
 	echo "[$ifname]"
-	[ $transport != "UDPv4" ] && echo "network_transport $transport"
-	[ $delay_mechanism != "E2E" ] && echo "delay_mechanism $delay_mechanism"
+	[ "$transport" != "UDPv4" ] && echo "network_transport $transport"
+	[ "$delay_mechanism" != "E2E" ] && echo "delay_mechanism $delay_mechanism"
 	config_list_foreach $cfg "interface_opts" echo
 }
 
@@ -98,6 +98,8 @@ make_configfile() {
 
 	. /lib/functions/network.sh
 
+	mkdir -p "${CONFIGFILE%/*}"
+
 	(
 		handle_global $cfg || exit 1
 		config_foreach handle_interface ptp_interface
@@ -121,12 +123,32 @@ make_cmdline() {
 	config_list_foreach $cfg "extra_args" echo
 }
 
+service_triggers() {
+	procd_add_reload_trigger "linuxptp"
+}
+
 start_service() {
-	local clocksync_wanted rc role should_have_disciplined_clock=0
+	local clocksync_wanted cmdline rc role should_have_disciplined_clock=0
 
 	config_load linuxptp
 
+	config_get role $ID "role" "auto"
+	[ "$role" = "server" ] && should_have_disciplined_clock=1
+	config_get_bool clocksync_wanted $ID "require_clock_sync" "$should_have_disciplined_clock"
+
+	if [ "$clocksync_wanted" = 1 ]; then
+		wait_disciplined || return 1
+	fi
+
+	make_configfile $ID; rc=$?
+	if [ $rc -ne 0 ] || [ ! -s "$CONFIGFILE" ]; then
+		log err "Failed to generate $CONFIGFILE. Aborting."
+		rm -f "$CONFIGFILE"
+		return 1
+	fi
+
 	cmdline=$(make_cmdline $ID)
+	log info "Starting ptp4l: $cmdline"
 
 	procd_open_instance "ptp4l"
 	procd_set_param command $cmdline
@@ -134,25 +156,9 @@ start_service() {
 	procd_set_param stdout 1
 	procd_set_param stderr 1
 	procd_close_instance
-
-	config_get role $ID "role" "auto"
-	[ $role = "server" ] && should_have_disciplined_clock=1
-	config_get_bool clocksync_wanted $ID "require_clock_sync" "$should_have_disciplined_clock"
-
-	if [ $clocksync_wanted = 1 ]; then
-		wait_disciplined || return 1
-	fi
-
-	make_configfile $ID; rc=$?
-	if [ $rc -ne 0 ] || [ ! -s $CONFIGFILE ]; then
-		log err "Failed to generate $CONFIGFILE. Aborting."
-		rm -f $CONFIGFILE
-		return 1
-	fi
-
-	log info "Starting ptp4l: $cmdline"
 }
 
 stop_service() {
-	log info "ptp4l exitting (if running)"
+	rm -f "$CONFIGFILE"
+	log info "ptp4l exiting (if running)"
 }

--- a/net/linuxptp/files/ptp4l.init
+++ b/net/linuxptp/files/ptp4l.init
@@ -1,0 +1,158 @@
+#!/bin/sh /etc/rc.common
+# Init script for ptp4l daemon, from linuxptp package
+
+START=45
+USE_PROCD=1
+
+PROG=/usr/sbin/ptp4l
+HELPER=/usr/sbin/sysclock-discipline-check
+CONFIGFILE=/var/etc/ptp4l.conf
+
+ID=ptp4l
+
+log() {
+	local loglevel=$1; shift; local msg="$*"
+	logger -t ptp4l-init -p daemon.$loglevel "$msg"
+}
+
+is_clock_disciplined() {
+	local output rc
+
+	if ! [ -x "$HELPER" ]; then
+		echo "Helper $HELPER not found or not executable." >&2
+		echo "Error: Clock sync helper tool missing."
+		return 2
+	fi
+
+	output=$($HELPER)
+	rc=$?
+	echo $output
+
+	[ $rc -eq 2 ] && log err "ERROR: $HELPER call unsuccessful (rc=$rc): $output"
+	return $rc
+}
+
+wait_disciplined() {
+	local check_msg interval is_synced=0 rc role
+
+	config_get role $ID "role" ""
+	config_get interval $ID "clock_sync_check_interval" "15"
+
+	log info "Preparing to start with role:$role -> first checking if system clock is disciplined (has been syncronized)..."
+	while [ $is_synced -eq 0 ]; do
+		check_msg=$(is_clock_disciplined); rc=$?
+
+		if [ $rc -eq 0 ]; then
+			is_synced=1
+			log info "sysclock-discipline-check: $check_msg. Continuing."
+			return 0
+		elif [ $rc -eq 1 ]; then
+			log info "sysclock-discipline-check: $check_msg. Waiting..."
+		else
+			log crit "Clock sync check FAILED: $check_msg."
+			log err "ptp4l will NOT start. Resolve issue, or set 'require_clock_sync' to 0"
+			return 1
+		fi
+		sleep $interval
+	done
+}
+
+handle_interface() {
+	local cfg=$1 delay_mechanism interface ifname transport
+
+	config_get interface $cfg "interface" ""
+	[ -z $interface ] && { log err "Required 'interface' option missing in 'ptp_interface' section"; exit 1; }
+
+	network_get_device ifname $interface
+	[ -z $ifname ] && { log err "Cannot resolve UCI interface '$interface' to kernel-compatible ifname."; exit 1; }
+
+	config_get transport $cfg "transport" "UDPv4"
+	config_get delay_mechanism $cfg "delay_mechanism" "E2E"
+
+	echo ""
+	echo "[$ifname]"
+	[ $transport != "UDPv4" ] && echo "network_transport $transport"
+	[ $delay_mechanism != "E2E" ] && echo "delay_mechanism $delay_mechanism"
+	config_list_foreach $cfg "interface_opts" echo
+}
+
+handle_global() {
+	local cfg=$1 role
+
+	config_get role $cfg "role" "auto"
+
+	echo "[global]"
+
+	case "$role" in
+		server) printf "serverOnly 1\n";;
+		client) printf "clientOnly 1\n";;
+		auto) printf "";;
+		*) log err "Invalid role: $role! valid values: 'auto', 'client', 'server'"; return 1;;
+	esac
+
+	config_list_foreach $cfg "global_opts" echo
+}
+
+make_configfile() {
+	local cfg=$1 rc
+
+	. /lib/functions/network.sh
+
+	(
+		handle_global $cfg || exit 1
+		config_foreach handle_interface ptp_interface
+	) > "$CONFIGFILE"
+	rc=$?
+
+	return $rc
+}
+
+make_cmdline() {
+	local cfg=$1 loglevel
+
+	config_get loglevel $cfg "loglevel" "6"
+
+	echo $PROG
+	echo "-l $loglevel"
+	echo "-f $CONFIGFILE"
+	echo "-m"
+	echo "-q"
+
+	config_list_foreach $cfg "extra_args" echo
+}
+
+start_service() {
+	local clocksync_wanted rc role should_have_disciplined_clock=0
+
+	config_load linuxptp
+
+	cmdline=$(make_cmdline $ID)
+
+	procd_open_instance "ptp4l"
+	procd_set_param command $cmdline
+	procd_set_param file $CONFIGFILE
+	procd_set_param stdout 1
+	procd_set_param stderr 1
+	procd_close_instance
+
+	config_get role $ID "role" "auto"
+	[ $role = "server" ] && should_have_disciplined_clock=1
+	config_get_bool clocksync_wanted $ID "require_clock_sync" "$should_have_disciplined_clock"
+
+	if [ $clocksync_wanted = 1 ]; then
+		wait_disciplined || return 1
+	fi
+
+	make_configfile $ID; rc=$?
+	if [ $rc -ne 0 ] || [ ! -s $CONFIGFILE ]; then
+		log err "Failed to generate $CONFIGFILE. Aborting."
+		rm -f $CONFIGFILE
+		return 1
+	fi
+
+	log info "Starting ptp4l: $cmdline"
+}
+
+stop_service() {
+	log info "ptp4l exitting (if running)"
+}

--- a/net/linuxptp/files/ptp4l.init
+++ b/net/linuxptp/files/ptp4l.init
@@ -33,13 +33,15 @@ is_clock_disciplined() {
 }
 
 wait_disciplined() {
-	local check_msg interval is_synced=0 rc role
+	local check_msg interval is_synced=0 max_tries rc role tries=0
 
 	config_get role $ID "role" ""
 	config_get interval $ID "clock_sync_check_interval" "15"
+	config_get max_tries $ID "clock_sync_max_tries" "8"
 
-	log info "Preparing to start with role:$role -> first checking if system clock is disciplined (has been synchronized)..."
+	log info "Preparing to start with role:$role -> checking if system clock is disciplined..."
 	while [ $is_synced -eq 0 ]; do
+		tries=$((tries + 1))
 		check_msg=$(is_clock_disciplined); rc=$?
 
 		if [ $rc -eq 0 ]; then
@@ -47,7 +49,12 @@ wait_disciplined() {
 			log info "sysclock-discipline-check: $check_msg. Continuing."
 			return 0
 		elif [ $rc -eq 1 ]; then
-			log info "sysclock-discipline-check: $check_msg. Waiting..."
+			if [ "$max_tries" -gt 0 ] && [ "$tries" -ge "$max_tries" ]; then
+				log err "Clock sync wait timed out after $tries attempts. ptp4l will NOT start."
+				log err "Increase 'clock_sync_max_tries' or set 'require_clock_sync 0' to skip."
+				return 1
+			fi
+			log info "sysclock-discipline-check: $check_msg. Waiting... ($tries/$max_tries)"
 		else
 			log crit "Clock sync check FAILED: $check_msg."
 			log err "ptp4l will NOT start. Resolve issue, or set 'require_clock_sync' to 0"
@@ -94,7 +101,7 @@ handle_global() {
 }
 
 make_configfile() {
-	local cfg=$1 rc
+	local cfg=$1 iface_count rc
 
 	. /lib/functions/network.sh
 
@@ -106,7 +113,14 @@ make_configfile() {
 	) > "$CONFIGFILE"
 	rc=$?
 
-	return $rc
+	[ $rc -ne 0 ] && return 1
+
+	# Require at least one [interface] section beyond [global]
+	iface_count=$(grep -c '^\[' "$CONFIGFILE" 2>/dev/null)
+	if [ "${iface_count:-0}" -lt 2 ]; then
+		log err "No PTP interfaces configured. Add a 'config ptp_interface' section to /etc/config/linuxptp."
+		return 1
+	fi
 }
 
 make_cmdline() {
@@ -141,7 +155,7 @@ start_service() {
 	fi
 
 	make_configfile $ID; rc=$?
-	if [ $rc -ne 0 ] || [ ! -s "$CONFIGFILE" ]; then
+	if [ $rc -ne 0 ]; then
 		log err "Failed to generate $CONFIGFILE. Aborting."
 		rm -f "$CONFIGFILE"
 		return 1

--- a/net/linuxptp/files/sysclock-discipline-check.c
+++ b/net/linuxptp/files/sysclock-discipline-check.c
@@ -1,0 +1,30 @@
+/*
+ * Helper utility to query the kernel for the synchronization status of the
+ * system clock (CLOCK_REALTIME) via adjtimex(). Used by the ptp4l init script
+ * to delay startup in server mode until the clock is known to be accurate.
+ *
+ * Exit codes: 0 = synchronized, 1 = unsynchronized, 2 = error
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/timex.h>
+
+int main() {
+    struct timex txc;
+
+    txc.modes = 0;
+
+    if (adjtimex(&txc) < 0) {
+        perror("adjtimex failed");
+        return 2;
+    }
+
+    if (txc.status & STA_UNSYNC) {
+        fprintf(stdout, "Clock status: 0x%04X (STA_UNSYNC is SET - Unsynchronized)\n", txc.status);
+        return 1;
+    } else {
+        fprintf(stdout, "Clock status: 0x%04X (STA_UNSYNC is CLEAR - Synchronized)\n", txc.status);
+        return 0;
+    }
+}

--- a/net/linuxptp/files/sysclock-discipline-check.c
+++ b/net/linuxptp/files/sysclock-discipline-check.c
@@ -7,13 +7,13 @@
  */
 
 #include <stdio.h>
-#include <stdlib.h>
+#include <string.h>
 #include <sys/timex.h>
 
-int main() {
+int main(void) {
     struct timex txc;
 
-    txc.modes = 0;
+    memset(&txc, 0, sizeof(txc));
 
     if (adjtimex(&txc) < 0) {
         perror("adjtimex failed");
@@ -21,10 +21,10 @@ int main() {
     }
 
     if (txc.status & STA_UNSYNC) {
-        fprintf(stdout, "Clock status: 0x%04X (STA_UNSYNC is SET - Unsynchronized)\n", txc.status);
+        fprintf(stdout, "Clock status: 0x%04X (STA_UNSYNC is SET - Unsynchronized)\n", (unsigned int)txc.status);
         return 1;
     } else {
-        fprintf(stdout, "Clock status: 0x%04X (STA_UNSYNC is CLEAR - Synchronized)\n", txc.status);
+        fprintf(stdout, "Clock status: 0x%04X (STA_UNSYNC is CLEAR - Synchronized)\n", (unsigned int)txc.status);
         return 0;
     }
 }


### PR DESCRIPTION
This adds UCI configuration and init scripts for the `ptp4l` and `phc2sys`
daemons included in the linuxptp package, addressing #26546.

## What's included

- **`/etc/config/linuxptp`** - UCI config with sections for `ptp4l`,
  `ptp_interface` (repeatable, one per NIC), and `phc2sys`
- **`/etc/init.d/ptp4l`** - procd init script; generates `ptp4l.conf`
  dynamically from UCI, supports `auto`/`client`/`server` roles
- **`/etc/init.d/phc2sys`** - procd init script; auto-selects sync
  direction based on ptp4l's configured role
- **`sysclock-discipline-check`** - small C utility (compiled and
  installed to `/usr/sbin/`) that queries `adjtimex()` to check whether
  the kernel considers the system clock synchronized. Used to delay ptp4l
  startup in `server` mode on systems without an RTC (prevents
  broadcasting wildly incorrect timestamps at boot). The linuxptp
  upstream mailing list confirmed this responsibility belongs with the
  init system, not with ptp4l itself.

## Changes vs the previous PR (#26600)

- Fixed `loglvl` -> `loglevel` in both init scripts (config option name
  now matches the documented UCI option in `linuxptp.config`)
- Removed redundant `wanted_stats` variable in `phc2sys.init`; the real
  gate is `stats_interval >= 1`, which is now checked directly
- Quoted variable expansions in shell conditionals
- Commit message body lines wrapped at 72 characters

Closes: #26546
