### PR TITLE
slide-switch: update to 1.0.1

### DIFF
--- a/utils/slide-switch/Makefile
+++ b/utils/slide-switch/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2016, 2018-2019, 2022 Jeffery To
+# Copyright (C) 2016, 2018-2019, 2022, 2026 Jeffery To
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=slide-switch
-PKG_VERSION:=1.0.0
+PKG_VERSION:=1.0.1
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/jefferyto/openwrt-slide-switch.git
-PKG_MIRROR_HASH:=3c1604b78c92172f1f219a92bcab52ae1d6fe440b40b6dd7cfa23456d499d3a5
+PKG_MIRROR_HASH:=2670b64e8e906daa4f7bdbc2a0edc9589729abf7eca8ab374b7d20a8356ab160
 PKG_SOURCE_VERSION:=$(PKG_VERSION)
 
 PKG_BUILD_PARALLEL:=1


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me

**Description:**
Release notes: https://github.com/jefferyto/openwrt-slide-switch/releases/tag/1.0.1

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 2026-08-20 snapshot
- **OpenWrt Target/Subtarget:** armsr/armv7
- **OpenWrt Device:** qemu

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
