### PR TITLE
strongswan: drop legacy frontend from full package

### DIFF
--- a/net/strongswan/Makefile
+++ b/net/strongswan/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=strongswan
 PKG_VERSION:=6.0.7
-PKG_RELEASE:=7
+PKG_RELEASE:=8
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://download.strongswan.org/ https://download2.strongswan.org/
@@ -150,7 +150,6 @@ $(call Package/strongswan/Default)
   DEPENDS:= strongswan \
 	+strongswan-charon \
 	+strongswan-charon-cmd \
-	+strongswan-ipsec \
 	+strongswan-mod-addrblock \
 	+strongswan-mod-aes \
 	+strongswan-mod-agent \
@@ -216,7 +215,6 @@ $(call Package/strongswan/Default)
 	+strongswan-mod-sql \
 	+strongswan-mod-sqlite \
 	+strongswan-mod-sshkey \
-	+strongswan-mod-stroke \
 	+strongswan-mod-test-vectors \
 	+strongswan-mod-unity \
 	+strongswan-mod-updown \
@@ -234,10 +232,9 @@ endef
 
 define Package/strongswan-full/description
 $(call Package/strongswan/description/Default)
- This meta-package contains dependencies for all of the strongswan plugins
- except kernel-libipsec,
- socket-dynamic and which are omitted in favor of the kernel-netlink and
- socket-default plugins.
+  This meta-package contains dependencies for most strongSwan plugins. It uses
+  kernel-netlink, socket-default and the swanctl frontend instead of
+  kernel-libipsec, socket-dynamic and the legacy stroke frontend.
 endef
 
 


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @pprindeville, @Thermi 

**Description:**

strongswan-full currently installs both the legacy ipsec/stroke frontend and swanctl. This provides two init scripts for the same Charon daemon and can cause conflicts if both services are enabled.

Remove strongswan-ipsec and strongswan-mod-stroke from the meta-package, leaving swanctl as the supported frontend. The legacy packages remain available for users who explicitly need them.

This deliberately leaves the policy-based/XFRM choice unchanged.

Related: #21989

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT (`f1bf2d18392e`)
- **OpenWrt Target/Subtarget:** `x86/64`
- **OpenWrt Device:** build machine

Verified the generated strongswan-full package metadata. It reports version 6.0.7-r8, retains strongswan-swanctl and strongswan-mod-vici, and no longer includes strongswan-ipsec or strongswan-mod-stroke.

Also verified with git diff --check.

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.