### PR TITLE
pcsc-lite, ccid: update to 2.5.1, 1.8.2

### DIFF
--- a/utils/ccid/Makefile
+++ b/utils/ccid/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ccid
-PKG_VERSION:=1.8.0
+PKG_VERSION:=1.8.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://ccid.apdu.fr/files/
-PKG_HASH:=531dc29e7c1b9e22e1918f0767b625d52ce8a98f266eb2144c5cf5dbd29c0f67
+PKG_HASH:=d74294e23d436546c3e719c95a4da180b17f5e7ffdd36efca53f75351cb0de75
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=LGPL-2.1-or-later
 PKG_LICENSE_FILES:=COPYING

--- a/utils/pcsc-lite/Makefile
+++ b/utils/pcsc-lite/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pcsc-lite
-PKG_VERSION:=2.5.0
+PKG_VERSION:=2.5.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://pcsclite.apdu.fr/files/
-PKG_HASH:=59b3c4b5be4ab228698edeb5b3ef46ad54ea217e7dd0891372770bb92b55db92
+PKG_HASH:=bfcfe38a20afc49849c6bf55325e38f449fc4b26d3923fdc32b969ae41a8741b
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=COPYING


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @dangowrt
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
Two commits, both from the established pcsc/ccid cluster (ccid depends on libpcsclite from pcsc-lite).

**pcsc-lite 2.5.1** (Ludovic Rousseau, 10 June 2026):
- Fix a bug (introduced in 2.5.0) with multi-slots readers
- Add support of Haiku Operating System

**ccid 1.8.2** (via 1.8.1 and 1.8.2):
- Correctly close the slots of a multi-slots reader
- Fix 3 minor issues found by AISLE in partnership with Red Hat
- Correctly report IFD_NO_SUCH_DEVICE in InterruptRead
- Fix initialisation of composite devices (like Yubico tokens)
- Correctly close the slots of a multi-slots reader (serial)

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT (main, reboot-35870-gc0262ed5af)
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** generic

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>