### PR TITLE
syslog-ng: update to version 4.12.0

### DIFF
--- a/admin/syslog-ng/Makefile
+++ b/admin/syslog-ng/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=syslog-ng
-PKG_VERSION:=4.11.0
+PKG_VERSION:=4.12.0
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
@@ -11,7 +11,7 @@ PKG_CPE_ID:=cpe:/a:oneidentity:syslog-ng
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/syslog-ng/syslog-ng/releases/download/$(PKG_NAME)-$(PKG_VERSION)/
-PKG_HASH:=37ea0d4588533316de122df4e1b249867b0a0575f646c7478d0cc4d747462943
+PKG_HASH:=03a03d19ac203dca53c7ec79a7005c8a850665a95ff4cd0f1e7bb4c497c64d46
 
 PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @BKPepe

**Description:**
Update to 4.12.0.

Note that upstream made the secure logging (slog) module build-conditional and disabled it by default in this release, so `slogkey`, `slogencrypt` and `slogverify` are no longer part of the package. Building them again would need `--enable-slog`.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** TurrisOS 9.1.0 (OpenWrt 24.10 base)
- **OpenWrt Target/Subtarget:** mpc85xx/p2020
- **OpenWrt Device:** CZ.NIC Turris 1.1

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
- [x] This PR only includes a package version or release update, or a new package.
- [x] Sending a pull request against the correct branch: `master`