### PR TITLE
syslog-ng: install the configuration with INSTALL_CONF

### DIFF
--- a/admin/syslog-ng/Makefile
+++ b/admin/syslog-ng/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=syslog-ng
 PKG_VERSION:=4.12.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=LGPL-2.1-or-later GPL-2.0-or-later
@@ -125,7 +125,7 @@ define Package/syslog-ng/install
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/syslog-ng.init $(1)/etc/init.d/syslog-ng
 	$(INSTALL_DIR) $(1)/etc/syslog-ng.d
-	$(INSTALL_DATA) ./files/syslog-ng.conf $(1)/etc
+	$(INSTALL_CONF) ./files/syslog-ng.conf $(1)/etc/syslog-ng.conf
 	touch $(1)/etc/syslog-ng.d/.keep
 
 	$(INSTALL_DIR) $(1)/usr/libexec


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @BKPepe

**Description:**
`/etc/syslog-ng.conf` is installed with `INSTALL_DATA`, which leaves it world readable at 0644. The file holds the credentials of every destination configured to need them, so it should go in with `INSTALL_CONF` at 0600, the way the rest of the tree installs configuration under `/etc`.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** OpenWrt master
- **OpenWrt Target/Subtarget:** mpc85xx/p2020
- **OpenWrt Device:** CZ.NIC Turris 1.1

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
- [x] Sending a pull request against the correct branch: `master`