### PR TITLE
nes-emulator: add package

### DIFF
--- a/multimedia/nes-emulator/Makefile
+++ b/multimedia/nes-emulator/Makefile
@@ -1,0 +1,102 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=nes-emulator
+PKG_VERSION:=1.0.0
+PKG_RELEASE:=1
+
+PKG_SOURCE:=openwrt-nes-emulator-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/communism420/openwrt-nes-emulator/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=a47435bd02c5610144a105d39c8e2d0f4a9940ee9eff02452353accec038feba
+PKG_BUILD_DIR:=$(BUILD_DIR)/openwrt-nes-emulator-$(PKG_VERSION)
+
+# The main repository intentionally does not vendor this large upstream core.
+# Keep the full commit so downloads and compiled provenance use the same pin.
+PKG_FCEUMM_VERSION:=76f68314ce4213703174108f461c431001dcc204
+
+PKG_LICENSE:=MIT GPL-2.0-only
+PKG_LICENSE_FILES:=LICENSE third_party/libretro-fceumm/Copying
+PKG_BUILD_FLAGS:=no-mips16 gc-sections
+PKG_BUILD_PARALLEL:=1
+PKG_ASLR_PIE_REGULAR:=1
+
+PKG_MAINTAINER:=Yaroslav Vereshchagin <yarik.vereshchagin1996@gmail.com>
+
+include $(INCLUDE_DIR)/package.mk
+
+FCEUMM_BUILD_DIR:=$(PKG_BUILD_DIR)/third_party/libretro-fceumm
+
+define Download/fceumm
+  FILE:=libretro-fceumm-$(PKG_FCEUMM_VERSION).tar.gz
+  URL:=https://codeload.github.com/libretro/libretro-fceumm/tar.gz/$(PKG_FCEUMM_VERSION)?
+  HASH:=b067ebd0a973751e9b5af56f5b54d74d0a6e67349549b392a4615d3f0d44f031
+endef
+$(eval $(call Download,fceumm))
+
+define Package/nes-emulator
+  SECTION:=multimedia
+  CATEGORY:=Multimedia
+  TITLE:=NES emulator service with built-in FCEUmm
+  URL:=https://github.com/communism420/openwrt-nes-emulator
+  DEPENDS:=+libatomic +libpthread
+  USERID:=nesd:nesd
+endef
+
+define Package/nes-emulator/description
+  Lightweight NES emulator service for OpenWrt with HTTP and WebSocket
+  streaming. The pinned FCEUmm libretro core is linked into nesd, so no
+  separate emulator-core package or shared object is required at run time.
+endef
+
+define Package/nes-emulator/conffiles
+/etc/config/nes-emulator
+endef
+
+define Build/Prepare
+	$(call Build/Prepare/Default)
+	$(INSTALL_DIR) $(FCEUMM_BUILD_DIR)
+	gzip -dc $(DL_DIR)/libretro-fceumm-$(PKG_FCEUMM_VERSION).tar.gz | \
+		$(HOST_TAR) --strip-components=1 \
+			-C $(FCEUMM_BUILD_DIR) $(TAR_OPTIONS)
+	$(call PatchDir,$(FCEUMM_BUILD_DIR),\
+		$(CURDIR)/patches-fceumm,)
+	$(if $(QUILT),touch $(FCEUMM_BUILD_DIR)/.quilt_used)
+endef
+
+define Quilt/Refresh/Package
+	$(call Quilt/RefreshDir,$(FCEUMM_BUILD_DIR),\
+		$(CURDIR)/patches-fceumm)
+endef
+
+# The only downstream patch stack belongs to the separately unpacked core.
+Build/Quilt=$(call Quilt/Template,$(FCEUMM_BUILD_DIR),,,Package)
+
+define Build/Compile
+	+$(MAKE) $(PKG_JOBS) -C $(PKG_BUILD_DIR)/package/nes-emulator/src \
+		BUILD_DIR="$(PKG_BUILD_DIR)/.nesd-build" \
+		TARGET="$(PKG_BUILD_DIR)/nesd" \
+		FCEUMM_DIR="$(FCEUMM_BUILD_DIR)" \
+		FCEUMM_GIT_VERSION="$(PKG_FCEUMM_VERSION)" \
+		FCEUMM_ENDIAN_CPPFLAGS="$(if $(filter y,$(CONFIG_BIG_ENDIAN)),-DMSB_FIRST)" \
+		CC="$(TARGET_CC)" \
+		AR="$(TARGET_AR)" \
+		RANLIB="$(TARGET_RANLIB)" \
+		CPPFLAGS="$(TARGET_CPPFLAGS)" \
+		CFLAGS="$(TARGET_CFLAGS) -std=c11" \
+		LDFLAGS="$(TARGET_LDFLAGS) -Wl,-z,stack-size=2097152" \
+		LDLIBS="-ldl -lpthread -lm -latomic"
+endef
+
+define Package/nes-emulator/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/nesd $(1)/usr/bin/nesd
+
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) $(CURDIR)/files/nes-emulator.init \
+		$(1)/etc/init.d/nes-emulator
+
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_CONF) $(CURDIR)/files/nes-emulator.config \
+		$(1)/etc/config/nes-emulator
+endef
+
+$(eval $(call BuildPackage,nes-emulator))

--- a/multimedia/nes-emulator/files/nes-emulator.config
+++ b/multimedia/nes-emulator/files/nes-emulator.config
@@ -1,0 +1,21 @@
+config nes-emulator 'main'
+	option enabled '0'
+	# These defaults use persistent overlay storage. On small-flash routers,
+	# point them at writable directories on mounted storage.
+	option rom_dir '/etc/nes-emulator/roms'
+	option extra_rom_dirs_enabled '0'
+	option system_dir '/etc/nes-emulator/system'
+	option save_dir '/etc/nes-emulator/saves'
+	option bind '0.0.0.0'
+	option port '29876'
+	option rom ''
+	# Optional exact browser Origin, for example https://192.168.1.1
+	option allowed_origin ''
+	# raw RGB565, max 60 fps — 2 fps is the conservative router-safe default
+	option stream_format 'raw'
+	option jpeg_quality '92'
+	option stream_fps '2'
+	option show_fps '1'
+	option show_touch_controls '1'
+	# Stored list entries are ignored unless extra_rom_dirs_enabled is 1.
+	# list extra_rom_dir '/mnt/sda1/roms'

--- a/multimedia/nes-emulator/files/nes-emulator.init
+++ b/multimedia/nes-emulator/files/nes-emulator.init
@@ -1,0 +1,657 @@
+#!/bin/sh /etc/rc.common
+
+# Consumed by /etc/rc.common rather than this file directly.
+# shellcheck disable=SC2034
+START=99
+STOP=10
+USE_PROCD=1
+EXTRA_COMMANDS="preflight"
+EXTRA_HELP="	preflight	Validate configuration and managed files without starting nesd"
+PROG=/usr/bin/nesd
+NAME=nes-emulator
+CONFIG_FILE=/etc/config/nes-emulator
+TOKEN_FILE=/etc/nes-emulator/auth.token
+LOCK_DIR=/var/run/nes-emulator
+TOKEN_LOCK_FILE="$LOCK_DIR/auth.token.lock"
+TOKEN_LOCK_MAX_ATTEMPTS=10
+TOKEN_LOCK_HELD=0
+NESD_UID=
+NESD_GID=
+NESD_GROUPS=
+EXTRA_ROMS_INVALID=0
+PATH_METADATA_MODE=
+PATH_METADATA_NLINK=
+PATH_METADATA_UID=
+PATH_METADATA_GID=
+
+log_error() {
+	logger -t "$NAME" -p daemon.err -- "$*"
+}
+
+log_warn() {
+	logger -t "$NAME" -p daemon.warn -- "$*"
+}
+
+normalize_stream_fps() {
+	local value="$1"
+
+	case "$value" in
+		''|*[!0-9]*)
+			printf '%s\n' 2
+			return 0
+			;;
+	esac
+	if [ "$value" -ge 1 ] && [ "$value" -le 60 ]; then
+		printf '%s\n' "$value"
+	else
+		printf '%s\n' 2
+	fi
+}
+
+read_path_metadata() {
+	local path="$1" metadata
+
+	metadata="$(LC_ALL=C ls -ldn "$path" 2>/dev/null)" || return 1
+	case "$metadata" in
+		*'
+'*) return 1 ;;
+	esac
+	# Intentional field splitting of the fixed-format numeric ls output.
+	# shellcheck disable=SC2086
+	set -- $metadata
+	[ "$#" -ge 4 ] || return 1
+	case "$2:$3:$4" in
+		*[!0-9:]*) return 1 ;;
+	esac
+	PATH_METADATA_MODE="$1"
+	PATH_METADATA_NLINK="$2"
+	PATH_METADATA_UID="$3"
+	PATH_METADATA_GID="$4"
+	return 0
+}
+
+validate_lock_directory() {
+	[ -d "$LOCK_DIR" ] && [ ! -L "$LOCK_DIR" ] || return 1
+	read_path_metadata "$LOCK_DIR" &&
+		[ "$PATH_METADATA_MODE" = drwx------ ] &&
+		[ "$PATH_METADATA_UID" = 0 ] &&
+		[ "$PATH_METADATA_GID" = 0 ]
+}
+
+validate_token_lock_file() {
+	[ -f "$TOKEN_LOCK_FILE" ] && [ ! -L "$TOKEN_LOCK_FILE" ] ||
+		return 1
+	read_path_metadata "$TOKEN_LOCK_FILE" &&
+		[ "$PATH_METADATA_MODE" = -rw------- ] &&
+		[ "$PATH_METADATA_NLINK" = 1 ] &&
+		[ "$PATH_METADATA_UID" = 0 ] &&
+		[ "$PATH_METADATA_GID" = 0 ]
+}
+
+prepare_lock_directory() {
+	if [ -e "$LOCK_DIR" ] || [ -L "$LOCK_DIR" ]; then
+		validate_lock_directory
+		return
+	fi
+	(
+		exec 8>&-
+		umask 077
+		mkdir "$LOCK_DIR"
+	) 2>/dev/null || validate_lock_directory || return 1
+	validate_lock_directory
+}
+
+prepare_token_lock_file() {
+	prepare_lock_directory || return 1
+	if [ -e "$TOKEN_LOCK_FILE" ] || [ -L "$TOKEN_LOCK_FILE" ]; then
+		validate_token_lock_file
+		return
+	fi
+	(
+		exec 8>&-
+		set -C
+		umask 077
+		: >"$TOKEN_LOCK_FILE"
+	) 2>/dev/null || validate_token_lock_file || return 1
+	validate_token_lock_file
+}
+
+repair_regular_metadata() {
+	local path="$1" expected_mode="$2" expected_uid="$3" expected_gid="$4"
+	local owner_group="$5" numeric_mode="$6"
+
+	[ -f "$path" ] && [ ! -L "$path" ] || return 1
+	read_path_metadata "$path" || return 1
+	[ "$PATH_METADATA_NLINK" = 1 ] || return 1
+	if [ "$PATH_METADATA_MODE" = "$expected_mode" ] &&
+	   [ "$PATH_METADATA_UID" = "$expected_uid" ] &&
+	   [ "$PATH_METADATA_GID" = "$expected_gid" ]; then
+		return 0
+	fi
+	chown "$owner_group" "$path" 2>/dev/null &&
+		chmod "$numeric_mode" "$path" 2>/dev/null || return 1
+	read_path_metadata "$path" &&
+		[ "$PATH_METADATA_MODE" = "$expected_mode" ] &&
+		[ "$PATH_METADATA_NLINK" = 1 ] &&
+		[ "$PATH_METADATA_UID" = "$expected_uid" ] &&
+		[ "$PATH_METADATA_GID" = "$expected_gid" ]
+}
+
+repair_directory_metadata() {
+	local path="$1" expected_uid="$2" expected_gid="$3"
+	local owner_group="$4"
+
+	[ -d "$path" ] && [ ! -L "$path" ] || return 1
+	read_path_metadata "$path" || return 1
+	if [ "$PATH_METADATA_MODE" = drwxr-x--- ] &&
+	   [ "$PATH_METADATA_UID" = "$expected_uid" ] &&
+	   [ "$PATH_METADATA_GID" = "$expected_gid" ]; then
+		return 0
+	fi
+	chown "$owner_group" "$path" 2>/dev/null &&
+		chmod 0750 "$path" 2>/dev/null || return 1
+	read_path_metadata "$path" &&
+		[ "$PATH_METADATA_MODE" = drwxr-x--- ] &&
+		[ "$PATH_METADATA_UID" = "$expected_uid" ] &&
+		[ "$PATH_METADATA_GID" = "$expected_gid" ]
+}
+
+directory_is_writable_by_nesd() {
+	if [ "$PATH_METADATA_UID" = "$NESD_UID" ]; then
+		case "$PATH_METADATA_MODE" in
+			d?w[xs]??????) return 0 ;;
+		esac
+	elif case " $NESD_GROUPS " in
+		*" $PATH_METADATA_GID "*) true ;;
+		*) false ;;
+	esac; then
+		case "$PATH_METADATA_MODE" in
+			d????w[xs]???) return 0 ;;
+		esac
+	else
+		case "$PATH_METADATA_MODE" in
+			d???????w[xt]) return 0 ;;
+		esac
+	fi
+	return 1
+}
+
+directory_is_readable_by_nesd() {
+	if [ "$PATH_METADATA_UID" = "$NESD_UID" ]; then
+		case "$PATH_METADATA_MODE" in
+			dr?[xs]??????) return 0 ;;
+		esac
+	elif case " $NESD_GROUPS " in
+		*" $PATH_METADATA_GID "*) true ;;
+		*) false ;;
+	esac; then
+		case "$PATH_METADATA_MODE" in
+			d???r?[xs]???) return 0 ;;
+		esac
+	else
+		case "$PATH_METADATA_MODE" in
+			d??????r?[xt]) return 0 ;;
+		esac
+	fi
+	return 1
+}
+
+directory_is_searchable_by_nesd() {
+	if [ "$PATH_METADATA_UID" = "$NESD_UID" ]; then
+		case "$PATH_METADATA_MODE" in
+			d??[xs]??????) return 0 ;;
+		esac
+	elif case " $NESD_GROUPS " in
+		*" $PATH_METADATA_GID "*) true ;;
+		*) false ;;
+	esac; then
+		case "$PATH_METADATA_MODE" in
+			d?????[xs]???) return 0 ;;
+		esac
+	else
+		case "$PATH_METADATA_MODE" in
+			d????????[xt]) return 0 ;;
+		esac
+	fi
+	return 1
+}
+
+external_data_dir_is_usable_by_nesd() {
+	local current="$1" required="${2:-write}" leaf=1
+
+	while :; do
+		read_path_metadata "$current" || return 1
+		if [ "$leaf" -eq 1 ]; then
+			case "$required" in
+				read) directory_is_readable_by_nesd || return 1 ;;
+				write) directory_is_writable_by_nesd || return 1 ;;
+				*) return 1 ;;
+			esac
+			leaf=0
+		else
+			directory_is_searchable_by_nesd || return 1
+		fi
+		[ "$current" != "/" ] || return 0
+		current="${current%/*}"
+		[ -n "$current" ] || current=/
+	done
+}
+
+secure_config_file() {
+	repair_regular_metadata "$CONFIG_FILE" -rw------- 0 0 root:root 0600
+}
+
+append_extra() {
+	local d="$1"
+	[ -n "$d" ] || return 0
+	valid_data_dir "$d" || {
+		log_error "refusing unsafe extra ROM directory: $d"
+		EXTRA_ROMS_INVALID=1
+		return 0
+	}
+	if [ -z "$EXTRA_ROMS" ]; then
+		EXTRA_ROMS="$d"
+	else
+		EXTRA_ROMS="$EXTRA_ROMS:$d"
+	fi
+}
+
+load_extra_rom_dirs() {
+	local extra_rom_dirs_enabled
+
+	config_get_bool extra_rom_dirs_enabled main extra_rom_dirs_enabled 0
+	[ "$extra_rom_dirs_enabled" -eq 1 ] || return 0
+	config_list_foreach main extra_rom_dir append_extra
+}
+
+valid_data_dir() {
+	local d="$1"
+
+	[ -n "$d" ] && [ "${d#/}" != "$d" ] || return 1
+	while [ "$d" != "/" ] && [ "${d%/}" != "$d" ]; do
+		d="${d%/}"
+	done
+	[ "$(printf '%s' "$d" | wc -l)" -eq 0 ] || return 1
+	case "$d" in
+		/|/bin|/boot|/dev|/etc|/home|/lib|/lib64|/mnt|/opt|/overlay|/proc|/root|/run|/sbin|/sys|/tmp|/usr|/var)
+			return 1
+			;;
+		*/../*|*/..|*/./*|*/.|*//*|*:*|*';'*|*,*)
+			return 1
+			;;
+	esac
+	return 0
+}
+
+prepare_data_dir() {
+	local d="$1"
+	local required="${2:-write}"
+	local existed=0
+	local access parent resolved
+
+	case "$required" in
+		read|write) ;;
+		*) log_error "invalid data-directory access requirement: $required"; return 1 ;;
+	esac
+
+	while [ "$d" != "/" ] && [ "${d%/}" != "$d" ]; do
+		d="${d%/}"
+	done
+
+	valid_data_dir "$d" || {
+		log_error "refusing unsafe data directory: $d"
+		return 1
+	}
+	if [ -e "$d" ] || [ -L "$d" ]; then
+		[ -d "$d" ] && [ ! -L "$d" ] || {
+			log_error "refusing non-directory or symlink data path: $d"
+			return 1
+		}
+		existed=1
+	else
+		parent="${d%/*}"
+		[ -n "$parent" ] || parent=/
+		if [ "$parent" = "/" ]; then
+			resolved="$(readlink -f / 2>/dev/null)" || return 1
+			[ "$resolved" = "/" ] || return 1
+		elif [ -e "$parent" ] || [ -L "$parent" ]; then
+			[ -d "$parent" ] && [ ! -L "$parent" ] || {
+				log_error "refusing unsafe parent directory: $parent"
+				return 1
+			}
+			resolved="$(readlink -f "$parent" 2>/dev/null)" || return 1
+			[ "$resolved" = "$parent" ] || {
+				log_error "refusing parent path containing a symlink: $parent"
+				return 1
+			}
+		else
+			prepare_data_dir "$parent" || return 1
+		fi
+		mkdir "$d" || {
+			log_error "cannot create data directory: $d"
+			return 1
+		}
+	fi
+
+	resolved="$(readlink -f "$d" 2>/dev/null)" || {
+		log_error "cannot resolve data directory: $d"
+		return 1
+	}
+	[ "$resolved" = "$d" ] || {
+		log_error "refusing data path containing a symlink: $d"
+		return 1
+	}
+
+	# Never change ownership or mode of an arbitrary pre-existing mount.
+	# The package-owned default tree and directories created here are safe.
+	case "$d" in
+		/etc/nes-emulator)
+			repair_directory_metadata "$d" 0 "$NESD_GID" root:nesd ||
+				return 1
+			;;
+		/etc/nes-emulator/*)
+			repair_directory_metadata "$d" "$NESD_UID" "$NESD_GID" \
+				nesd:nesd || return 1
+			;;
+		*)
+			if [ "$existed" -eq 0 ] &&
+			   ! repair_directory_metadata "$d" "$NESD_UID" "$NESD_GID" \
+				nesd:nesd; then
+				log_warn "cannot apply nesd ownership/mode to new external directory: $d;" \
+					"filesystems such as vfat/exfat cannot store them," \
+					"checking effective access instead"
+			fi
+			if ! external_data_dir_is_usable_by_nesd "$d" "$required"; then
+				case "$required" in
+					read) access=read/search ;;
+					*) access=write/search ;;
+				esac
+				log_error "external data path lacks $access access for nesd" \
+					"(uid $NESD_UID, primary gid $NESD_GID, groups $NESD_GROUPS): $d;" \
+					"adjust ownership/mode or mount uid/gid/dmask"
+				return 1
+			fi
+			;;
+	esac
+	return 0
+}
+
+token_is_valid() {
+	local token="$1"
+
+	[ "${#token}" -ge 32 ] 2>/dev/null &&
+		[ "${#token}" -le 127 ] 2>/dev/null || return 1
+	case "$token" in *[!A-Za-z0-9._~-]*) return 1 ;; esac
+	return 0
+}
+
+read_auth_token() {
+	local token bytes lines
+
+	repair_regular_metadata "$TOKEN_FILE" -rw-r----- 0 "$NESD_GID" \
+		root:nesd 0640 || return 1
+	token="$(cat "$TOKEN_FILE" 2>/dev/null)" || return 1
+	token_is_valid "$token" || return 1
+	bytes="$(wc -c <"$TOKEN_FILE" 2>/dev/null | tr -d ' ')"
+	lines="$(wc -l <"$TOKEN_FILE" 2>/dev/null | tr -d ' ')"
+	[ "$lines" = 1 ] &&
+		[ "$bytes" -eq $((${#token} + 1)) ] 2>/dev/null || return 1
+	return 0
+}
+
+write_auth_token() {
+	local token="$1" temporary
+
+	token_is_valid "$token" || return 1
+	[ -d "${TOKEN_FILE%/*}" ] && [ ! -L "${TOKEN_FILE%/*}" ] ||
+		return 1
+	if [ -e "$TOKEN_FILE" ] || [ -L "$TOKEN_FILE" ]; then
+		repair_regular_metadata "$TOKEN_FILE" -rw-r----- 0 "$NESD_GID" \
+			root:nesd 0640 || return 1
+	fi
+	temporary="$(mktemp "${TOKEN_FILE}.tmp.XXXXXX" 2>/dev/null)" ||
+		return 1
+	if ! printf '%s\n' "$token" >"$temporary" ||
+	   ! chown root:nesd "$temporary" 2>/dev/null ||
+	   ! chmod 0640 "$temporary" 2>/dev/null ||
+	   ! mv -f "$temporary" "$TOKEN_FILE"; then
+		rm -f "$temporary"
+		return 1
+	fi
+	return 0
+}
+
+release_token_lock() {
+	[ "$TOKEN_LOCK_HELD" -eq 1 ] || return 0
+	trap - 0 1 2 15
+	exec 8>&-
+	TOKEN_LOCK_HELD=0
+}
+
+acquire_token_lock() {
+	local attempts=0
+
+	[ "$TOKEN_LOCK_HELD" -eq 0 ] || return 0
+	prepare_token_lock_file || return 1
+	command exec 8<>"$TOKEN_LOCK_FILE" || return 1
+	validate_token_lock_file || {
+		exec 8>&-
+		return 1
+	}
+	while ! flock -n 8 2>/dev/null; do
+		attempts=$((attempts + 1))
+		if [ "$attempts" -ge "$TOKEN_LOCK_MAX_ATTEMPTS" ]; then
+			exec 8>&-
+			return 1
+		fi
+		sleep 1 8>&-
+	done
+	TOKEN_LOCK_HELD=1
+	trap 'release_token_lock' 0
+	trap 'release_token_lock; exit 1' 1 2 15
+	return 0
+}
+
+ensure_auth_token() {
+	local token legacy had_legacy=0 needs_write=0
+
+	acquire_token_lock || {
+		log_error "cannot acquire authentication token lock"
+		return 1
+	}
+	config_get legacy main auth_token ''
+	uci -q get nes-emulator.main.auth_token >/dev/null 2>&1 &&
+		had_legacy=1
+	if read_auth_token; then
+		:
+	elif token_is_valid "$legacy"; then
+		token="$legacy"
+		needs_write=1
+	else
+		token="$(hexdump -v -n 32 -e '1/1 "%02x"' \
+			/dev/urandom 2>/dev/null)" || token=
+		[ "${#token}" -eq 64 ] || {
+			log_error "cannot generate API authentication token"
+			release_token_lock
+			return 1
+		}
+		needs_write=1
+	fi
+	if [ "$needs_write" -eq 1 ]; then
+		write_auth_token "$token" || {
+			log_error "cannot securely save API authentication token"
+			release_token_lock
+			return 1
+		}
+	fi
+	if [ "$had_legacy" -eq 1 ]; then
+		if ! uci -q delete nes-emulator.main.auth_token ||
+		   ! uci -q commit nes-emulator ||
+		   ! secure_config_file; then
+			log_error "cannot remove legacy token from UCI"
+			release_token_lock
+			return 1
+		fi
+	fi
+
+	release_token_lock
+	return 0
+}
+
+start_service() {
+	local enabled rom_dir bind port system_dir save_dir rom
+	local jpeg_quality stream_fps show_fps show_touch_controls stream_format
+	local allowed_origin origin_authority
+	EXTRA_ROMS=""
+	EXTRA_ROMS_INVALID=0
+	umask 027
+
+	NESD_UID="$(id -u nesd 2>/dev/null)" || NESD_UID=
+	NESD_GID="$(id -g nesd 2>/dev/null)" || NESD_GID=
+	NESD_GROUPS="$(id -G nesd 2>/dev/null)" || NESD_GROUPS=
+	case "$NESD_UID:$NESD_GID" in
+		:*|*:|*[!0-9:]*)
+			log_error "missing or invalid nesd service account"
+			return 10
+			;;
+	esac
+	case "$NESD_GROUPS" in
+		''|*[!0-9\ ]*)
+			log_error "missing or invalid nesd service groups"
+			return 10
+			;;
+	esac
+	secure_config_file || {
+		log_error "refusing missing, linked, or insecure $CONFIG_FILE"
+		return 11
+	}
+	config_load nes-emulator || {
+		log_error "cannot load $CONFIG_FILE"
+		return 11
+	}
+	config_get_bool enabled main enabled 0
+
+	config_get rom_dir main rom_dir '/etc/nes-emulator/roms'
+	config_get bind main bind '0.0.0.0'
+	config_get port main port '29876'
+	config_get system_dir main system_dir '/etc/nes-emulator/system'
+	config_get save_dir main save_dir '/etc/nes-emulator/saves'
+	config_get rom main rom ''
+	config_get jpeg_quality main jpeg_quality '92'
+	config_get stream_fps main stream_fps '2'
+	config_get_bool show_fps main show_fps 1
+	config_get_bool show_touch_controls main show_touch_controls 1
+	config_get stream_format main stream_format 'raw'
+	config_get allowed_origin main allowed_origin ''
+	load_extra_rom_dirs
+	[ "$EXTRA_ROMS_INVALID" -eq 0 ] || return 13
+
+	case "$port" in
+		''|*[!0-9]*) log_error "invalid port: $port"; return 12 ;;
+	esac
+	[ "$port" -ge 1 ] 2>/dev/null && [ "$port" -le 65535 ] 2>/dev/null || {
+		log_error "port is outside 1..65535: $port"
+		return 12
+	}
+	case "$jpeg_quality" in ''|*[!0-9]*) jpeg_quality=92 ;; esac
+	[ "$jpeg_quality" -ge 1 ] 2>/dev/null &&
+		[ "$jpeg_quality" -le 100 ] 2>/dev/null || jpeg_quality=92
+	stream_fps="$(normalize_stream_fps "$stream_fps")"
+	case "$stream_format" in raw|jpeg) ;; *) stream_format=raw ;; esac
+	case "$bind" in
+		''|*[!0-9A-Fa-f:.]*) log_error "invalid bind address: $bind"; return 12 ;;
+	esac
+	case "$allowed_origin" in
+		'') ;;
+		http://*) origin_authority="${allowed_origin#http://}" ;;
+		https://*) origin_authority="${allowed_origin#https://}" ;;
+		*) log_error "allowed_origin must be an exact http(s) Origin"; return 12 ;;
+	esac
+	if [ -n "$allowed_origin" ]; then
+		[ "$(printf '%s' "$origin_authority" | wc -l)" -eq 0 ] || {
+			log_error "allowed_origin contains a line break"
+			return 12
+		}
+		case "$origin_authority" in
+			''|*/*|*\\*|*\?*|*\#*|*' '*|*'	'*|*@*)
+				log_error "allowed_origin must contain only scheme and authority"
+				return 12
+				;;
+		esac
+	fi
+
+	prepare_data_dir /etc/nes-emulator || return 13
+	ensure_auth_token || return 14
+	prepare_data_dir "$rom_dir" &&
+		prepare_data_dir "$system_dir" read &&
+		prepare_data_dir "$save_dir" || return 13
+
+	[ "${NESD_PREFLIGHT:-0}" = 1 ] && return 0
+	# The companion luci-app-nes-emulator RPCD bridge sets these variables for
+	# transient on-demand starts and token-rotation restarts.
+	[ "$enabled" -eq 1 ] || [ "${NESD_ON_DEMAND:-0}" = 1 ] || return 0
+
+	procd_open_instance nesd
+	procd_set_param command "$PROG"
+	procd_append_param command -d "$rom_dir"
+	procd_append_param command -b "$bind"
+	procd_append_param command -p "$port"
+	procd_append_param command -s "$system_dir"
+	procd_append_param command -S "$save_dir"
+	procd_append_param command -q "$jpeg_quality"
+	procd_append_param command -f "$stream_fps"
+	if [ "$show_fps" -eq 1 ]; then
+		procd_append_param command --show-fps
+	else
+		procd_append_param command --hide-fps
+	fi
+	if [ "$show_touch_controls" -eq 1 ]; then
+		procd_append_param command --show-touch-controls
+	else
+		procd_append_param command --hide-touch-controls
+	fi
+	procd_append_param command --auth-token-file "$TOKEN_FILE"
+	[ -n "$allowed_origin" ] &&
+		procd_append_param command --allowed-origin "$allowed_origin"
+	if [ "$stream_format" = "jpeg" ]; then
+		procd_append_param command --jpeg-video
+	else
+		procd_append_param command --raw-video
+	fi
+	[ -n "$EXTRA_ROMS" ] && procd_append_param command -e "$EXTRA_ROMS"
+	if [ "${NESD_ON_DEMAND:-0}" = 1 ] && [ "$enabled" -ne 1 ]; then
+		procd_append_param command --idle-exit-seconds 120
+	fi
+	# An RPC load starts an empty control daemon and then explicitly loads the
+	# selected path through /api/load.  Reusing a stale autoload path here
+	# would make nesd exit before its API becomes reachable and would prevent
+	# the user from selecting a replacement ROM.
+	if [ "${NESD_SKIP_AUTOLOAD:-0}" != 1 ] &&
+	   [ -n "$rom" ] && [ -f "$rom" ]; then
+		procd_append_param command -r "$rom"
+	fi
+
+	# Critical for routers: low priority so network stack is never starved
+	procd_set_param nice 5
+	procd_set_param user nesd
+	procd_set_param group nesd
+	procd_set_param limits core="0 0" nofile="64 64"
+	procd_set_param term_timeout 10
+	procd_set_param stdout 1
+	procd_set_param stderr 1
+	procd_close_instance
+}
+
+preflight() {
+	NESD_PREFLIGHT=1
+	start_service
+}
+
+service_triggers() {
+	procd_add_reload_trigger "nes-emulator"
+}
+
+reload_service() {
+	stop
+	start
+}

--- a/multimedia/nes-emulator/patches-fceumm/001-propagate-savestate-parse-errors.patch
+++ b/multimedia/nes-emulator/patches-fceumm/001-propagate-savestate-parse-errors.patch
@@ -1,0 +1,156 @@
+From e6d1dc153562ec4f888033d60dd3b7cddddd2c94 Mon Sep 17 00:00:00 2001
+From: Yaroslav Vereshchagin <yarik.vereshchagin1996@gmail.com>
+Date: Sat, 22 Aug 2026 14:00:00 +0300
+Subject: [PATCH 1/2] state: propagate savestate parse errors
+
+Return parser and payload-decoding failures from FCEUSS_Load_Mem and
+surface the result through retro_unserialize() instead of reporting
+every restore as successful.
+
+Upstream-Status: Backport [https://github.com/libretro/libretro-fceumm/commit/3db086eabeb6608706df330e7991b1bce8d25fba]
+Signed-off-by: Yaroslav Vereshchagin <yarik.vereshchagin1996@gmail.com>
+---
+ src/drivers/libretro/libretro.c |  3 +--
+ src/state.c                     | 38 +++++++++++++++++++++++----------
+ src/state.h                     |  2 +-
+ 3 files changed, 29 insertions(+), 14 deletions(-)
+
+--- a/src/drivers/libretro/libretro.c
++++ b/src/drivers/libretro/libretro.c
+@@ -3437,8 +3437,7 @@ bool retro_unserialize(const void * data
+    if (!data || size < 16 || size > retro_serialize_size() * 4)
+       return false;
+ 
+-   FCEUSS_Load_Mem(data, size);
+-   return true;
++   return FCEUSS_Load_Mem(data, size) != 0;
+ }
+ 
+ static int checkGG(char c)
+--- a/src/state.c
++++ b/src/state.c
+@@ -357,9 +357,15 @@ static int ReadStateChunks(memstream_t *
+    {
+       t = memstream_getc(st);
+       if (t == EOF)
++      {
++         ret = 0;
+          break;
++      }
+       if (!read32le_mem(&size, st))
++      {
++         ret = 0;
+          break;
++      }
+       /* size came straight off disk and is attacker-controlled. The
+        * arithmetic below was previously
+        *
+@@ -373,7 +379,10 @@ static int ReadStateChunks(memstream_t *
+        * payload, which is the only legitimate range. */
+       if (size > (uint32_t)0x7FFFFFFFu - 5
+             || (uint32_t)totalsize < size + 5)
++      {
++         ret = 0;
+          break;
++      }
+       totalsize -= (int32_t)(size + 5);
+ 
+       switch(t)
+@@ -406,12 +415,15 @@ static int ReadStateChunks(memstream_t *
+             break;
+          default:
+             if (memstream_seek(st, size, SEEK_CUR) < 0)
++            {
++               ret = 0;
+                goto endo;
++            }
+             break;
+       }
+    }
+ endo:
+-   return ret;
++   return ret && totalsize == 0;
+ }
+ 
+ extern int geniestage;
+@@ -458,7 +470,7 @@ size_t FCEUSS_Save_Mem(void *buf, size_t
+    return (size_t)totalsize + 16;
+ }
+ 
+-void FCEUSS_Load_Mem(const void *buf, size_t size)
++int FCEUSS_Load_Mem(const void *buf, size_t size)
+ {
+    memstream_t *mem = memstream_open((uint8_t*)buf, size, 0);
+ 
+@@ -472,7 +484,7 @@ void FCEUSS_Load_Mem(const void *buf, si
+     * buffer is supplied directly by retro_unserialize; treat NULL
+     * defensively rather than dereferencing. */
+    if (!mem)
+-      return;
++      return 0;
+ 
+    /* If the buffer is shorter than the 16-byte header the read returns
+     * fewer bytes; the magic-string memcmp would otherwise compare against
+@@ -481,13 +493,13 @@ void FCEUSS_Load_Mem(const void *buf, si
+    if (memstream_read(mem, header, 16) != 16u)
+    {
+       memstream_close(mem);
+-      return;
++      return 0;
+    }
+ 
+    if (memcmp(header, "FCS", 3) != 0)
+    {
+       memstream_close(mem);
+-      return;
++      return 0;
+    }
+ 
+    if (header[3] == 0xFF)
+@@ -505,25 +517,29 @@ void FCEUSS_Load_Mem(const void *buf, si
+    if (totalsize_u > 0x7FFFFFFFu)
+    {
+       memstream_close(mem);
+-      return;
++      return 0;
+    }
+    totalsize = (int32_t)totalsize_u;
+ 
+    x = ReadStateChunks(mem, totalsize);
+ 
++   if (!x)
++   {
++      memstream_close(mem);
++      return 0;
++   }
++
+    if (stateversion < 9500)
+       X.IRQlow = 0;
+ 
+    if (GameStateRestore)
+       GameStateRestore(stateversion);
+ 
+-   if (x)
+-   {
+-      FCEUPPU_LoadState(stateversion);
+-      FCEUSND_LoadState(stateversion);
+-   }
++   FCEUPPU_LoadState(stateversion);
++   FCEUSND_LoadState(stateversion);
+ 
+    memstream_close(mem);
++   return 1;
+ }
+ 
+ void ResetExState(void (*PreSave)(void), void (*PostSave)(void))
+--- a/src/state.h
++++ b/src/state.h
+@@ -25,7 +25,7 @@
+ 
+ #include "fceu-memory.h"
+ 
+-void FCEUSS_Load_Mem(const void *buf, size_t size);
++int FCEUSS_Load_Mem(const void *buf, size_t size);
+ size_t FCEUSS_Save_Mem(void *buf, size_t size);
+ 
+ typedef struct {

--- a/multimedia/nes-emulator/patches-fceumm/002-load-supplied-rom-buffer.patch
+++ b/multimedia/nes-emulator/patches-fceumm/002-load-supplied-rom-buffer.patch
@@ -1,0 +1,39 @@
+From 221584d62687fab8ddca74c5ea39471325428b34 Mon Sep 17 00:00:00 2001
+From: Yaroslav Vereshchagin <yarik.vereshchagin1996@gmail.com>
+Date: Sat, 22 Aug 2026 14:01:00 +0300
+Subject: [PATCH 2/2] libretro: load the frontend's immutable ROM buffer
+
+The project frontend supplies both the original content path and an
+already validated in-memory snapshot. Preserve the path for filename-based
+region detection and auxiliary-resource naming while loading the exact bytes
+that the frontend hashed. This closes the path/inode modification window
+between hashing and FCEUmm parsing.
+
+This package links the patched core only into nesd. FCEUmm advertises
+need_fullpath=true when content-info overrides are unavailable, so generic
+frontends may leave retro_game_info.data and size invalid. nesd deliberately
+supplies path, data and size together after reading and hashing the ROM.
+Loading that explicit buffer preserves nesd's hash/load invariant and is
+therefore kept as a downstream integration.
+
+Upstream-Status: Inappropriate [nesd frontend specific]
+Signed-off-by: Yaroslav Vereshchagin <yarik.vereshchagin1996@gmail.com>
+---
+ src/drivers/libretro/libretro.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+--- a/src/drivers/libretro/libretro.c
++++ b/src/drivers/libretro/libretro.c
+@@ -3966,6 +3966,12 @@ bool retro_load_game(const struct retro_
+ 
+       strlcpy(content_path, info->path,
+             sizeof(content_path));
++
++      if (info->data && info->size)
++      {
++         content_data = (const uint8_t *)info->data;
++         content_size = info->size;
++      }
+    }
+ 
+ #ifdef HAVE_HDPACK


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @communism420

**Description:**

Add `nes-emulator`, a router-side NES emulation service for OpenWrt.

The daemon provides authenticated HTTP and WebSocket streaming. No ROM or BIOS
files are included.

The recipe downloads the canonical SemVer-tagged project source and the pinned
FCEUmm commit as two independently SHA-256-verified archives. The two required
FCEUmm changes are feed-local, reviewable patches with authorship, DCO sign-off,
and upstream-status metadata. The daemon is built as a dynamically linked PIE
with OpenWrt hardening enabled.

The generic savestate error-propagation change was merged upstream through
[libretro-fceumm#653](https://github.com/libretro/libretro-fceumm/pull/653) as
[commit 3db086e](https://github.com/libretro/libretro-fceumm/commit/3db086eabeb6608706df330e7991b1bce8d25fba),
so patch 001 is marked as a backport. The package deliberately retains the
audited FCEUmm pin `76f68314`: the merge tip also contains an unrelated
savestate-format transition to 9900, while project v1.0.0 builds the embedded
core with `FCEU_VERSION_NUMERIC=9813`. That coordinated transition belongs in a
later project release.

The ROM-buffer change remains downstream-specific: FCEUmm advertises
`need_fullpath=true`, under which generic libretro frontends may leave `data`
and `size` invalid, while nesd deliberately supplies the path and the exact
buffer it hashed to preserve its hash/load invariant.

The feed owns and reviews the procd init script and UCI defaults directly. The
standard OpenWrt package lifecycle invokes the init script on a live root, and
the package-owned data tree is provisioned before the disabled-service early
return.

Existing external paths are never chowned or chmodded. For a newly created
external directory, ownership/mode repair is best-effort: a failure is logged
at `daemon.warn` because filesystems such as vfat/exfat may reject
`chown`/`chmod` while mount
`uid`, `gid`, and `dmask` options already provide the required access. The final
decision is always the effective-access check using the numeric `nesd` uid and
all effective groups. `rom_dir` and `save_dir` require write/search access;
`system_dir` requires read/search access; every ancestor must be searchable.
Failures report the required access and the relevant identity/mount guidance.
Metadata repair remains strict for the package-owned `/etc/nes-emulator` tree.

The init script and the companion
[`luci-app-nes-emulator`](https://github.com/openwrt/luci/pull/8962) RPCD bridge
coordinate authentication-token updates through
`/var/run/nes-emulator/auth.token.lock`. The shared runtime directory is
validated as root-owned mode `0700`; lock files must be root-owned regular
single-link files with mode `0600`. Files are created with no-clobber semantics,
opened catchably without truncation, and revalidated after opening.

The RPCD phase of token rotation permits at most seven one-second lock-wait
sleeps: two waits before the pre-dispatch token check, two inside rotation, and
three for the startup lock. A contended native restart can add at most nine
native token-lock sleeps, so the coordinated lock-wait bound is 16 rather than
seven. The companion LuCI view gives the complete non-cancellable operation a
120-second RPC budget.

This native package is the dependency of the separate LuCI submission.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12.5 on hardware; current SNAPSHOT SDK validation
- **OpenWrt Target/Subtarget:** mediatek/filogic; x86/64; armsr/armv8
- **OpenWrt Device:** ASUS RT-AX52 Pro (`aarch64_cortex-a53`)
- **Current review heads:** native `62ec2dff9`; LuCI `038ad57ad8`

The complete native/LuCI pair was tested on the router using native PR head
`b4424df4` and LuCI PR head `5028c07a`. Package installation and dependency
resolution, service control, ROM upload/loading, video, audio, controller
input, save/load state, and the FPS OSD all worked on the device.

The hardware-tested emulator and FCEUmm sources remain unchanged. Current heads
add the review-driven lifecycle, external-storage, protected-lock, bounded-wait,
isolated/unbatched long-RPC, and complete file-descriptor fixes without changing
the native binary source.

The source revision exporting these heads is covered by the successful
[project CI run](https://github.com/communism420/openwrt-nes-emulator/actions/runs/32956033619).
That run includes:

- plain ShellCheck and the complete `scripts/check.sh` suite
- official packages/LuCI export and template contracts
- vfat/exfat-style metadata-repair failure with both usable and unusable
  effective-access outcomes
- owner, supplementary-group, other, ancestor, and read-vs-write permission
  precedence
- protected lock creation, symlink/hardlink rejection, post-open validation,
  catchable opens, bounded waits, and rotation/start race contracts
- per-method isolated/unbatched LuCI long-RPC timeout, shared-module, and
  lock-fd inheritance contracts
- verified FCEUmm downloads/patches, a clean native build, and the complete
  black-box regression suite

The recipe and unchanged native binary were also validated with current x86/64
and armsr/armv8 SDKs:

- both codeload hashes match and both feed-local patches apply cleanly
- `make package/feeds/packages/nes-emulator/refresh V=s` was run twice; both
  runs left the patch series byte-identical
- both refreshed patches apply in order with `git am` to the pinned FCEUmm tree
- package check and compilation complete successfully
- generated APK metadata, maintainer, dependencies, files, and scriptlets were
  inspected
- `nesd --version` reports `1.0.0`
- packaged daemons are dynamically linked PIE executables with GNU RELRO,
  BIND_NOW, stack protection, and non-executable stacks

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/feeds/packages/nes-emulator/refresh V=s
  ```
- [x] It is structured in a way that it is potentially upstreamable
