### PR TITLE
croc: update to v11.2.2

### DIFF
--- a/net/croc/Makefile
+++ b/net/croc/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=croc
-PKG_VERSION:=10.3.1
+PKG_VERSION:=11.2.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/schollz/croc/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=098f9f7295843b09378dd49877ef189aaafac8e6255a346a5f1f9ce310538312
+PKG_HASH:=474b25626986649fcfaa2a336a0fdecd29132b525270aeabfb57122cf4256f5a
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
@@ -21,7 +21,7 @@ PKG_BUILD_DEPENDS:=golang/host
 PKG_BUILD_PARALLEL:=1
 PKG_BUILD_FLAGS:=no-mips16
 
-GO_PKG:=github.com/schollz/croc/v10
+GO_PKG:=github.com/schollz/croc/v11
 GO_PKG_BUILD_PKG:=$(GO_PKG)
 GO_PKG_LDFLAGS_X:=$(GO_PKG)/src/cli.Version=v$(PKG_VERSION)
 


### PR DESCRIPTION
A lot of changes and commits across various release tags. Full diff can be found at https://github.com/schollz/croc/compare/v10.3.1...v11.2.2

Not updated to latest version since it requires Go 1.27 from 11.2.3 onwards.