### PR TITLE
ksmbd-tools: update to 3.5.7 and add version test

### DIFF
--- a/net/ksmbd-tools/Makefile
+++ b/net/ksmbd-tools/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ksmbd-tools
-PKG_VERSION:=3.5.6
+PKG_VERSION:=3.5.7
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/cifsd-team/ksmbd-tools/releases/download/$(PKG_VERSION)
-PKG_HASH:=8ce27cf947667b634478186aa7ef91fce68461c781d3880693a4639f8fecc397
+PKG_HASH:=d8e532b2d032e3f447f3fd19e0f9ea0abeb355285f8d6871ce9036bc6393a5b2
 
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=COPYING

--- a/net/ksmbd-tools/test-version.sh
+++ b/net/ksmbd-tools/test-version.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+# shellcheck shell=busybox
+
+case "$PKG_NAME" in
+ksmbd-server)
+	/usr/sbin/ksmbd.mountd -V 2>&1 | grep -F "$PKG_VERSION"
+	;;
+
+ksmbd-avahi-service|\
+ksmbd-hotplug)
+	exit 0
+	;;
+
+*)
+	echo "Untested package: $PKG_NAME" >&2
+	exit 1
+	;;
+esac


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @nobody

**Description:**

Update ksmbd-tools from 3.5.6 to 3.5.7 and add a package-specific
version test for the OpenWrt package test runner.

Upstream highlights:
- Enable SMB2 leases by default and add AAPL support.
- Add hide-unreadable and secure wide-link handling.
- Propagate Kerberos ticket expiration through IPC.
- Align IPC structures with the upstream kernel.
- Fix RPC memory leaks and dangling pointers.
- Improve installation and default configuration.
- Raise the default SMB2 maximum transaction size to 4 MiB.
- Remove the network-online dependency and mark multichannel non-experimental.

Packaging changes:
- Add `test-version.sh` for the generated subpackages.
- Check the version through `ksmbd.mountd -V`, since the
  `ksmbd.tools` multicall binary rejects direct invocation under that name.
- Skip the version check for `ksmbd-avahi-service` and `ksmbd-hotplug`,
  which do not contain version-reporting executables.

Upstream release: https://github.com/cifsd-team/ksmbd-tools/releases/tag/3.5.7

---

## 🧪 Run Testing Details

- **OpenWrt Version:** snapshot (gcff6f49bc2)
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** GL.iNet GL-MT6000
- **Build test:** ksmbd-server and ksmbd-avahi-service 3.5.7-r1 APKs generated successfully
- **Package version test:** checks 3.5.7 through `/usr/sbin/ksmbd.mountd -V`
- **Runtime test:** not performed

---

## ✅ Formalities

- [x] I have reviewed the CONTRIBUTING.md file for detailed contributing guidelines.