### PR TITLE
xdg-dbus-proxy: update to 0.1.8

### DIFF
--- a/utils/xdg-dbus-proxy/Makefile
+++ b/utils/xdg-dbus-proxy/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=xdg-dbus-proxy
-PKG_VERSION:=0.1.7
-PKG_RELEASE:=2
+PKG_VERSION:=0.1.8
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/flatpak/$(PKG_NAME)/releases/download/$(PKG_VERSION)
-PKG_HASH:=3ad3d27ba574e178acb5e4d438ba36ace25e3564f899c36f31c56f82c7adbbe7
+PKG_HASH:=b6630bd24f8161b0e2546d2acbb014a3b3249f5c0d75f2a863ade898b9034d3d
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=LGPL-2.1-or-later


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @dangowrt
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
From 0.1.7. Security-relevant: fixes broadcast messages bypassing this filtering D-Bus proxy's own path/interface/member checks. Also improves the test infrastructure and adds tests for owning names, issuing method calls, and receiving messages.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT (main, reboot-35870-gc0262ed5af)
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** generic

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>