### PR TITLE
lvm2: update to 2.03.42

### DIFF
--- a/utils/lvm2/Makefile
+++ b/utils/lvm2/Makefile
@@ -9,15 +9,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=LVM2
-PKG_VERSION:=2.03.41
-PKG_VERSION_DM:=1.02.215
+PKG_VERSION:=2.03.42
+PKG_VERSION_DM:=1.02.216
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME).$(PKG_VERSION).tgz
 PKG_SOURCE_URL:=https://sourceware.org/pub/lvm2 \
                 https://www.mirrorservice.org/sites/sourceware.org/pub/lvm2
 
-PKG_HASH:=d58011b845df8ec13816ca13ea6c39d4cb3d038cd2d7d387acdf5681ad7d6637
+PKG_HASH:=352703ef5b72ebb22d4f250284a29b89fe64d4049c6bf64c693f9af486c8081e
 PKG_BUILD_DIR:=$(BUILD_DIR)/lvm2-$(BUILD_VARIANT)/$(PKG_NAME).$(PKG_VERSION)
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>

--- a/utils/lvm2/patches/002-const-stdio.patch
+++ b/utils/lvm2/patches/002-const-stdio.patch
@@ -1,6 +1,23 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Daniel Golle <daniel@makrotopia.org>
+Date: Sat, 25 Apr 2015 23:34:05 +0200
+Subject: [PATCH] const-stdio: guard glibc-specific stream buffering behind
+ __GLIBC__
+
+create_toolcontext()/destroy_toolcontext() tune glibc's stdio stream
+buffering directly via glibc-only internals; _check_standard_fds() has
+a musl-compatible fallback path already available. Wrap the
+glibc-specific code in #ifdef __GLIBC__ so this builds against musl.
+
+Signed-off-by: Daniel Golle <daniel@makrotopia.org>
+---
+ lib/commands/toolcontext.c | 4 ++++
+ tools/lvmcmdline.c         | 7 +++++++
+ 2 files changed, 11 insertions(+)
+
 --- a/lib/commands/toolcontext.c
 +++ b/lib/commands/toolcontext.c
-@@ -1665,6 +1665,7 @@ struct cmd_context *create_toolcontext(c
+@@ -1666,6 +1666,7 @@ struct cmd_context *create_toolcontext(c
  	/* FIXME Make this configurable? */
  	reset_lvm_errno(1);
  
@@ -8,7 +25,7 @@
  	/* Set in/out stream buffering before glibc */
  	if (set_buffering
  	    && !cmd->running_on_valgrind /* Skipping within valgrind execution. */
-@@ -1709,6 +1710,7 @@ struct cmd_context *create_toolcontext(c
+@@ -1710,6 +1711,7 @@ struct cmd_context *create_toolcontext(c
  	} else if (!set_buffering)
  		/* Without buffering, must not use stdin/stdout */
  		init_silent(1);
@@ -16,7 +33,7 @@
  
  	/*
  	 * Environment variable LVM_SYSTEM_DIR overrides this below.
-@@ -2047,6 +2049,7 @@ void destroy_toolcontext(struct cmd_cont
+@@ -2048,6 +2050,7 @@ void destroy_toolcontext(struct cmd_cont
  	if (cmd->cft_def_hash)
  		dm_hash_destroy(cmd->cft_def_hash);
  
@@ -24,7 +41,7 @@
  	if (!cmd->running_on_valgrind && cmd->linebuffer) {
  		int flags;
  		/* Reset stream buffering to defaults */
-@@ -2070,6 +2073,7 @@ void destroy_toolcontext(struct cmd_cont
+@@ -2071,6 +2074,7 @@ void destroy_toolcontext(struct cmd_cont
  
  		free(cmd->linebuffer);
  	}

--- a/utils/lvm2/patches/003-no-mallinfo.patch
+++ b/utils/lvm2/patches/003-no-mallinfo.patch
@@ -1,3 +1,21 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Daniel Golle <daniel@makrotopia.org>
+Date: Sat, 25 Apr 2015 23:34:05 +0200
+Subject: [PATCH] no-mallinfo: guard glibc mallinfo()/mlockall policy behind
+ __GLIBC__
+
+_allocate_memory()'s heap-growth probing uses glibc's MALLINFO/mallinfo(),
+which musl doesn't provide; guard it behind #ifdef __GLIBC__ and always
+grow by the full alloc_size on musl instead. Likewise _lock_mem() reads
+activation/use_mlockall from lvm.conf on glibc but always uses mlockall
+unconditionally on musl, where the glibc-specific heuristic this option
+tunes doesn't apply.
+
+Signed-off-by: Daniel Golle <daniel@makrotopia.org>
+---
+ lib/mm/memlock.c | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
 --- a/lib/mm/memlock.c
 +++ b/lib/mm/memlock.c
 @@ -209,12 +209,15 @@ static void _allocate_memory(void)
@@ -29,7 +47,7 @@
  
  		if (area == MAX_AREAS && missing > 0) {
  			/* Too bad. Warn the user and proceed, as things are
-@@ -560,8 +566,13 @@ static void _lock_mem(struct cmd_context
+@@ -565,8 +571,13 @@ static void _lock_mem(struct cmd_context
  	 * will not block memory locked thread
  	 * Note: assuming _memlock_count_daemon is updated before _memlock_count
  	 */


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @dangowrt
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
From 2.03.41. Substantial pvmove-in-shared-VG work for lvmlockd (new --lockopt retries/removeretry, cluster lock lifecycle, metadata auto-revert, activation refusal across nodes, suspend+resume for DM table reload), VDO formatting with the kernel vdo target (>=9.2), and new --enable-asan/--enable-tsan build options.

The tarball also bundles device-mapper as a separately versioned component; bumped `PKG_VERSION_DM` from 1.02.215 to 1.02.216 to match upstream's `VERSION_DM` file (libdm made thread safe, dm_vdo_target_params gained use_kernel_format, new libdevmapper-san with asan/tsan support).

Refreshed 002-const-stdio.patch and 003-no-mallinfo.patch against the new upstream source: hunk offsets only, no diff content changed, but both patches also gained a proper `From <hash> Mon Sep 17 00:00:00 2001` / `From:` / `Date:` / `Subject:` / `Signed-off-by:` header block (neither patch had one before), attributed to their original author/date via `git log --follow`.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT (main, reboot-35870-gc0262ed5af)
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** generic

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
<sub>(No new patch *content* here — this is a hunk-offset refresh against the new upstream source, plus adding the git-am header block both patches were missing.)</sub>