### PR TITLE
maddy: add new package

### DIFF
--- a/mail/maddy/Makefile
+++ b/mail/maddy/Makefile
@@ -1,0 +1,66 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=maddy
+PKG_VERSION:=0.9.5
+PKG_RELEASE:=1
+PKG_LICENSE:=GPL-3.0-or-later
+PKG_LICENSE_FILES:=COPYING
+
+PKG_SOURCE:=$(PKG_NAME)-v$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/foxcpp/maddy/tar.gz/v${PKG_VERSION}?
+PKG_HASH:=c5670ff64930a4d69053557cdf252527b54c32bff882c33d120bd208f34a6e19
+
+PKG_MAINTAINER:=Romain Isnel <ri@frmg.eu>
+
+PKG_BUILD_DEPENDS:=golang/host
+PKG_BUILD_PARALLEL:=1
+PKG_BUILD_FLAGS:=no-mips16
+
+GO_PKG:=github.com/foxcpp/maddy
+GO_PKG_BUILD_PKG:=github.com/foxcpp/maddy/cmd/maddy
+GO_PKG_LDFLAGS_X:=$(GO_PKG).Version=$(PKG_VERSION)
+
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/golang/golang-package.mk
+
+define Package/maddy
+  SECTION:=mail
+  CATEGORY:=Mail
+  TITLE:=Composable all-in-one mail server
+  URL:=https://github.com/foxcpp/maddy
+  USERID:=maddy:maddy
+  DEPENDS:=$(GO_ARCH_DEPENDS) +ca-bundle
+endef
+
+define Package/maddy/conffiles
+/etc/maddy/maddy.conf
+/etc/config/maddy
+endef
+
+define Package/maddy/description
+  Maddy Mail Server implements all functionality required to run an e-mail server.
+  It can send messages via SMTP (works as MTA), accept messages via SMTP (works as MX)
+  and store messages while providing access to them via IMAP. In addition to that it
+  implements auxiliary protocols that are mandatory to keep email reasonably secure
+  (DKIM, SPF, DMARC, DANE, MTA-STS).
+endef
+
+define Package/maddy/install
+	$(INSTALL_DIR) $(1)/usr/bin/
+	$(INSTALL_BIN) $(GO_PKG_BUILD_BIN_DIR)/maddy $(1)/usr/bin/maddy
+
+	$(INSTALL_DIR) $(1)/etc/init.d/
+	$(INSTALL_BIN) $(CURDIR)/files/maddy.init $(1)/etc/init.d/maddy
+
+	$(INSTALL_DIR) $(1)/etc/maddy/
+	$(INSTALL_CONF) $(PKG_BUILD_DIR)/maddy.conf $(1)/etc/maddy/maddy.conf
+
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_CONF) $(CURDIR)/files/maddy.uci $(1)/etc/config/maddy
+
+	$(INSTALL_DIR) $(1)/etc/capabilities/
+	$(INSTALL_DATA) $(CURDIR)/files/maddy.json $(1)/etc/capabilities/maddy.json
+endef
+
+$(eval $(call GoBinPackage,maddy))
+$(eval $(call BuildPackage,maddy))

--- a/mail/maddy/files/maddy.init
+++ b/mail/maddy/files/maddy.init
@@ -1,0 +1,67 @@
+#!/bin/sh /etc/rc.common
+
+START=99
+STOP=10
+USE_PROCD=1
+PROG=/usr/bin/maddy
+CONF_DIR=/etc/maddy
+CONF_FILE=$CONF_DIR/maddy.conf
+RUNTIME_DIR=/run/maddy
+STATE_DIR=/var/lib/maddy
+USER=maddy
+GROUP=maddy
+
+start_service() {
+	config_load 'maddy'
+	local config_name='config'
+
+	local gc maxprocs memlimit
+
+	uci_validate_section 'maddy' 'maddy' "$config_name" \
+		'jail_mount:list(string)' \
+		'jail_mount_rw:list(string)' \
+		'gc:uinteger:0' \
+		'maxprocs:uinteger:0' \
+		'memlimit:uinteger:0'
+
+	[ -d $RUNTIME_DIR ] || mkdir -m 0750 -p $RUNTIME_DIR
+	[ -d $STATE_DIR ] || mkdir -m 0750 -p $STATE_DIR
+
+	chown $USER:$GROUP -R $CONF_DIR
+	chown $USER:$GROUP -R $STATE_DIR
+	chown $USER:$GROUP -R $RUNTIME_DIR
+
+	procd_open_instance "maddy"
+
+	procd_set_param command "$PROG"
+	procd_append_param command --config $CONF_FILE
+	procd_append_param command run
+
+	[ "$gc" -le 0 ] || procd_append_param env GOGC="$gc"
+	[ "$maxprocs" -le 0 ] || procd_append_param env GOMAXPROCS="$maxprocs"
+	[ "$memlimit" -le 0 ] || procd_append_param env GOMEMLIMIT="${memlimit}MiB"
+
+	procd_set_param user "$USER"
+	procd_set_param group "$GROUP"
+	procd_set_param stdout 1
+	procd_set_param stderr 1
+	procd_set_param respawn
+	procd_set_param file "$CONF_FILE"
+
+	procd_add_jail maddy
+	procd_add_jail_mount $CONF_DIR
+	procd_add_jail_mount_rw $RUNTIME_DIR
+	procd_add_jail_mount_rw $STATE_DIR
+	config_list_foreach "$config_name" jail_mount procd_add_jail_mount
+	config_list_foreach "$config_name" jail_mount_rw procd_add_jail_mount_rw
+	procd_add_jail_mount /etc/ssl/certs
+
+	procd_set_param capabilities "/etc/capabilities/maddy.json"
+	procd_set_param no_new_privs 1
+
+	procd_close_instance
+}
+
+service_triggers() {
+	procd_add_reload_trigger 'maddy'
+}

--- a/mail/maddy/files/maddy.json
+++ b/mail/maddy/files/maddy.json
@@ -1,0 +1,17 @@
+{
+	"bounding": [
+		"CAP_NET_BIND_SERVICE"
+	],
+	"effective": [
+		"CAP_NET_BIND_SERVICE"
+	],
+	"ambient": [
+		"CAP_NET_BIND_SERVICE"
+	],
+	"permitted": [
+		"CAP_NET_BIND_SERVICE"
+	],
+	"inheritable": [
+		"CAP_NET_BIND_SERVICE"
+	]
+}

--- a/mail/maddy/files/maddy.uci
+++ b/mail/maddy/files/maddy.uci
@@ -1,0 +1,21 @@
+
+config maddy 'config'
+	# Files and directories that maddy has read-only access to
+	# list jail_mount '/etc/ssl/maddy.crt'
+	# list jail_mount '/etc/ssl/maddy.key'
+
+	# Files and directories that maddy has read-write access to
+	# list jail_mount_rw '/path/to/dir'
+
+	# Go lang runtime options
+
+	# More info: https://go.dev/doc/gc-guide#GOGC
+	option gc '0'
+
+	# Max number of OS threads to use
+	# 0 to match the number of CPUs (default)
+	# >0 to explicitly specify concurrency
+	option maxprocs '0'
+
+	# Soft memory limit in MB, 0 to disable
+	option memlimit '0'

--- a/mail/maddy/test-version.sh
+++ b/mail/maddy/test-version.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+# shellcheck shell=busybox
+
+case "$PKG_NAME" in
+maddy)
+	maddy version | grep -F "$PKG_VERSION"
+	;;
+*)
+	echo "Untested package: $PKG_NAME" >&2
+	exit 1
+	;;
+esac


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @fromagium

**Description:**
Maddy is a composable all-in-one mail server. It implements all functionality required to run a e-mail server into a single daemon.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT (main, r35836-20d94d5a2b)
- **OpenWrt Target/Subtarget:** Filogic 8x0 (MT798x)
- **OpenWrt Device:** Bananapi BPi-R4

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.