### PR TITLE
crowdsec-firewall-bouncer: restart on config changes

### DIFF
--- a/net/crowdsec-firewall-bouncer/files/crowdsec-firewall-bouncer.initd
+++ b/net/crowdsec-firewall-bouncer/files/crowdsec-firewall-bouncer.initd
@@ -16,7 +16,7 @@ TABLE6="crowdsec6"
 
 service_triggers() {
 	procd_add_reload_trigger crowdsec-firewall-bouncer
-	procd_add_config_trigger "config.change" "crowdsec" /etc/init.d/crowdsec-firewall-bouncer reload
+	procd_add_config_trigger "config.change" "crowdsec" /etc/init.d/crowdsec-firewall-bouncer restart
 }
 
 init_yaml() {


### PR DESCRIPTION
The current `config.change` trigger invokes `reload` for changes to the
CrowdSec UCI configuration.

With the nftables backend, this can leave the bouncer running without its
dynamically populated CrowdSec sets after a configuration change. In
testing, `reload` replaced the nftables table and rotated the bouncer child
process, but the dynamic sets were not recreated or populated afterward.
The CAPI set remained absent across multiple update cycles.

A full `restart` correctly tears down the previous generation and starts a
fresh one. The new generation recreates the per-origin sets and repopulates
the decisions from LAPI.

Change the `config.change` trigger from `reload` to `restart` so
configuration changes follow that lifecycle.

Reproduction/verification on OpenWrt 25.12:

- Started from a healthy bouncer with a populated CAPI set (22,725 elements).
- Invoked the existing reload path.
- The nftables table was replaced and the bouncer child PID changed, while
  the procd-managed outer PID remained the same.
- The CAPI set remained absent for at least 60 seconds / six update cycles.
- Repeating the lifecycle using a full restart recreated all dynamic origin
  sets and hydrated 31,940 decisions.
- The resulting generation had populated CAPI, blocklist, and local CrowdSec
  sets, and authenticated LAPI access remained healthy.

This intentionally changes only the config-change lifecycle; the explicit
reload command remains available through the existing reload trigger.
