### PR TITLE
postgresql: update to 18.6

### DIFF
--- a/libs/postgresql/Makefile
+++ b/libs/postgresql/Makefile
@@ -5,7 +5,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=postgresql
-PKG_VERSION:=18.4
+PKG_VERSION:=18.6
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
@@ -16,7 +16,7 @@ PKG_CPE_ID:=cpe:/a:postgresql:postgresql
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://ftp.postgresql.org/pub/source/v$(PKG_VERSION)
 
-PKG_HASH:=81a81ec695fb0c7901407defaa1d2f7973617154cf27ba74e3a7ab8e64436094
+PKG_HASH:=555610c24d53e4316da5b7d3fc25c279d96856d5e0e23ee308c328c5fa881d9f
 
 PKG_BUILD_FLAGS:=no-mips16
 PKG_FIXUP:=autoreconf


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @dangowrt
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
Security release from 18.4 (18.5 was never released upstream; pulled post-wrap due to a regression). A dump/restore is not required for those already on 18.x, but see the upstream migration notes for GIN index reltuples corruption and btree_gist/ltree reindexing.

- restrict logical decoding output plugins to a new output_plugin_libraries allowlist (CVE-2026-6471)
- fix contrib/pgcrypto to detect unsupported ciphers instead of silently XORing plaintext (CVE-2026-14663)
- fix psql to skip in-line data after a failed scripted `COPY ... FROM STDIN` (SQL-injection hazard in scripts) (CVE-2026-6464)
- cross-check the output row type of a portal running EXECUTE/FETCH; divergence could leak server memory or lead to arbitrary code execution (CVE-2026-16239)
- fix a buffer overrun with a long time zone abbreviation in to_char() (CVE-2026-14669)

Plus a variety of other fixes from 18.4; see the upstream release notes for the complete list.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT (main, reboot-35870-gc0262ed5af)
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** generic

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>