### PR TITLE
ddns-scripts: add ionos.com dyndns provider

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.4
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_LICENSE:=GPL-2.0
 

--- a/net/ddns-scripts/files/usr/share/ddns/default/ionos.com.json
+++ b/net/ddns-scripts/files/usr/share/ddns/default/ionos.com.json
@@ -1,0 +1,9 @@
+{
+        "name": "ionos.com",
+        "ipv4": {
+                "url": "https://ipv4.api.hosting.ionos.com/dns/v1/dyndns?q=[PASSWORD]&ipv4=[IP]"
+        },
+        "ipv6": {
+                "url": "https://ipv4.api.hosting.ionos.com/dns/v1/dyndns?q=[PASSWORD]&ipv6=[IP]"
+        }
+}

--- a/net/ddns-scripts/files/usr/share/ddns/list
+++ b/net/ddns-scripts/files/usr/share/ddns/list
@@ -40,6 +40,7 @@ he.net
 hetzner.cloud
 hosting.de
 infomaniak.com
+ionos.com
 ipnodns.ru
 ipv64.net
 inwx.de


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @databloat
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
Adds ionos.com as predefined DDNS service. IONOS' dynamic DNS API only supports domains hosted at IONOS and uses a single fixed update URL with a generated token as password; no username or domain parameter is required in the request itself.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12.5
- **OpenWrt Target/Subtarget:** qoriq/generic
- **OpenWrt Device:** WatchGuard M300

---

## ✅ Formalities

- [ X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
