### PR TITLE
gnupg2: update to 2.5.21

### DIFF
--- a/utils/gnupg2/Makefile
+++ b/utils/gnupg2/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gnupg
-PKG_VERSION:=2.5.20
+PKG_VERSION:=2.5.21
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://gnupg.org/ftp/gcrypt/gnupg
-PKG_HASH:=6461266e99c308419a379abe6c356d54c214136c4589bd65951091138989ffc6
+PKG_HASH:=e3af2c8caa46a66a9329fa7c6880af260451914d819595beabc2c26597b31352
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=GPL-3.0-or-later


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @dangowrt
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
From 2.5.20. New: gpg/gpgsm use a partial file on decryption and remove it on failure; gpg uses the INT_RCP_FPR subpacket in revocation signatures. Fixes: a use-after-free in batch key generation, a gpgsm_verify regression with expired certificates, gpgsm now requires a minimum tag length for GCM decryption (CVE-2026-34182), and scd limits the size of returned APDU objects from faulty cards.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT (main, reboot-35870-gc0262ed5af)
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** generic

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>