### PR TITLE
libp11: update to 0.4.20

### DIFF
--- a/libs/libp11/Makefile
+++ b/libs/libp11/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libp11
-PKG_VERSION:=0.4.18
+PKG_VERSION:=0.4.20
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=https://github.com/OpenSC/libp11/releases/download/$(PKG_NAME)-$(PKG_VERSION)/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=9292de67ca73aba1deacf577c9086b595765f36ef47712cfeb49fa31f6e772fb
+PKG_HASH:=a125e0310ff10c189fc1b32a9652101486ea94a6b07c677a30e90e3638d2db48
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=LGPL-2.1-or-later


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @dangowrt
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
From 0.4.18, via 0.4.19. Adds native KEYMGMT/SIGNATURE/ASYM_CIPHER PKCS#11 provider operations (OpenSSL 4.x support), post-quantum ML-DSA/SLH-DSA/FALCON support, PKCS#11 3.2 interface discovery, ML-KEM-512/768/1024 key generation/encapsulation/decapsulation, and a new PKCS11_evp_pkey_decapsulate() API. Multiple use-after-free, out-of-bounds-write and resource-leak fixes across both releases.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT (main, reboot-35870-gc0262ed5af)
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** generic

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>