### PR TITLE
modemmanager: improvements to the netifd protocol

### DIFF
--- a/net/modemmanager/Makefile
+++ b/net/modemmanager/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=modemmanager
 PKG_VERSION:=1.24.0
-PKG_RELEASE:=12
+PKG_RELEASE:=13
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://gitlab.freedesktop.org/mobile-broadband/ModemManager.git

--- a/net/modemmanager/README.md
+++ b/net/modemmanager/README.md
@@ -28,6 +28,7 @@ Once installed, you can configure the 2G/3G/4G modem connections directly in
         option allow_roaming '1'
         option force_connection '1'
         option init_epsbearer '<none|default|custom>'
+        option timeout     '120'
 
 Only 'device' and 'proto' are mandatory options, the remaining ones are all
 optional.
@@ -44,6 +45,12 @@ The 'plmn' option allows to set the network operator MCCMNC.
 
 The 'signalrate' option set's the signal refresh rate (in seconds) for the device.
 You can call signal info with command: mmcli -m 0 --signal-get
+
+The 'timeout' option set's the command timeout (in seconds) for the long
+running 'mmcli' calls ('enable', 'simple-connect',
+3gpp-register-in-operator' and '3gpp-set-initial-eps-bearer-settings')
+in the modemmanager protohandler. The default value is 120 seconds, if
+no value is configured.
 
 The 'force_connection' option is designed to ensure that the modem automatically
 attempts to reconnect regardless of any errors encountered during the

--- a/net/modemmanager/files/lib/netifd/proto/modemmanager.sh
+++ b/net/modemmanager/files/lib/netifd/proto/modemmanager.sh
@@ -573,25 +573,24 @@ proto_modemmanager_setup() {
 	local modempath modemstatus bearercount bearerpath connectargs bearerstatus beareriface
 	local bearermethod_ipv4 bearermethod_ipv6 auth cliauth
 	local operatorname operatorid registration accesstech signalquality
-	local allowedmode preferredmode
 
 	local device apn allowedauth username password pincode
 	local iptype plmn metric signalrate allow_roaming
-	local force_connection
+	local allowedmode preferredmode force_connection
+	local sourcefilter
+	json_get_vars device apn allowedauth username password pincode
+	json_get_vars iptype plmn metric signalrate allow_roaming
+	json_get_vars allowedmode preferredmode force_connection
+	json_get_vars sourcefilter
 
 	local init_epsbearer
 	local init_iptype init_allowedauth
 	local init_password init_user init_apn
-
-	local address prefix gateway mtu dns1 dns2
-
-	json_get_vars device apn allowedauth username password
-	json_get_vars pincode iptype sourcefilter plmn metric signalrate allow_roaming
-	json_get_vars allowedmode preferredmode force_connection
-
 	json_get_vars init_epsbearer
 	json_get_vars init_iptype init_allowedauth
 	json_get_vars init_password init_user init_apn
+
+	local address prefix gateway mtu dns1 dns2
 
 	# validate sysfs path given in config
 	[ -n "${device}" ] || {

--- a/net/modemmanager/files/lib/netifd/proto/modemmanager.sh
+++ b/net/modemmanager/files/lib/netifd/proto/modemmanager.sh
@@ -529,9 +529,9 @@ modemmanager_init_epsbearer() {
 	local apn="$4"
 
 	if [ "$eps" = "none" ]; then
-		echo "Deleting inital EPS bearer..."
+		echo "Deleting inital EPS bearer"
 	else
-		echo "Setting '$eps' inital EPS bearer apn to '$apn'..."
+		echo "Setting '$eps' inital EPS bearer apn to '$apn'"
 	fi
 
 	mmcli --modem="${device}" \
@@ -697,13 +697,13 @@ proto_modemmanager_setup() {
 		modemmanager_set_plmn "$device" "$interface" "" "$force_connection"
 		[ "$?" -ne "0" ] && return 1
 	else
-		echo "starting network registration with plmn '${plmn}'..."
+		echo "starting network registration with plmn '${plmn}'"
 		modemmanager_set_plmn "$device" "$interface" "$plmn" "$force_connection"
 		[ "$?" -ne "0" ] && return 1
 	fi
 
 	# setup connect args; APN mandatory (even if it may be empty)
-	echo "starting connection with apn '${apn}'..."
+	echo "starting connection with apn '${apn}'"
 
 	# setup allow-roaming parameter
 	if [ -n "${allow_roaming}" ] && [ "${allow_roaming}" -eq 0 ];then

--- a/net/modemmanager/files/lib/netifd/proto/modemmanager.sh
+++ b/net/modemmanager/files/lib/netifd/proto/modemmanager.sh
@@ -282,6 +282,7 @@ proto_modemmanager_init_config() {
 	proto_config_add_boolean lowpower
 	proto_config_add_boolean allow_roaming
 	proto_config_add_boolean force_connection
+	proto_config_add_int timeout
 	proto_config_add_string init_epsbearer
 	proto_config_add_string init_iptype
 	proto_config_add_string 'init_allowedauth:list(string)'
@@ -527,6 +528,7 @@ modemmanager_init_epsbearer() {
 	local device="$2"
 	local connectargs="$3"
 	local apn="$4"
+	local timeout="$5"
 
 	if [ "$eps" = "none" ]; then
 		echo "Deleting inital EPS bearer"
@@ -535,7 +537,7 @@ modemmanager_init_epsbearer() {
 	fi
 
 	mmcli --modem="${device}" \
-		--timeout 120 \
+		--timeout "${timeout}" \
 		--3gpp-set-initial-eps-bearer-settings="${connectargs}" || {
 		proto_notify_error "${interface}" MM_INIT_EPS_BEARER_SET_FAILED
 		proto_block_restart "${interface}"
@@ -552,9 +554,10 @@ modemmanager_set_plmn() {
 	local interface="$2"
 	local plmn="$3"
 	local force_connection="$4"
+	local timeout="$5"
 
 	mmcli --modem="${device}" \
-		--timeout 120 \
+		--timeout "${timeout}" \
 		--3gpp-register-in-operator="${plmn}" || {
 		if [ -n "${force_connection}" ] && [ "${force_connection}" -eq 1 ]; then
 			echo "3GPP operator registration failed -> attempting restart"
@@ -577,11 +580,11 @@ proto_modemmanager_setup() {
 	local device apn allowedauth username password pincode
 	local iptype plmn metric signalrate allow_roaming
 	local allowedmode preferredmode force_connection
-	local sourcefilter
+	local sourcefilter timeout
 	json_get_vars device apn allowedauth username password pincode
 	json_get_vars iptype plmn metric signalrate allow_roaming
 	json_get_vars allowedmode preferredmode force_connection
-	json_get_vars sourcefilter
+	json_get_vars sourcefilter timeout
 
 	local init_epsbearer
 	local init_iptype init_allowedauth
@@ -611,20 +614,23 @@ proto_modemmanager_setup() {
 	}
 	echo "modem available at ${modempath}"
 
+	[ -z "${timeout}" ] && timeout="120"
+	echo "setting command timeout to '${timeout}'"
+
 	modemmanager_check_pin_state "$device" "$interface" "${modemstatus}" "$pincode"
 	[ "$?" -ne "0" ] && return 1
 
 	# always cleanup before attempting a new connection, just in case
 	modemmanager_cleanup_connection "${modemstatus}"
 
-	mmcli --modem="${device}" --timeout 120 --enable || {
+	mmcli --modem="${device}" --timeout "${timeout}" --enable || {
 		proto_notify_error "${interface}" MM_MODEM_DISABLED
 		return 1
 	}
 
 	# set initial eps bearer settings
 	if [ -z "${init_epsbearer}" ]; then
-		modemmanager_init_epsbearer "none" "$device" "" "$apn"
+		modemmanager_init_epsbearer "none" "$device" "" "$apn" "${timeout}"
 	else
 		case "$init_epsbearer" in
 			"default")
@@ -639,7 +645,8 @@ proto_modemmanager_setup() {
 				append_param "${username:+user=${username}}"
 				append_param "${password:+password=${password}}"
 				modemmanager_init_epsbearer "default" \
-					"$device" "${connectargs}" "$apn"
+					"$device" "${connectargs}" "$apn" \
+					"${timeout}"
 				;;
 			"custom")
 				cliauth=""
@@ -653,7 +660,8 @@ proto_modemmanager_setup() {
 				append_param "${init_username:+user=${init_username}}"
 				append_param "${init_password:+password=${init_password}}"
 				modemmanager_init_epsbearer "custom" \
-					"$device" "${connectargs}" "$init_apn"
+					"$device" "${connectargs}" "$init_apn" \
+					"${timeout}"
 				;;
 		esac
 		# check error for init_epsbearer function call
@@ -694,11 +702,11 @@ proto_modemmanager_setup() {
 	fi
 
 	if [ -z "${plmn}" ]; then
-		modemmanager_set_plmn "$device" "$interface" "" "$force_connection"
+		modemmanager_set_plmn "$device" "$interface" "" "$force_connection" "${timeout}"
 		[ "$?" -ne "0" ] && return 1
 	else
 		echo "starting network registration with plmn '${plmn}'"
-		modemmanager_set_plmn "$device" "$interface" "$plmn" "$force_connection"
+		modemmanager_set_plmn "$device" "$interface" "$plmn" "$force_connection" "${timeout}"
 		[ "$?" -ne "0" ] && return 1
 	fi
 
@@ -727,7 +735,7 @@ proto_modemmanager_setup() {
 	append_param "${username:+user=${username}}"
 	append_param "${password:+password=${password}}"
 
-	mmcli --modem="${device}" --timeout 120 --simple-connect="${connectargs}" || {
+	mmcli --modem="${device}" --timeout "${timeout}" --simple-connect="${connectargs}" || {
 		if [ -n "${force_connection}" ] && [ "${force_connection}" -eq 1 ]; then
 			echo "Connection failed -> attempting restart"
 			proto_notify_error "${interface}" MM_INTERFACE_RESTART


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me


**Description:**

* modemmanager: make command timeout configurable
* modemmanager: update logging messages
* modemmanager: cleanup vars in proto_modemmanager_setup


---

## 🧪 Run Testing Details

- **OpenWrt Version:** master
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.