### PR TITLE
syslog-ng: add version check override

### DIFF
--- a/admin/syslog-ng/test-version.sh
+++ b/admin/syslog-ng/test-version.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# shellcheck shell=busybox
+
+case "$PKG_NAME" in
+syslog-ng)
+	# The daemon is the only executable that reports a version. The tools
+	# shipped next to it (dqtool, loggen, pdbtool, persist-tool,
+	# syslog-ng-ctl, syslog-ng-debun, update-patterndb) only print their
+	# usage, so the generic probe cannot read a version from them.
+	syslog-ng --version | grep -F "$PKG_VERSION"
+	;;
+
+*)
+	echo "Untested package: $PKG_NAME" >&2
+	exit 1
+	;;
+esac


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @BKPepe

**Description:**
The package ships ten executables and only the daemon reports a version, so the generic probe warns for the other nine:

```
syslog-ng: 9/10 executables are missing version 4.12.0
```

`dqtool`, `loggen`, `pdbtool`, `persist-tool`, `syslog-ng-ctl`, `syslog-ng-debun` and `update-patterndb` print their usage instead, which the probe cannot read a version from. The override asserts the version on `syslog-ng` itself.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** TurrisOS 9.1.0 (OpenWrt 24.10 base)
- **OpenWrt Target/Subtarget:** mpc85xx/p2020
- **OpenWrt Device:** CZ.NIC Turris 1.1

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
- [x] Sending a pull request against the correct branch: `master`