### PR TITLE
zabbix: default agentd to enabled

### DIFF
--- a/admin/zabbix/Makefile
+++ b/admin/zabbix/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zabbix
 PKG_VERSION:=7.0.29
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://cdn.zabbix.com/zabbix/sources/stable/$(basename $(PKG_VERSION))/ \

--- a/admin/zabbix/files/zabbix_agentd.config
+++ b/admin/zabbix/files/zabbix_agentd.config
@@ -1,4 +1,4 @@
 
 config zabbix_agentd 'general'
-    option enabled 0
+    option enabled 1
     # option never_root 1

--- a/admin/zabbix/files/zabbix_agentd.init
+++ b/admin/zabbix/files/zabbix_agentd.init
@@ -27,7 +27,7 @@ start_service() {
 
 	# Get enabled config option
 	config_load "$NAME"
-	config_get_bool enabled general enabled 0
+	config_get_bool enabled general enabled 1
 	config_get_bool never_root general never_root 1
 
 	# shellcheck disable=SC2154


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @danielfdickinson

**Description:**

With the addition of the enabled / disabled config for zabbix-agentd, the agent will not start after the upgrade to 7.0.29. Based on the discussion in #30317 and much consideration, it has been decided to make the agend default enabled but leave the server and proxy to
default disabled.

This is because the agent can successfully launch and at least be harmless if it started without additional configuration. The same is not true of the server and proxy, which will fail to start (creating procd 'crash loop').

Closes: #30317

---

## 🧪 Run Testing Details

TODO: Testing will be done once the 'curses' issue is resolved and SDK building works again.

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
