### PR TITLE
comrade: add package

### DIFF
--- a/libs/kcp/Makefile
+++ b/libs/kcp/Makefile
@@ -1,0 +1,63 @@
+#
+# Copyright (C) 2026 Daniel Golle <daniel@makrotopia.org>
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=kcp
+PKG_VERSION:=2.1.1
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/skywind3000/kcp/tar.gz/$(PKG_VERSION)?
+PKG_HASH:=54d3c80928d206529f67cba6f96f2c98007182b46e3112819b200d914f96e425
+
+PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+CMAKE_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+# Upstream honours BUILD_SHARED_LIBS but sets no VERSION/SOVERSION, so the
+# soname is imposed here (see Build/Prepare): a bare libkcp.so leaves no way
+# to express an ABI break. Upstream offers no ABI guarantee either way, so
+# treat 0 as a packaged ABI epoch and bump it if the ikcp_* surface changes.
+define Package/libkcp
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=KCP - A Fast and Reliable ARQ Protocol
+  URL:=https://github.com/skywind3000/kcp
+  ABI_VERSION:=0
+endef
+
+define Package/libkcp/description
+  KCP is a fast and reliable ARQ protocol implementing a TCP-like reliable
+  ordered stream on top of an unreliable datagram transport such as UDP,
+  trading about 10-20% more bandwidth for 30-40% lower latency than TCP.
+  It is a pure algorithm: the caller supplies the datagram in- and output.
+endef
+
+CMAKE_OPTIONS += \
+	-DBUILD_TESTING=OFF \
+	-DBUILD_SHARED_LIBS=ON
+
+# CMake sets the soname itself, so a linker flag cannot win; the target
+# property is the only thing it honours.
+define Build/Prepare
+	$(Build/Prepare/Default)
+	echo 'set_target_properties(kcp PROPERTIES VERSION $(PKG_VERSION) SOVERSION 0)' \
+		>> $(PKG_BUILD_DIR)/CMakeLists.txt
+endef
+
+define Package/libkcp/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libkcp.so.* $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,libkcp))

--- a/libs/libjuice/Makefile
+++ b/libs/libjuice/Makefile
@@ -1,0 +1,55 @@
+#
+# Copyright (C) 2026 Daniel Golle <daniel@makrotopia.org>
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=libjuice
+PKG_VERSION:=1.7.3
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/paullouisageneau/libjuice/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=86e075ca4732882746b6d5733ff1b6090f942e5750df58630b191b5f00f30010
+
+PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
+PKG_LICENSE:=MPL-2.0
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_FLAGS:=gc-sections lto
+CMAKE_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+define Package/libjuice
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=UDP Interactive Connectivity Establishment (ICE) library
+  URL:=https://github.com/paullouisageneau/libjuice
+  ABI_VERSION:=$(PKG_VERSION)
+  DEPENDS:=+libpthread
+endef
+
+define Package/libjuice/description
+  libjuice ("JUICE is a UDP Interactive Connectivity Establishment library")
+  is a lightweight implementation of ICE (RFC 8445) in C, allowing to open
+  a peer-to-peer UDP connection between two hosts behind NAT by hole
+  punching, using STUN (RFC 8489) to gather reflexive candidates and
+  optionally TURN (RFC 8656) to relay. It also provides a minimal
+  STUN/TURN server implementation.
+endef
+
+CMAKE_OPTIONS += \
+	-DNO_TESTS=ON \
+	-DUSE_NETTLE=OFF
+
+define Package/libjuice/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libjuice.so.* $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,libjuice))

--- a/libs/monocypher/Makefile
+++ b/libs/monocypher/Makefile
@@ -1,0 +1,68 @@
+#
+# Copyright (C) 2026 Daniel Golle <daniel@makrotopia.org>
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=monocypher
+PKG_VERSION:=4.0.3
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://monocypher.org/download
+PKG_HASH:=8cc9bc341a66249016db9bd70e9142d8d0aef9945973744b1ac05dbc55d8ee66
+
+PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
+PKG_LICENSE:=BSD-2-Clause OR CC0-1.0
+PKG_LICENSE_FILES:=LICENCE.md
+
+PKG_BUILD_FLAGS:=gc-sections
+PKG_BUILD_PARALLEL:=1
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/libmonocypher
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=Small, auditable, portable cryptographic library
+  URL:=https://monocypher.org/
+  ABI_VERSION:=4
+endef
+
+define Package/libmonocypher/description
+  Monocypher is a small, portable, easy to use cryptographic library in
+  about 2000 lines of C99. It provides authenticated encryption
+  (XChaCha20-Poly1305), hashing (BLAKE2b, SHA-512), password hashing
+  (Argon2), key exchange (X25519), signatures (EdDSA with BLAKE2b, and
+  Ed25519 proper) and Elligator 2 hidden key encoding.
+endef
+
+MAKE_FLAGS += \
+	PREFIX=/usr
+
+# The stock "install" target also runs install-doc, which drags in the man
+# pages we do not ship on the target.
+define Build/Install
+	$(call Build/Install/Default,install-lib install-pc)
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/monocypher.h $(1)/usr/include/
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/monocypher-ed25519.h $(1)/usr/include/
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libmonocypher.so* $(1)/usr/lib/
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/monocypher.pc $(1)/usr/lib/pkgconfig/
+endef
+
+define Package/libmonocypher/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libmonocypher.so.* $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,libmonocypher))

--- a/net/comrade/Makefile
+++ b/net/comrade/Makefile
@@ -1,0 +1,94 @@
+#
+# Copyright (C) 2026 Daniel Golle <daniel@makrotopia.org>
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=comrade
+PKG_VERSION:=0.1.1
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/dangowrt/comrade/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=b778bbc4aa61e6e77632f4931557a2831eb80ef981f099d175d48b40324d4619
+
+PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
+PKG_LICENSE:=AGPL-3.0-or-later
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_FLAGS:=gc-sections lto
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+# The GitHub source archive used above carries no submodule content, so
+# deps/always-online-stun arrives as an empty directory; without the file
+# below CMake falls back to three hard-coded servers. This is the same list
+# that submodule would provide, pinned to the commit the v$(PKG_VERSION) tag
+# references. Either way "comrade stun-update" refreshes the pool at
+# runtime into the user's data directory.
+STUN_LIST_VERSION:=0932114f96cd80886f559994545692870df73804
+STUN_LIST_FILE:=always-online-stun-$(STUN_LIST_VERSION)-valid_nat_testing_hosts.txt
+
+define Download/stunlist
+  FILE:=$(STUN_LIST_FILE)
+  URL:=https://raw.githubusercontent.com/pradt2/always-online-stun/$(STUN_LIST_VERSION)
+  URL_FILE:=valid_nat_testing_hosts.txt
+  HASH:=0aee95ad2cb98a2def9886045d241a62cca64541f77697a010bf0477e02a7322
+endef
+$(eval $(call Download,stunlist))
+
+# comrade adds no crypto library of its own: it reads the DT_NEEDED entries
+# out of libssh and follows whatever backend that already uses. OpenWrt's
+# libssh is built against mbedTLS, which implements neither BLAKE2b nor
+# Ed25519, so this resolves to monocypher (~70 kB) rather than dragging in
+# libcrypto. Should libssh ever move to OpenSSL, the backend follows it and
+# libmonocypher below has to become libopenssl.
+define Package/comrade
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=SSH
+  TITLE:=Serverless peer-to-peer terminal sharing
+  URL:=https://github.com/dangowrt/comrade
+  DEPENDS:=+libssh +libjuice +libdht +libkcp +libmonocypher +libpthread
+endef
+
+define Package/comrade/description
+  Peer-to-peer terminal sharing with tmate-like semantics and no central
+  server: a host shares a tmux session, a client joins it with a base58
+  token passed out-of-band. Rendezvous happens on the BitTorrent mainline
+  DHT (or link-local multicast on isolated LANs), connectivity is
+  established by ICE hole punching, and the session itself is end-to-end
+  SSH wrapping stock tmux, with the host key pinned in the token. -L and
+  -R tunnel TCP ports through that same session with ssh's own syntax.
+
+  Hosting a session needs tmux installed; joining one never does. tmux is
+  therefore not pulled in as a dependency, install it separately on
+  boxes that will host.
+endef
+
+# With no -DCOMRADE_DHT_DIR the build finds and links the shared libdht,
+# which is what we want: comrade is an ordinary consumer of the packaged
+# library, exactly as transmission is. comrade defines the four symbols
+# libdht deliberately leaves undefined (dht_hash, dht_random_bytes,
+# dht_blacklisted, dht_sendto) and the dynamic linker resolves them back
+# into the executable.
+CMAKE_OPTIONS += \
+	-DBUILD_TESTING=OFF
+
+define Build/Prepare
+	$(Build/Prepare/Default)
+	$(INSTALL_DIR) $(PKG_BUILD_DIR)/deps/always-online-stun
+	$(INSTALL_DATA) $(DL_DIR)/$(STUN_LIST_FILE) \
+		$(PKG_BUILD_DIR)/deps/always-online-stun/valid_nat_testing_hosts.txt
+endef
+
+define Package/comrade/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/comrade $(1)/usr/bin/
+endef
+
+$(eval $(call BuildPackage,comrade))


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @dangowrt (also the upstream project author)

**Description:**
Serverless peer-to-peer terminal sharing: a host shares a tmux session that a client joins with a token, over a hole-punched link discovered on the mainline DHT or link-local multicast, wrapped in an end-to-end SSH session with the host key pinned in the token.
    
comrade adds no crypto of its own and follows whatever backend libssh already links; OpenWrt's libssh uses mbedTLS, so this resolves to monocypher.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** snapshot
- **OpenWrt Target/Subtarget:** -
- **OpenWrt Device:** -

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.