### PR TITLE
syslog-ng: do not install syslog-ng-update-virtualenv

### DIFF
--- a/admin/syslog-ng/Makefile
+++ b/admin/syslog-ng/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=syslog-ng
 PKG_VERSION:=4.12.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=LGPL-2.1-or-later GPL-2.0-or-later
@@ -119,6 +119,7 @@ define Package/syslog-ng/install
 	rm -rf $(1)/usr/lib/pkgconfig \
 	$(1)/usr/lib/*.a \
 	$(1)/usr/include \
+	$(1)/usr/bin/syslog-ng-update-virtualenv \
 	$(1)/var
 
 	$(INSTALL_DIR) $(1)/etc/init.d


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @BKPepe

**Description:**
`syslog-ng-update-virtualenv` creates and updates the private Python virtualenv that the Python module runs from, but the package is built with `--disable-python`, so there is nothing for it to do.

It cannot even parse its arguments on a stock image:

```
/usr/bin/syslog-ng-update-virtualenv: line 30: getopt: not found
Error parsing arguments
```

---

## 🧪 Run Testing Details

- **OpenWrt Version:** TurrisOS 9.1.0 (OpenWrt 24.10 base)
- **OpenWrt Target/Subtarget:** mpc85xx/p2020
- **OpenWrt Device:** CZ.NIC Turris 1.1

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
- [x] This PR only includes a package version or release update, or a new package.
- [x] Sending a pull request against the correct branch: `master`