### PR TITLE
zabbix: improve initscript enable/disable

### DIFF
--- a/admin/zabbix/Makefile
+++ b/admin/zabbix/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zabbix
 PKG_VERSION:=7.0.29
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://cdn.zabbix.com/zabbix/sources/stable/$(basename $(PKG_VERSION))/ \

--- a/admin/zabbix/files/zabbix_agentd.config
+++ b/admin/zabbix/files/zabbix_agentd.config
@@ -1,4 +1,3 @@
 
 config zabbix_agentd 'general'
-    option enabled 0
     # option never_root 1

--- a/admin/zabbix/files/zabbix_agentd.init
+++ b/admin/zabbix/files/zabbix_agentd.init
@@ -27,14 +27,7 @@ start_service() {
 
 	# Get enabled config option
 	config_load "$NAME"
-	config_get_bool enabled general enabled 0
 	config_get_bool never_root general never_root 1
-
-	# shellcheck disable=SC2154
-	if [ "$enabled" -eq 0 ]; then
-		logger "service not enabled in $UCI_CONFIG"
-		return 1
-	fi
 
 	mkdir -p "/var/run/$USER"
 	chown $USER:$USER "/var/run/$USER"

--- a/admin/zabbix/files/zabbix_proxy.config
+++ b/admin/zabbix/files/zabbix_proxy.config
@@ -1,4 +1,3 @@
 
 config zabbix_proxy 'general'
-    option enabled 0
     # option never_root 1

--- a/admin/zabbix/files/zabbix_proxy.init
+++ b/admin/zabbix/files/zabbix_proxy.init
@@ -25,14 +25,7 @@ start_service() {
 
 	# Get enabled config option
 	config_load "$NAME"
-	config_get_bool enabled general enabled 0
 	config_get_bool never_root general never_root 1
-
-	# shellcheck disable=SC2154
-	if [ "$enabled" -eq 0 ]; then
-		logger "service not enabled in $UCI_CONFIG"
-		return 1
-	fi
 
 	mkdir -p "/var/run/$USER"
 	chown $USER:$USER "/var/run/$USER"

--- a/admin/zabbix/files/zabbix_server.config
+++ b/admin/zabbix/files/zabbix_server.config
@@ -1,4 +1,4 @@
 
 config zabbix_server 'general'
-    option enabled 0
-    # option never_root 1
+  # option never_root 1
+  # option no_db_password 0

--- a/admin/zabbix/files/zabbix_server.init
+++ b/admin/zabbix/files/zabbix_server.init
@@ -15,6 +15,27 @@ CONFIG=/etc/${NAME}.conf
 UCI_CONFIG=/etc/config/${NAME}
 USER=zabbix-server
 
+is_database_configured() {
+	local no_db_password
+
+	# We consider the database configured if there is a configured DBName,
+	# DBUser, and DBPassword or 'no_db_password' is true in the UCI config
+	if grep -q '[^#].*DBPassword=' "${CONFIG}" && grep -q '[^#].*DBName' "${CONFIG}"; then
+		if ! grep -q '[^#].*DBUser=' "${CONFIG}"; then
+			config_get_bool no_db_password general no_db_password 0
+			if [ "$no_db_password" -eq 1 ]; then
+				return 0
+			else
+				return 1
+			fi
+		else
+			return 0
+		fi
+	else
+		return 1
+	fi
+}
+
 start_service() {
 	local enabled never_root
 
@@ -25,12 +46,10 @@ start_service() {
 
 	# Get enabled config option
 	config_load "$NAME"
-	config_get_bool enabled general enabled 0
 	config_get_bool never_root general never_root 1
 
-	# shellcheck disable=SC2154
-	if [ "$enabled" -eq 0 ]; then
-		logger "service not enabled in $UCI_CONFIG"
+	if ! is_database_configured; then
+		logger "No database configuration for ${NAME}. Not starting."
 		return 1
 	fi
 

--- a/admin/zabbix/patches/030-zabbix_proxy-tweak-config-file-for-openwrt.patch
+++ b/admin/zabbix/patches/030-zabbix_proxy-tweak-config-file-for-openwrt.patch
@@ -19,6 +19,8 @@ Created 2026-07-16.
 8. Include configurations under /etc/zabbix_proxy.conf.d/.
 9. Require configurations under /etc/zabbix_proxy.conf.d/ end in .conf
    (other files are ignored for configuration purposes).
+10. Default to using an SQLITE database (ephemeral) /var/lib/zabbix_proxy.db.
+    This allows the proxy to start when first installed (i.e. not configured).
 ---
  conf/zabbix_proxy.conf | 11 +++++++++--
  1 file changed, 9 insertions(+), 2 deletions(-)
@@ -67,7 +69,17 @@ Created 2026-07-16.
  
  ### Option: SocketDir
  #	IPC socket directory.
-@@ -613,6 +616,7 @@ Timeout=4
+@@ -164,7 +167,8 @@ LogFile=/tmp/zabbix_proxy.log
+ # Default:
+ # DBName=
+ 
+-DBName=zabbix_proxy
++# DBName=zabbix_proxy
++DBName=/var/lib/zabbix_proxy.db
+ 
+ ### Option: DBSchema
+ #	Schema name. Used for PostgreSQL.
+@@ -613,6 +617,7 @@ Timeout=4
  # Mandatory: no
  # Default:
  # FpingLocation=/usr/sbin/fping
@@ -75,7 +87,7 @@ Created 2026-07-16.
  
  ### Option: Fping6Location
  #	Location of fping6.
-@@ -622,6 +626,7 @@ Timeout=4
+@@ -622,6 +627,7 @@ Timeout=4
  # Mandatory: no
  # Default:
  # Fping6Location=/usr/sbin/fping6
@@ -83,7 +95,7 @@ Created 2026-07-16.
  
  ### Option: SSHKeyLocation
  #	Location of public and private keys for SSH checks and actions.
-@@ -667,6 +672,7 @@ LogSlowQueries=3000
+@@ -667,6 +673,7 @@ LogSlowQueries=3000
  # Mandatory: no
  # Default:
  # User=zabbix
@@ -91,7 +103,7 @@ Created 2026-07-16.
  
  ### Option: SSLCertLocation
  #	Location of SSL client certificates.
-@@ -1051,3 +1057,4 @@ StatsAllowedIP=127.0.0.1
+@@ -1051,3 +1058,4 @@ StatsAllowedIP=127.0.0.1
  # Include=/usr/local/etc/zabbix_proxy.general.conf
  # Include=/usr/local/etc/zabbix_proxy.conf.d/
  # Include=/usr/local/etc/zabbix_proxy.conf.d/*.conf


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @danielfdickinson 

**Description:**
In #30317 zabbix-agentd defaults to disabled on upgrade from pre-7.0.29 it was observed that adding the default disabled config results in existing agents failing to start.

This lead to a rethink of the initscript enable/disable situation. It has been decided that initscript enable/disable be left to the /etc/init.d/initscript disable (or enable) mechanism and that the determination of whether to start the daemons (agentd, proxy, or server) be made based on whether sufficient configuration exists.

Further, the default configuration for the zabbix_proxy is now to use an SQLITE database on /var/lib/zabbix_proxy.db (so that the script is able to start by default). This is in line with the mechanism used by postgresql.

Closes: #30317

---

## 🧪 Run Testing Details

TODO: Draft until testing is done

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- N/A It is structured in a way that it is potentially upstreamable
  It OpenWrt-specific configuration defaults.