### PR TITLE
libjwt: update to 3.6.1

### DIFF
--- a/libs/libjwt/Makefile
+++ b/libs/libjwt/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libjwt
-PKG_VERSION:=3.3.3
+PKG_VERSION:=3.6.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/benmcollins/libjwt/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=a562e5548a8e10ac6fcba64a5e6d326c15712211cb54d25242c15e8b3250b4f2
+PKG_HASH:=b483a5f77e548964553f54a0ec5f0c810cc6c0629c5ac5a03610bcced150e7be
 
 PKG_LICENSE:=MPL-2.0
 PKG_LICENSE_FILES:=LICENSE
@@ -28,7 +28,7 @@ define Package/libjwt
   TITLE:=libjwt
   URL:=https://github.com/benmcollins/libjwt
   DEPENDS:=+libopenssl +jansson
-  ABI_VERSION:=0
+  ABI_VERSION:=14
 endef
 
 define Package/libjwt/description
@@ -40,7 +40,6 @@ endef
 define Package/libjwt/install
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libjwt.so* $(1)/usr/lib/
-	$(LN) libjwt.so.0 $(1)/usr/lib/libjwt.so
 endef
 
 $(eval $(call BuildPackage,libjwt))


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @dangowrt
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
From 3.3.3, via 3.4.0/3.5.0/3.6.0. Adds a complete JWE implementation, post-quantum ML-DSA signatures, JWS JSON Serialization with multiple signatures, unencoded/detached payloads, JWK thumbprints, confirmation/proof-of-possession, cached remote JWKS with SSRF guards, and application profiles for at+jwt/DPoP/VAPID/PASSporT/OpenID4VCI/mTLS/JAdES.

Packaging fix: upstream's SONAME moved from `libjwt.so.0` to `libjwt.so.14` somewhere in the 3.4-3.6 range. Bumped `ABI_VERSION` from 0 to 14 (renames the built package to `libjwt14`) and dropped the install rule's stale `$(LN) libjwt.so.0 .../libjwt.so`, which would have overwritten the correct symlink already produced by $(CP) with a dangling one. Verified against the built tree that `libjwt.so -> libjwt.so.14 -> libjwt.so.14.4.1` is now correct.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT (main, reboot-35870-gc0262ed5af)
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** generic

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>