### PR TITLE
oci-runtime-tools: fix packaging bugs

### DIFF
--- a/utils/oci-runtime-tools/Makefile
+++ b/utils/oci-runtime-tools/Makefile
@@ -20,7 +20,7 @@ PKG_BUILD_PARALLEL:=1
 PKG_BUILD_FLAGS:=no-mips16
 
 GO_PKG:=github.com/opencontainers/runtime-tools/
-GO_PKG_LDFLAGS_X:=main.gitCommit=$(PKG_SOURCE_VERSION) main.version=$(PKG_SOURCE_VERSION)
+GO_PKG_LDFLAGS_X:=main.gitCommit=$(PKG_SOURCE_VERSION) main.version=$(PKG_VERSION)
 
 BUSYBOX_STATIC_VERSION:=1.31.0
 

--- a/utils/oci-runtime-tools/Makefile
+++ b/utils/oci-runtime-tools/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=oci-runtime-tools
 PKG_VERSION:=1.3.0.20260316
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 
@@ -82,6 +82,14 @@ endef
 
 define Build/Compile
 	$(call GoPackage/Build/Compile)
+	$(GO_GENERAL_BUILD_CONFIG_VARS) \
+	$(GO_PKG_BUILD_CONFIG_VARS) \
+	GO_BUILD_PKG="$(GO_PKG)cmd/runtimetest" \
+	$(GO_PKG_VARS) \
+	CGO_ENABLED=0 \
+	$(SHELL) $(GO_INCLUDE_DIR)golang-build.sh build \
+		-v -buildvcs=false -trimpath -tags "netgo osusergo" \
+		-ldflags "$(patsubst %,-X %,$(GO_PKG_LDFLAGS_X))"
 	$(call GoPackage/Package/Install/Bin,$(PKG_INSTALL_DIR))
 endef
 

--- a/utils/oci-runtime-tools/Makefile
+++ b/utils/oci-runtime-tools/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=oci-runtime-tools
 PKG_VERSION:=1.3.0.20260316
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 
@@ -65,7 +65,7 @@ define Package/oci-runtime-tests
   CATEGORY:=Utilities
   TITLE:=OCI runtimetest tool
   URL:=https://github.com/opencontainers/runtime-tools
-  DEPENDS:=@(aarch64||i386||i686||x86_64) oci-runtime-tool +tar
+  DEPENDS:=@(aarch64||i386||i686||x86_64) oci-runtime-tool +tar +unshare
 endef
 
 define Package/oci-runtime-tests/description

--- a/utils/oci-runtime-tools/Makefile
+++ b/utils/oci-runtime-tools/Makefile
@@ -24,6 +24,19 @@ GO_PKG_LDFLAGS_X:=main.gitCommit=$(PKG_SOURCE_VERSION) main.version=$(PKG_SOURCE
 
 BUSYBOX_STATIC_VERSION:=1.31.0
 
+ifdef CONFIG_i386
+  ROOTFS_ARCHIVE:=rootfs-386.tar.gz
+endif
+ifdef CONFIG_i686
+  ROOTFS_ARCHIVE:=rootfs-386.tar.gz
+endif
+ifdef CONFIG_x86_64
+  ROOTFS_ARCHIVE:=rootfs-amd64.tar.gz
+endif
+ifdef CONFIG_aarch64
+  ROOTFS_ARCHIVE:=rootfs-arm64.tar.gz
+endif
+
 include $(INCLUDE_DIR)/package.mk
 include ../../lang/golang/golang-package.mk
 
@@ -106,15 +119,7 @@ define Package/oci-runtime-tests/install
 		$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/$$$${testbin} \
 			$(1)/usr/libexec/oci-runtime-test/$$$${testbin}.t ; \
 	done )
-ifdef CONFIG_x86
-	$(INSTALL_DATA) $(PKG_BUILD_DIR)/rootfs-386.tar.gz $(1)/usr/libexec/oci-runtime-test
-ifdef CONFIG_x86_64
-	$(INSTALL_DATA) $(PKG_BUILD_DIR)/rootfs-amd64.tar.gz $(1)/usr/libexec/oci-runtime-test
-endif
-endif
-ifdef CONFIG_aarch64
-	$(INSTALL_DATA) $(PKG_BUILD_DIR)/rootfs-arm64.tar.gz $(1)/usr/libexec/oci-runtime-test
-endif
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/$(ROOTFS_ARCHIVE) $(1)/usr/libexec/oci-runtime-test
 endef
 
 $(eval $(call GoBinPackage,oci-runtime-tools))

--- a/utils/oci-runtime-tools/test.sh
+++ b/utils/oci-runtime-tools/test.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+case "$1" in
+oci-runtime-tool)
+	oci-runtime-tool --version 2>&1 | grep -F "$2"
+	;;
+
+oci-runtime-tests)
+	# runtimetest and the validation/*.go test binaries installed here have
+	# no version flag; probing any of them with one runs the OCI compliance
+	# test it implements instead, out of the working directory it expects
+	exit 0
+	;;
+
+*)
+	echo "Untested package: $1" >&2
+	exit 1
+	;;
+esac


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @dangowrt 

**Description:**
Two improvements making the test-suite of OCI runtime tests more useful.
---

## 🧪 Run Testing Details

- **OpenWrt Version:** snapshot
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** QEMU (x86/64)

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.