### PR TITLE
k3screenctrl: add new package

### DIFF
--- a/utils/k3screenctrl/Makefile
+++ b/utils/k3screenctrl/Makefile
@@ -1,0 +1,57 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=k3screenctrl
+PKG_VERSION:=1.0
+PKG_RELEASE:=1
+
+PKG_LICENSE:=GPL-2.0-only
+PKG_LICENSE_FILES:=COPYING
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://github.com/kazutoiris/k3screenctrl/archive/refs/tags/v$(PKG_VERSION).tar.gz?
+PKG_HASH:=cc9927f324ce7e221a2ac3351ec78156719195662cc5bafd5424d340c170cd39
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
+PKG_MAINTAINER:=Kazuto Iris <hitomi@apache.org>, Hamster Tian <haotia@gmail.com>
+PKG_BUILD_DEPENDS:=automake
+PKG_FIXUP:=autoreconf
+
+include $(INCLUDE_DIR)/package.mk
+
+TARGET_CFLAGS+= -D_GNU_SOURCE
+
+define Package/k3screenctrl
+  SECTION:=utils
+  CATEGORY:=Utilities
+  DEPENDS:=+coreutils-od +bash +curl @TARGET_bcm53xx_generic_DEVICE_phicomm_k3
+  TITLE:=LCD screen controller on PHICOMM K3
+  URL:=https://github.com/kazutoiris/k3screenctrl.git
+endef
+
+define Package/k3screenctrl/description
+  K3 Screen Controller (k3screenctrl) is a program utilizing the LCD screen on PHICOMM K3 to display some stats.
+endef
+
+define Package/k3screenctrl/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_DIR) $(1)/lib/k3screenctrl
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_DIR) $(1)/lib/k3screenctrl/oui
+	$(INSTALL_DIR) $(1)/etc/config
+
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/k3screenctrl $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/lib/k3screenctrl/wan.sh $(1)/lib/k3screenctrl/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/lib/k3screenctrl/wifi.sh $(1)/lib/k3screenctrl/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/lib/k3screenctrl/port.sh $(1)/lib/k3screenctrl/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/lib/k3screenctrl/basic.sh $(1)/lib/k3screenctrl/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/lib/k3screenctrl/host.sh $(1)/lib/k3screenctrl/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/lib/k3screenctrl/weather.sh $(1)/lib/k3screenctrl/
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/lib/k3screenctrl/oui/oui.txt $(1)/lib/k3screenctrl/oui/
+
+	$(INSTALL_BIN) ./files/k3screenctrl.init $(1)/etc/init.d/k3screenctrl
+	$(INSTALL_CONF) ./files/k3screenctrl.config $(1)/etc/config/k3screenctrl
+endef
+
+define Package/k3screenctrl/conffiles
+/etc/config/k3screenctrl
+endef
+
+$(eval $(call BuildPackage,k3screenctrl))

--- a/utils/k3screenctrl/files/k3screenctrl.config
+++ b/utils/k3screenctrl/files/k3screenctrl.config
@@ -1,0 +1,4 @@
+config general
+	option screen_time '30'
+	option refresh_time '2'
+	option psk_hide '0'

--- a/utils/k3screenctrl/files/k3screenctrl.init
+++ b/utils/k3screenctrl/files/k3screenctrl.init
@@ -1,0 +1,28 @@
+#!/bin/sh /etc/rc.common
+
+START=99
+STOP=99
+
+USE_PROCD=1
+PROG=/usr/bin/k3screenctrl
+
+start_service() {
+	local m d
+	m=$(uci -q get k3screenctrl.@general[0].screen_time)
+	d=$(uci -q get k3screenctrl.@general[0].refresh_time)
+	case "$m" in ''|*[!0-9]*) m=10 ;; esac
+	case "$d" in ''|*[!0-9]*) d=2 ;; esac
+	[ "$m" -lt 10 ] && m=10
+	[ "$d" -lt 1 ] && d=1
+
+	procd_open_instance
+	procd_set_param command "$PROG" -m "$m" -d "$d"
+	procd_set_param respawn
+	procd_set_param stdout 1
+	procd_set_param stderr 1
+	procd_close_instance
+}
+
+service_triggers() {
+	procd_add_config_trigger "config.change" "k3screenctrl" /etc/init.d/k3screenctrl reload
+}


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @kazutoiris

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

k3screenctrl is the package that drives the screen of Phicomm K3. If it is not installed, the screen will always stay on and display "Rebooting". Therefore, this package is essential for all Phicomm K3 users.

Over the past ***10 years***, this package was hosted in different maintainers' repositories, and all users have to search and compile it on their own.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 24.10 & 25.12
- **OpenWrt Target/Subtarget:** bcm53xx_generic-phicomm_k3
- **OpenWrt Device:** Phicomm K3
- **Build Action:** [#31494274691](https://github.com/kazutoiris/k3screenctrl-build/actions/runs/31494274691)

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

