### PR TITLE
dockerd: skip copy nested binaries

### DIFF
--- a/utils/dockerd/Makefile
+++ b/utils/dockerd/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dockerd
 PKG_VERSION:=29.6.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 PKG_CPE_ID:=cpe:/a:mobyproject:moby

--- a/utils/dockerd/patches/001-skip-copy-nested-binaries.patch
+++ b/utils/dockerd/patches/001-skip-copy-nested-binaries.patch
@@ -1,0 +1,47 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andy Chiang <AndyChiang_git@outlook.com>
+Date: Sun, 16 Aug 2026 22:50:48 +0700
+Subject: [PATCH] skip copy nested binaries
+
+This script copies containerd, containerd-shim-runc-v2, ctr, runc,
+docker-init, rootlesskit, dockerd-rootless.sh, and dockerd-rootless-setuptool.sh
+into the `$dir` directory, which is unnecessary for OpenWrt. Moreover,
+if the host is missing any one of these files, cp will fail and cause an error.
+
+Fixes:
+```
+Copying nested executables into bundles/binary-daemon
+cp: cannot stat '': No such file or directory
+make[3]: *** [Makefile:166: /home/runner/work/Build/Build/openwrt/build_dir/target-x86_64_musl/dockerd-29.6.1/.built] Error 1
+```
+
+Signed-off-by: Andy Chiang <AndyChiang_git@outlook.com>
+---
+ hack/make/binary-daemon | 16 +---------------
+ 1 file changed, 1 insertion(+), 15 deletions(-)
+
+--- a/hack/make/binary-daemon
++++ b/hack/make/binary-daemon
+@@ -2,21 +2,7 @@
+ set -e
+ 
+ copy_binaries() {
+-	local dir="${1:?}"
+-
+-	# Add nested executables to bundle dir so we have complete set of
+-	# them available, but only if the native OS/ARCH is the same as the
+-	# OS/ARCH of the build target
+-	if [ "$(go env GOOS)/$(go env GOARCH)" != "$(go env GOHOSTOS)/$(go env GOHOSTARCH)" ]; then
+-		return
+-	fi
+-	if [ ! -x /usr/local/bin/runc ]; then
+-		return
+-	fi
+-	echo "Copying nested executables into $dir"
+-	for file in containerd containerd-shim-runc-v2 ctr runc docker-init rootlesskit dockerd-rootless.sh dockerd-rootless-setuptool.sh; do
+-		cp -f "$(command -v "$file")" "$dir/"
+-	done
++	return
+ }
+ 
+ [ -z "$KEEPDEST" ] && rm -rf "$DEST"


### PR DESCRIPTION
This script copies containerd, containerd-shim-runc-v2, ctr, runc, docker-init, rootlesskit, dockerd-rootless.sh, and dockerd-rootless-setuptool.sh into the `$dir` directory, which is unnecessary for OpenWrt. Moreover, if the host is missing any one of these files, cp will fail and cause an error.

Fixes:
```
Copying nested executables into bundles/binary-daemon
cp: cannot stat '': No such file or directory
make[3]: *** [Makefile:166: /home/runner/work/Build/Build/openwrt/build_dir/target-x86_64_musl/dockerd-29.6.1/.built] Error 1
```

## 📦 Package Details

**Maintainer:** @G-M0N3Y-2503

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

---

## 🧪 Run Testing Details

- **OpenWrt Version:** Snapshot
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** N100

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [X] It can be applied using `git am`
- [X] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
