### PR TITLE
fluidsynth: update to 2.6.0

### DIFF
--- a/sound/fluidsynth/Makefile
+++ b/sound/fluidsynth/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fluidsynth
-PKG_VERSION:=2.5.4
+PKG_VERSION:=2.6.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/FluidSynth/fluidsynth/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=72f5720328fe44e2e5c67813885f0a6b4b004d048bd2eeeb0c0064074ebff530
+PKG_HASH:=6d17570ea2086dd6fbcac995465773a6f316e689089b7fb7ba0b34c2ec6f680d
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=LGPL-2.1
@@ -39,11 +39,11 @@ CMAKE_OPTIONS += \
 	-Denable-ipv6=off \
 	-Denable-jack=off \
 	-Denable-ladspa=off \
-	-Denable-libinstpatch=off \
 	-Denable-libsndfile=on \
 	-Denable-midishare=off \
 	-Denable-opensles=off \
 	-Denable-oboe=off \
+	-Denable-native-dls=off \
 	-Denable-network=off \
 	-Denable-oss=off \
 	-Denable-dsound=off \
@@ -62,14 +62,15 @@ CMAKE_OPTIONS += \
 	-Denable-coremidi=off \
 	-Denable-framework=off \
 	-Denable-dart=off \
-	-Denable-kai=off
+	-Denable-kai=off \
+	-Denable-signalsmith=off
 
 define Package/libfluidsynth
   SECTION:=sound
   CATEGORY:=Sound
   TITLE:=A SoundFont Synthesizer
   URL:=https://www.fluidsynth.org
-  DEPENDS:=+alsa-lib +glib2 +libsndfile +libstdcpp
+  DEPENDS:=+alsa-lib +libsndfile +libstdcpp
 endef
 
 define Package/libfluidsynth/description


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @dangowrt
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
From 2.5.4. New: automatic gain control/output limiter, signed 32-bit/24-bit linear PCM (WASAPI now allows 24-bit), MIDI RPN 5 (Modulation Depth Range), multiple reverb engines, GM2 bank select mode. Musically breaking: fixed a 17-year-old sample fine-tuning bug, implemented MIDI RP-020 to fix MTS playback, switched the default reverb engine to Dattorro, replaced 7th-order sinc interpolation with a higher-order one.

Packaging: upstream dropped the GLib and libInstPatch dependencies in this release; confirmed via `readelf -d` that `libfluidsynth.so` no longer links `libglib-2.0`, and dropped `+glib2` from `DEPENDS` accordingly.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT (main, reboot-35870-gc0262ed5af)
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** generic

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>