### PR TITLE
nodogsplash: minor cleanup

### DIFF
--- a/net/nodogsplash/Makefile
+++ b/net/nodogsplash/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nodogsplash
 PKG_VERSION:=5.0.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/nodogsplash/nodogsplash/tar.gz/v$(PKG_VERSION)?

--- a/net/nodogsplash/files/etc/init.d/nodogsplash
+++ b/net/nodogsplash/files/etc/init.d/nodogsplash
@@ -9,9 +9,6 @@ STOP=95
 
 USE_PROCD=1
 
-IPT=/usr/sbin/iptables
-WD_DIR=/usr/bin
-
 # Run in PROCD (-f) and log to SYSLOG (-s)
 OPTIONS="-f -s"
 #
@@ -77,7 +74,7 @@ setup_firewall() {
 
   for rule in authenticated-users preauthenticated-users users-to-router trusted-users trusted-users-to-router; do
     # uci does not allow dashes
-    uci_name=${rule//-/_}
+    uci_name=$(echo "$rule" | tr - _)
     addline "FirewallRuleSet $rule {"
     config_list_foreach "$cfg" "$uci_name" append_firewall
     addline "}"
@@ -158,7 +155,7 @@ generate_uci_config() {
   for option in fasport fasremoteip faspath fas_secure_enabled ; do
     config_get val "$cfg" "$option"
     if [ -n "$val" ]; then
-      echo "Warning: nodogsplash does not support $option"
+      echo "Warning: nodogsplash does not support $option" >&2
       return 1
     fi
   done

--- a/net/nodogsplash/files/usr/lib/nodogsplash/restart.sh
+++ b/net/nodogsplash/files/usr/lib/nodogsplash/restart.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Check if nodogsplash is running
-if ndsctl status &> /dev/null; then
+if ndsctl status >/dev/null 2>&1; then
   if [ "$(uci -q get nodogsplash.@nodogsplash[0].fwhook_enabled)" = "1" ]; then
     /etc/init.d/nodogsplash restart
   fi


### PR DESCRIPTION
A few minor cleanup changes:

- redirect warning message that causes abort to stderr
- replace bashism &>
- remove unused variables IPT and WD_DIR

## 📦 Package Details

**Maintainer:** @mwarning 

**Description:**
Followup from https://github.com/openwrt/packages/pull/30169

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

Not tested yet!

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch: