### PR TITLE
snowflake: update to 2.14.1

### DIFF
--- a/net/snowflake/Makefile
+++ b/net/snowflake/Makefile
@@ -1,13 +1,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=snowflake
-PKG_VERSION:=2.13.1
+PKG_VERSION:=2.14.1
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/snowflake.git
 PKG_SOURCE_VERSION:=v$(PKG_VERSION)
-PKG_MIRROR_HASH:=a993a8fae3ce8ff545615c21f95e134c77b2904c2ff062bd33a9a4683810da18
+PKG_MIRROR_HASH:=e6a0d04f1273cd58f67e6d95527cf5b33d56aecc3932044979c6f5666f2c02b7
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE

--- a/net/snowflake/test.sh
+++ b/net/snowflake/test.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+case "$1" in
+snowflake-broker|\
+snowflake-client|\
+snowflake-probetest|\
+snowflake-proxy|\
+snowflake-server)
+	# broker and probetest have no -version flag upstream, so this
+	# checks that each binary runs and prints its usage rather than
+	# matching a version/identity string
+	"$1" -h 2>&1 | grep "Usage"
+	;;
+esac


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @dangowrt
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
Git-sourced rolling package, from v2.13.1. Notable upstream changes: broker WebRTC offer/answer validation, SDP deserialization type-assertion checks, proxy poll-loop refactor (ticker, immediate return from runSession, adjust per ProxyPollResponse), broker poll-interval-from-file loading and nil-pointer-dereference fix, and covert-dtls config/API improvements. Full commit range (v2.13.1..v2.14.1) is in the commit message.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT (main, reboot-35870-gc0262ed5af)
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** generic

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>