### PR TITLE
screen-haven: add status display for the 3.5in USB panel

### DIFF
--- a/utils/screen-haven/Makefile
+++ b/utils/screen-haven/Makefile
@@ -1,0 +1,57 @@
+#
+# Copyright (C) 2026 LulHaven
+#
+# This is free software, licensed under the MIT License.
+#
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=screen-haven
+PKG_VERSION:=1.1
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://github.com/mndavew3/screen-haven/releases/download/v$(PKG_VERSION)
+PKG_HASH:=5686acc92d46623e72744a5894e45308ce7e70b7a16c2d04b2392ca51bcaec14
+
+PKG_MAINTAINER:=Dave Wengert <dave@lulhaven.com>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/screen-haven
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=Status display for the 3.5in Turing-style USB panel
+  URL:=https://lulhaven.com
+  DEPENDS:=+zlib
+endef
+
+define Package/screen-haven/description
+  A table-driven status deck for the 480x320 "Turing" style 3.5-inch USB
+  display: live bandwidth graphs, system health, network detail, connected
+  devices and a clock. Driven by an attached USB mouse (or wireless air-mouse):
+  the scroll wheel slides between screens, clicks step and the middle button
+  snapshots. A USB mouse is required.
+  Reads only stock system state (/proc, /sys, the default route, dhcp leases,
+  uci wireless). Starts automatically when the panel is plugged in.
+endef
+
+define Build/Compile
+	$(TARGET_CC) $(TARGET_CFLAGS) $(TARGET_CPPFLAGS) $(TARGET_LDFLAGS) -Wall \
+		-o $(PKG_BUILD_DIR)/screen-haven \
+		$(PKG_BUILD_DIR)/screendeck.c $(PKG_BUILD_DIR)/hvn.c \
+		$(PKG_BUILD_DIR)/shdata.c $(PKG_BUILD_DIR)/qrcodegen.c \
+		-lz
+endef
+
+define Package/screen-haven/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/screen-haven $(1)/usr/bin/
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/screen-haven.init $(1)/etc/init.d/screen-haven
+	$(INSTALL_DIR) $(1)/etc/hotplug.d/tty
+	$(INSTALL_DATA) ./files/screen-haven.hotplug $(1)/etc/hotplug.d/tty/40-screen-haven
+endef
+
+$(eval $(call BuildPackage,screen-haven))

--- a/utils/screen-haven/files/screen-haven.hotplug
+++ b/utils/screen-haven/files/screen-haven.hotplug
@@ -1,0 +1,15 @@
+# hotplug.d/tty - follow the USB panel (ttyACM*) as it comes and goes.
+case "$DEVNAME" in
+	ttyACM*) ;;
+	*) return 0 ;;
+esac
+
+/etc/init.d/screen-haven enabled || return 0
+
+case "$ACTION" in
+	# 'remove' matters: procd respawns the deck, and the device guard lives in
+	# start_service only, so an unplug would loop until procd gave up instead
+	# of stopping cleanly.
+	add) /etc/init.d/screen-haven restart ;;
+	remove) /etc/init.d/screen-haven stop ;;
+esac

--- a/utils/screen-haven/files/screen-haven.init
+++ b/utils/screen-haven/files/screen-haven.init
@@ -1,0 +1,22 @@
+#!/bin/sh /etc/rc.common
+# procd init for Screen Haven. Runs only when the USB panel is present.
+START=95
+STOP=10
+USE_PROCD=1
+
+start_service() {
+	# No fixed device node. A hub renumbers ttyACM* on every replug, so the
+	# panel is whichever node is there now - and a hard-coded /dev/ttyACM0
+	# drifts apart from the hotplug rule, which fires on ttyACM*.
+	set -- /dev/ttyACM*
+	if [ ! -c "$1" ]; then
+		logger -t screen-haven "no /dev/ttyACM* panel present - not starting"
+		return 0
+	fi
+	procd_open_instance
+	procd_set_param command /usr/bin/screen-haven "$1"
+	procd_set_param respawn
+	procd_set_param stdout 1
+	procd_set_param stderr 1
+	procd_close_instance
+}


### PR DESCRIPTION
Screen Haven is a status display for the 480x320 "Turing"-style 3.5-inch USB panel: live bandwidth, system health, network detail, connected devices and a clock, driven by an attached USB mouse. It reads only stock system state (/proc, /sys, the default route, DHCP leases, uci wireless) — no external data, nothing sent anywhere. Source is fetched from a tagged release tarball.

**Maintainer:** @mndavew3

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12.5 (SDK `openwrt-sdk-25.12.5-x86-64_gcc-14.3.0_musl.Linux-x86_64`)
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** none — SDK build only

Built against the **1.1** tarball now referenced by the Makefile (`PKG_HASH` verified against the release asset): compiles cleanly and produces `screen-haven-1.1-r1.apk`. The resulting executable was run under the SDK's musl loader and answers the version query the package CI uses:

```
$ screen-haven --version
screen-haven 1.1
$ screen-haven -V
screen-haven 1.1
```

so no `test-version.sh` override is needed.

**Not run against the physical panel from this tarball** — the display path is untested here.

With `-w` replaced by `-Wall`, the package's own sources now emit 6 warnings, all reviewed and benign: four `-Wmisleading-indentation` in `hvn_tri()` (two statements sharing a line; the code is correct) and two `-Woverflow` in `hvn_screenshot()`, where `HVN_W`/`HVN_H` are truncated on purpose to write the little-endian width/height bytes of a bitmap header. They are left visible rather than silenced.

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
