### PR TITLE
dnsproxy log file does not work

### DIFF
--- a/net/dnsproxy/files/dnsproxy.init
+++ b/net/dnsproxy/files/dnsproxy.init
@@ -141,7 +141,7 @@ start_service() {
 	procd_set_param capabilities "/etc/capabilities/dnsproxy.json"
 	procd_add_jail_mount "/etc/hosts"
 	procd_add_jail_mount "/etc/ssl/certs/ca-certificates.crt"
-	[ -z "$log_file" ] || procd_add_jail_mount_rw "$log_file"
+	[ -z "$log_file" ] || { touch "$log_file" && chown dnsproxy:dnsproxy "$log_file" && procd_add_jail_mount_rw "$log_file"; }
 	[ -z "$tls_crt" ] || procd_add_jail_mount "$tls_crt"
 	[ -z "$tls_key" ] || procd_add_jail_mount "$tls_key"
 	is_enabled "hosts" "enabled" && config_list_foreach "hosts" "hosts_files" "procd_add_jail_mount"


### PR DESCRIPTION
for dnsproxy package the following error will happen when option log_file is specified in config file

Wed Aug 19 22:51:59 2026 daemon.err dnsproxy[31830]: cannot create a log file: open /var/log/dnsproxy.log: no such file or directory if the file is exist but with improper ownership, the following error will happen Wed Aug 19 22:53:42 2026 daemon.err dnsproxy[32097]: cannot create a log file: open /var/log/dnsproxy.log: permission denied this patch fixes these error

## 📦 Package Details

**Maintainer:** @<github-user>
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [ ] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
