### PR TITLE
frp: bump to 0.71.0

### DIFF
--- a/net/frp/Makefile
+++ b/net/frp/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=frp
-PKG_VERSION:=0.70.1
-PKG_RELEASE:=2
+PKG_VERSION:=0.71.0
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/fatedier/frp/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=67246606f504cb15df72193f1a83911259e92b6a87838cff8850031efd406dc8
+PKG_HASH:=1dd367d6d822a7fce1d3012fce0a6e778bc90c454e2c7baa0eb1e6de6054c61b
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** N/A

**Description:**
Changes: https://github.com/fatedier/frp/releases/tag/v0.71.0

---

## 🧪 Run Testing Details main/snapshot

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:** qualcommax/aarch64
- **OpenWrt Device:** ipq6000-360v6

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
