### PR TITLE
strongswan: fix build with wolfSSL 5.9.2

### DIFF
--- a/net/strongswan/Makefile
+++ b/net/strongswan/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=strongswan
 PKG_VERSION:=6.0.7
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://download.strongswan.org/ https://download2.strongswan.org/

--- a/net/strongswan/patches/0905-wolfssl-Adapt-to-removed-ML-KEM-header.patch
+++ b/net/strongswan/patches/0905-wolfssl-Adapt-to-removed-ML-KEM-header.patch
@@ -1,0 +1,24 @@
+From 98b133c54c5e3f66f46a5bb11c9b09d06fdc8469 Mon Sep 17 00:00:00 2001
+From: Tobias Brunner <tobias@strongswan.org>
+Date: Fri, 26 Jun 2026 08:10:16 +0200
+Subject: [PATCH] wolfssl: Adapt to removed ML-KEM header
+
+The mlkem.h header that mainly defined aliases for the old wc_Kyber* API
+has been removed and its contents moved to the wc_mlkem.h header.
+---
+ src/libstrongswan/plugins/wolfssl/wolfssl_kem.c | 3 ---
+ 1 file changed, 3 deletions(-)
+
+--- a/src/libstrongswan/plugins/wolfssl/wolfssl_kem.c
++++ b/src/libstrongswan/plugins/wolfssl/wolfssl_kem.c
+@@ -25,10 +25,7 @@
+ 
+ #ifdef WOLFSSL_HAVE_MLKEM
+ 
+-#include <wolfssl/wolfcrypt/mlkem.h>
+-#ifdef WOLFSSL_WC_MLKEM
+ #include <wolfssl/wolfcrypt/wc_mlkem.h>
+-#endif
+ 
+ typedef struct private_key_exchange_t private_key_exchange_t;
+ 


### PR DESCRIPTION
wolfSSL 5.9.2 removed `mlkem.h`. Backport the upstream change to use
`wc_mlkem.h` directly.

This is a backport of
[strongSwan commit 98b133c5](https://github.com/strongswan/strongswan/commit/98b133c54c5e3f66f46a5bb11c9b09d06fdc8469).

Fixes: #30291

## Package Details

**Maintainer:** [@pprindeville](https://github.com/pprindeville)

**Description:**

Fix the strongSwan wolfSSL plugin build after the wolfSSL 5.9.2 update removed
the compatibility header it included.

---

## Run Testing Details

- **OpenWrt Version:** main with wolfSSL 5.9.2
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** x86-vm

Also checked with:

```sh
git diff --check
```

---

## Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/strongswan/refresh V=s
  ```
- [x] It is structured in a way that is potentially upstreamable

The patch is already included upstream and is carried here as a backport.
