### PR TITLE
comrade: update to 0.1.16, add a comrade-tests package and test.sh

### DIFF
--- a/net/comrade/Makefile
+++ b/net/comrade/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=comrade
-PKG_VERSION:=0.1.1
+PKG_VERSION:=0.1.16
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://codeload.github.com/dangowrt/comrade/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=b778bbc4aa61e6e77632f4931557a2831eb80ef981f099d175d48b40324d4619
+PKG_SOURCE_URL:=https://github.com/dangowrt/comrade/releases/download/v$(PKG_VERSION)
+PKG_HASH:=1054b4b3df410401caa0b35d64b35c0f95c5dce91f617f25fbccb03bdd60553a
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=AGPL-3.0-or-later
@@ -24,29 +24,25 @@ PKG_BUILD_FLAGS:=gc-sections lto
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
 
-# The GitHub source archive used above carries no submodule content, so
-# deps/always-online-stun arrives as an empty directory; without the file
-# below CMake falls back to three hard-coded servers. This is the same list
-# that submodule would provide, pinned to the commit the v$(PKG_VERSION) tag
-# references. Either way "comrade stun-update" refreshes the pool at
-# runtime into the user's data directory.
-STUN_LIST_VERSION:=0932114f96cd80886f559994545692870df73804
+# The release tarball above is minted with `git archive` in upstream's own
+# release CI, not GitHub's codeload archive-on-demand, but that carries no
+# submodule content either; deps/always-online-stun arrives as an empty
+# directory, and the file below is the same hourly-validated list that
+# submodule provides, pinned to the exact commit v$(PKG_VERSION)'s own
+# deps/always-online-stun points at. comrade tries every server in the
+# pool in rotation, but a pool with many dead entries still degrades
+# public-IPv4 discovery.
+STUN_LIST_VERSION:=4dc3b52cffa8ca9532a56274d8ac789f5e2be175
 STUN_LIST_FILE:=always-online-stun-$(STUN_LIST_VERSION)-valid_nat_testing_hosts.txt
 
 define Download/stunlist
   FILE:=$(STUN_LIST_FILE)
   URL:=https://raw.githubusercontent.com/pradt2/always-online-stun/$(STUN_LIST_VERSION)
   URL_FILE:=valid_nat_testing_hosts.txt
-  HASH:=0aee95ad2cb98a2def9886045d241a62cca64541f77697a010bf0477e02a7322
+  HASH:=40fd158296353730a6e79ac6219ea2efb8c166c7188e9cfbbaf3997e814ef376
 endef
 $(eval $(call Download,stunlist))
 
-# comrade adds no crypto library of its own: it reads the DT_NEEDED entries
-# out of libssh and follows whatever backend that already uses. OpenWrt's
-# libssh is built against mbedTLS, which implements neither BLAKE2b nor
-# Ed25519, so this resolves to monocypher (~70 kB) rather than dragging in
-# libcrypto. Should libssh ever move to OpenSSL, the backend follows it and
-# libmonocypher below has to become libopenssl.
 define Package/comrade
   SECTION:=net
   CATEGORY:=Network
@@ -70,14 +66,35 @@ define Package/comrade/description
   boxes that will host.
 endef
 
-# With no -DCOMRADE_DHT_DIR the build finds and links the shared libdht,
-# which is what we want: comrade is an ordinary consumer of the packaged
-# library, exactly as transmission is. comrade defines the four symbols
-# libdht deliberately leaves undefined (dht_hash, dht_random_bytes,
-# dht_blacklisted, dht_sendto) and the dynamic linker resolves them back
-# into the executable.
+define Package/comrade-tests
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=SSH
+  TITLE:=Serverless peer-to-peer terminal sharing (test suite)
+  URL:=https://github.com/dangowrt/comrade
+  DEPENDS:=+libssh +libjuice +libdht +libkcp +libmonocypher +libpthread
+endef
+
+define Package/comrade-tests/description
+  comrade's compiled test suite, kept out of the comrade package so it
+  never reaches an end-user install.
+
+  The deterministic unit tests are wired into this package's own CI
+  test.sh, which runs run-unit-tests.sh automatically -- except for a
+  couple that need real network/timing conditions QEMU can't promise;
+  run-unit-tests.sh skips those by default, run COMRADE_SKIP=
+  run-unit-tests.sh to include them too, e.g. on real hardware. The
+  end-to-end scenarios (comrade-e2e plus its *.sh drivers) need real
+  network or multicast conditions, and some a live DHT
+  (COMRADE_E2E_NET=1), that CI's QEMU emulation cannot promise, so they
+  are shipped for manual use on real hardware instead, not run
+  automatically.
+  Usage: /usr/share/comrade/tests/run-unit-tests.sh
+         /usr/share/comrade/tests/<scenario>.sh /usr/share/comrade/tests/comrade-e2e
+endef
+
 CMAKE_OPTIONS += \
-	-DBUILD_TESTING=OFF
+	-DBUILD_TESTING=ON
 
 define Build/Prepare
 	$(Build/Prepare/Default)
@@ -91,4 +108,17 @@ define Package/comrade/install
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/comrade $(1)/usr/bin/
 endef
 
+define Package/comrade-tests/install
+	$(INSTALL_DIR) $(1)/usr/share/comrade/tests
+	for t in $(PKG_BUILD_DIR)/*_test; do \
+		$(INSTALL_BIN) "$$$${t}" $(1)/usr/share/comrade/tests/ || exit 1; \
+	done
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/comrade-e2e $(1)/usr/share/comrade/tests/
+	for s in $(PKG_BUILD_DIR)/tests/*.sh; do \
+		$(INSTALL_BIN) "$$$${s}" $(1)/usr/share/comrade/tests/ || exit 1; \
+	done
+	$(INSTALL_BIN) ./files/run-unit-tests.sh $(1)/usr/share/comrade/tests/
+endef
+
 $(eval $(call BuildPackage,comrade))
+$(eval $(call BuildPackage,comrade-tests))

--- a/net/comrade/files/run-unit-tests.sh
+++ b/net/comrade/files/run-unit-tests.sh
@@ -1,0 +1,97 @@
+#!/bin/sh
+# Runs comrade's deterministic unit test binaries, installed next to this
+# script by the comrade-tests package. Not the end-to-end scenarios, and
+# not the few *_test binaries in SKIP below: all of those need real
+# network/timing conditions QEMU CI can't promise, and are meant for
+# manual runs on real hardware instead (see the comrade-tests package
+# description).
+#
+# A test exiting 77 is the CTest/Automake skip convention (sig_rebuild_test
+# uses it when it cannot get a socket); this script honours the same
+# convention rather than treating it as a failure.
+#
+# What to run is discovered from what comrade-tests/install in the Makefile
+# actually put next to this script (every *_test binary), not a separate
+# list kept here: the two can never disagree about what was installed.
+
+# shellcheck shell=busybox
+
+set -u
+
+DIR=$(dirname "$0")
+
+# QEMU-emulated CI can hang or run too slow for these: stream_cc_test
+# asserts a throughput floor, natstream_test does real ICE/NAT gathering.
+# Manual runs on real hardware can opt back in with COMRADE_SKIP= (an
+# explicitly empty value, not just unset, so the default below still
+# applies).
+SKIP="${COMRADE_SKIP-stream_cc_test natstream_test}"
+skip_seen=""
+
+# sig_rebuild_test persists its node cache under XDG_DATA_HOME; give it a
+# throwaway directory instead of whatever this shell's real one is.
+XDG_DATA_HOME=$(mktemp -d)
+export XDG_DATA_HOME
+cleanup() { rm -rf "$XDG_DATA_HOME"; }
+trap cleanup EXIT INT TERM
+
+failed=0
+skipped=0
+passed=0
+
+for t in "$DIR"/*_test; do
+	[ -e "$t" ] || continue
+	name=$(basename "$t")
+
+	case " $SKIP " in
+	*" $name "*)
+		echo "SKIP $name (needs real hardware)"
+		skipped=$((skipped + 1))
+		skip_seen="$skip_seen $name"
+		continue
+		;;
+	esac
+
+	if [ ! -x "$t" ]; then
+		echo "FAIL $name (not executable)"
+		failed=$((failed + 1))
+		continue
+	fi
+
+	# A wedged test must fail in minutes and by name, not hang CI to the
+	# job's six-hour limit. 600s is 5x upstream's largest CTest TIMEOUT
+	# (120s), with margin for QEMU emulation of the slowest targets.
+	timeout 600 "$t"
+	ret=$?
+	if [ "$ret" -eq 0 ]; then
+		echo "PASS $name"
+		passed=$((passed + 1))
+	elif [ "$ret" -eq 77 ]; then
+		echo "SKIP $name"
+		skipped=$((skipped + 1))
+	else
+		echo "FAIL $name (exit $ret)"
+		failed=$((failed + 1))
+	fi
+done
+
+# A SKIP entry that never matched an installed binary is itself drift: a
+# rename or removal upstream, silently leaving the entry to skip nothing.
+for s in $SKIP; do
+	case " $skip_seen " in
+	*" $s "*) ;;
+	*) echo "warn: SKIP entry '$s' matched no installed *_test binary" >&2 ;;
+	esac
+done
+
+echo
+echo "$passed passed, $skipped skipped, $failed failed"
+
+# A glob that matched nothing looks identical to an all-pass run otherwise
+# ($failed stays 0) -- refuse to report success for a suite that never ran.
+if [ "$((passed + skipped + failed))" -eq 0 ]; then
+	echo "no *_test binaries found next to $0" >&2
+	exit 1
+fi
+
+[ "$failed" -eq 0 ]

--- a/net/comrade/test.sh
+++ b/net/comrade/test.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+#
+# comrade: no package-specific test -- the generic checks (executable,
+#   version banner, no hardcoded paths, stripped, linked libs) already cover
+#   this binary; there is no comrade-specific behaviour worth grepping
+#   arbitrary --help/show text for, which is free to change independently of
+#   this file.
+# comrade-tests: run the deterministic unit test suite (run-unit-tests.sh).
+#   The end-to-end scenarios shipped alongside it are not run here: they need
+#   real network/multicast conditions this CI's QEMU emulation cannot
+#   promise, and several also need a live DHT. They are for manual use on
+#   real hardware, see the comrade-tests package description.
+
+# shellcheck shell=busybox
+
+set -e
+
+case "$1" in
+comrade)
+	;;
+
+comrade-tests)
+	/usr/share/comrade/tests/run-unit-tests.sh
+	;;
+
+*)
+	echo "test.sh: unknown subpackage '$1' -- refusing to silently pass" >&2
+	echo "test.sh: update net/comrade/test.sh to cover this subpackage" >&2
+	exit 1
+	;;
+esac


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @dangowrt

**Description:**
Update net/comrade to 0.1.16.

### v0.1.3

- dangowrt/comrade@3c1857f README: declare Windows port as EXPERIMENTAL
- dangowrt/comrade@0bd4e36 ui: ignore escape sequences that are not quit requests
- dangowrt/comrade@056d89f session, sig, host: harden the LAN join path against unproven
  endpoints
- dangowrt/comrade@ee10c50 session: isolate an ICE agent from the offer that replaced it
- dangowrt/comrade@e091148 ui, cpty_win, sig_mcast: stop the operator's terminal stalling the
  service
- dangowrt/comrade@3df9b7c sig: refuse the DHT to a signaller that was not given it
- dangowrt/comrade@7eeecbe session, sig: qualify a path with a probe before running the session
  on it
- dangowrt/comrade@d67a9d4 session, sig: re-claim when the turnstile moves on without us
- dangowrt/comrade@74ab9ae ci, homebrew: create the tag's release once, with every asset

### v0.1.4

- dangowrt/comrade@fb16730 packaging/deb: drop version floors from generated Depends

### v0.1.5

- dangowrt/comrade@54f50ce PROTOCOL: specify the token connectivity indication and the path
  model
- dangowrt/comrade@d2a0c9a dhtnode: free a node without waiting on its bootstrap resolve
- dangowrt/comrade@b444a40 sig: never stop trying a transport the session was given
- dangowrt/comrade@ca750fe session: rebuild the signalling on a move
- dangowrt/comrade@a2c0210 main, host, token, tools, tests: retire NODHT and give the operator
  --no-dht
- dangowrt/comrade@752d95a statusbar: size the paint buffers off a column cap, not the message
  buffer
- dangowrt/comrade@43da2fe sig, dhtnode, README: close the loose ends the last series left
- dangowrt/comrade@b6717d1 netmon, tests: cover the roam and the teardown that must not block
- dangowrt/comrade@98ccfbc token, path, session: say what connectivity there is, and rank the
  paths by it
- dangowrt/comrade@2fd0c38 packaging/openwrt, ci: open the openwrt/packages bump PR from the
  release

### v0.1.6

- dangowrt/comrade@4acc1ea packaging/openwrt: strip a trailing newline from the packages token
- dangowrt/comrade@de81791 path, session: rename PATH_MAX, which is POSIX and not ours to define

### v0.1.7

- dangowrt/comrade@ef720e3 packaging/openwrt: strip all whitespace from the packages token, not
  just \n\r
- dangowrt/comrade@65337eb packaging/homebrew, ci: bottle libjuice, kcp and libdht too

### v0.1.8

- dangowrt/comrade@fa2773b ci: make openwrt-packages-pr wait on the release job
- dangowrt/comrade@a67523d packaging/openwrt: quote the full changelog since the upstream
  version
- dangowrt/comrade@f279f91 packaging/openwrt: build the changelog from git log, not release
  notes
- dangowrt/comrade@d759de3 packaging/openwrt: list each step's commits oldest first
- dangowrt/comrade@af4f478 packaging/openwrt: wrap changelog bullets to the formalities bot's
  100-column limit
- dangowrt/comrade@4d70324 packaging/openwrt: keep the commit terse, leave the changelog to the
  PR body
- dangowrt/comrade@9e92a7e stun: refresh the pinned server pool past a dead head entry
- dangowrt/comrade@2a4db84 session: stop staking every STUN gather on the first pool server
- dangowrt/comrade@751139a ui: classify the invite from the token it shows
- dangowrt/comrade@31f478d build, packaging/arch, flake: never bake the STUN fallback silently
- dangowrt/comrade@db53e6c packaging/openwrt: carry the tag's STUN pin into the bump PR
- dangowrt/comrade@bdf5be0 session: give a punched claim its window before reading rotation as
  loss
- dangowrt/comrade@d6af3bc candpolicy, session: fan the reflexive candidate across the NAT pool
- dangowrt/comrade@6975255 packaging/openwrt: adopt the open PR's branch, not just its number

### v0.1.9

- dangowrt/comrade@40207c4 packaging/openwrt: update the PR over REST, which public_repo can do
- dangowrt/comrade@ecff902 ui: route the foreground token events through um_token
- dangowrt/comrade@1ced6e7 packaging/arch: version the package from git describe, not the commit
  date
- dangowrt/comrade@ad726f8 session, ui: withdraw the STUN warning once a reflexive v4 arrives
- dangowrt/comrade@fc36abc stunprobe, session: ask the pool for its members instead of waiting
- dangowrt/comrade@c877fe1 sshfwd: walk every resolved target address, and name the one that
  failed
- dangowrt/comrade@85a763f host: pin the tmux lifecycle options against the operator's config
- dangowrt/comrade@1fe9c72 session: liveness is what arrives from the peer, not the pong alone
- dangowrt/comrade@7d1b88a session, nat: resume a returning client in place of replacing it

### v0.1.10

- dangowrt/comrade@e983a44 tests: a peer-scored loss also proves the path died
- dangowrt/comrade@c1cfe35 ci: publish the pages deploy only after the release exists
- dangowrt/comrade@cb9f8e6 sshfwd: pump the bridges by hand, libssh's connector kills them at 2
  MiB
- dangowrt/comrade@3bff5b9 stream, sshfwd: keep bulk forwards from starving the terminal
- dangowrt/comrade@d0a604c tests: keep assertions live in stream_room_test too

### v0.1.11

- dangowrt/comrade@1e1e874 stream: rate-based congestion control, and a window that can use it
- dangowrt/comrade@9238218 mailbox, sig: never let the turnstile wedge on a stale claim
- dangowrt/comrade@ccc1d7c session: clear the no-usable-address warning when addresses return
- dangowrt/comrade@a329c81 session: survive a host-side roam mid-session

### v0.1.12

- dangowrt/comrade@0835f8a ui: full-screen invite QR codes on the host dashboard
- dangowrt/comrade@524bddc qr: a double-space geometry for terminals with room to spare
- dangowrt/comrade@289c87e show, ui: tokens for scripts, clipboards and screen readers
- dangowrt/comrade@f68dc3b host: a headless mode for supervisors, with bounded grants
- dangowrt/comrade@c7a319b mview: stamp the state document with monotonic time
- dangowrt/comrade@15e6d04 ssh: a no-shell forwarding-only session, and refusal accounting
- dangowrt/comrade@00c8921 host: forward-only service, attach/capture, and one state dir for all

### v0.1.13

- dangowrt/comrade@97a2c1a README: add shareterminal.cloud section
- dangowrt/comrade@b2b5178 ci: mint the source tarball as a release asset, stop trusting
  codeload
- dangowrt/comrade@54f75fa deps: bump always-online-stun to 4dc3b52
- dangowrt/comrade@823af36 stunprobe, session, candpolicy, ui: classify the NAT's mapping
  behaviour

### v0.1.14

- dangowrt/comrade@14ec981 tests: give stream_cc_test's fast-path floor headroom for slow CI
  hosts
- dangowrt/comrade@1756581 ui: dedup net rows by address alone, not address+via
- dangowrt/comrade@5b06585 session: clear net rows and the path table on every client roam
- dangowrt/comrade@df5c98a session: never label the peer from an unproven advertised path
- dangowrt/comrade@2782356 session, sig, stunprobe, ui: per-family connectivity status, not a
  timeout

### v0.1.15

- dangowrt/comrade@6523993 netmon: report which address family changed
- dangowrt/comrade@2a0223b netstate: what this host knows about its own reachability
- dangowrt/comrade@6ddebbd session: notice a network change in one place, and act on it there
- dangowrt/comrade@1d1a8dd session: classify a v6 address against the source we actually hold
- dangowrt/comrade@2cea467 stunprobe: ask the first server at once, and remember where they live
- dangowrt/comrade@ace73bf sig, session: a validated get says who answered, and settles the
  anchor
- dangowrt/comrade@3abb341 session, ui: redraw one family's addresses, not both
- dangowrt/comrade@50c8372 session, netstate: never wait on a probe, and never stop asking
- dangowrt/comrade@8f71e43 stunprobe, session: report the address the v6 probe was answered with
- dangowrt/comrade@5512b90 session, ui: re-enumerate the interfaces, and colour the invite by
  what is achievable
- dangowrt/comrade@c11fb53 netstate, session, stunprobe: say it once
- dangowrt/comrade@00ca5d7 tools/e2e, tests: stage a move of one address family
- dangowrt/comrade@367ee98 session: recompute which families to expect, rather than accumulating
- dangowrt/comrade@86ff4f8 ui: a redraw of the addresses is not a change of the verdict
- dangowrt/comrade@451450c netstate, session, netmon, ui: drop the commentary
- dangowrt/comrade@95ab34b session, sig: count a revalidation only where one could have gone out
- dangowrt/comrade@81a10f7 netstate, session: a rendezvous is not condemned by our own silence
- dangowrt/comrade@698c116 sig, session, netstate: qualify a rendezvous once, then keep it
- dangowrt/comrade@0b5febd netstate: search for a rendezvous the held one has gone quiet on
- dangowrt/comrade@34529fd netstate, session: put the dashboard back after a reset that skipped
  it
- dangowrt/comrade@457112e session, ui: show the rendezvous the token is minted from
- dangowrt/comrade@80796d5 host: detaching from a re-attached session hands the terminal back
- dangowrt/comrade@c397e01 netstate, session: a client's rendezvous is the one it was given
- dangowrt/comrade@705a45f session, main: a client waits for the session rather than giving up
  on it
- dangowrt/comrade@5f14b0c netstate, session: let a STUN round finish, and ask a fresh set each
  time
- dangowrt/comrade@cfdd2df stunprobe, session: ask every STUN server, and every address each one
  has
- dangowrt/comrade@a22e8ce session: publish a public address the moment the NAT shows it
- dangowrt/comrade@ab0f2d2 cpty: reap the child, so the host can tell it has gone
- dangowrt/comrade@2e581c2 host, main: a detach lands on the dashboard, or hands the terminal
  back
- dangowrt/comrade@2f237d4 sig, netstate: another node answering is not this one falling silent
- dangowrt/comrade@0d5a0e9 sig: reach the mailbox by converging on the key, not only through a
  pin
- dangowrt/comrade@08bd95c sig: do not let an older read of the mailbox overwrite a newer one
- dangowrt/comrade@55eb8e9 session: bound a host's punch at a fresh claimant to a usable session
- dangowrt/comrade@cef69b4 session: let a returning client's newer attempt replace the punch it
  abandoned
- dangowrt/comrade@e75b3cf dhtnode, tools, tests: meet through a private DHT rather than the
  public one
- dangowrt/comrade@aa842f6 main, tests: -N and --forward-only are one request, and forwarding
  has a test
- dangowrt/comrade@4afbf07 sig, session, ui: show what the mailbox is doing
- dangowrt/comrade@275d93c session, ui: say that a stored item is not yet a node worth naming
- dangowrt/comrade@7c7765c mview: report the mailbox to whatever is watching a headless host
- dangowrt/comrade@01a9950 ui: draw the mailbox instead of tabulating it
- dangowrt/comrade@ba5dd88 session: a candidate belongs to the network it was gathered on
- dangowrt/comrade@5ca1b6a conn, session, ui: say what is known about each peer's link, and when
- dangowrt/comrade@257c350 sshd: serve the session from the pump, instead of waiting for a shell
  first
- dangowrt/comrade@50589ac session, tests: keep both ends agreed on where the session rendezvous
- dangowrt/comrade@12ef2f1 dhtseed, tests: build the swarm somewhere its members can hear each
  other
- dangowrt/comrade@68a31e3 session, sig, mailbox: rendezvous for a host that cannot reach a
  family
- dangowrt/comrade@36c3446 netstate, session, sig: drop a rendezvous candidate that does not
  earn its place
- dangowrt/comrade@0154553 netstate: try every node that answers, and take the first to earn its
  place
- dangowrt/comrade@3c0506f session: copy a probe's address text without tripping the truncation
  check
- dangowrt/comrade@0239101 bencode: guard integer overflow per digit and add a canonical-form
  check
- dangowrt/comrade@5495b36 ccrypto: screen degenerate Ed25519 keys and non-canonical S in the
  gcrypt backend
- dangowrt/comrade@8bb9fe6 bep44, dhtnode: serve BEP 44 as a storing node and add immutable
  client items
- dangowrt/comrade@bb8b3e2 tests: exercise the BEP 44 storing side
- dangowrt/comrade@c464d1f bep44: bound the serving side's rate and memory against abuse
- dangowrt/comrade@7a786c4 bep44, dhtseed: log rate-limiter actions, and exempt the test seed
  swarm
- dangowrt/comrade@5de8159 session: say which rule refused a claim, and who made it
- dangowrt/comrade@649e6c8 session: a punch that connected is not yet a client that arrived
- dangowrt/comrade@b665c34 session: an admission that carried nothing was nobody served
- dangowrt/comrade@15bf0d8 session: a resumption's long punch budget is for a session worth
  resuming
- dangowrt/comrade@823fc27 netstate: decide a rendezvous within fifteen seconds of placing the
  value
- dangowrt/comrade@1468873 session: draw a fresh place in the STUN pool on every move
- dangowrt/comrade@9131854 session: never offer a rendezvous nothing can be aimed at
- dangowrt/comrade@9bb9244 session, candpolicy, stunprobe: fan an egress pool on the question
  that matters
- dangowrt/comrade@568aff8 session: judge a NAT mapping within the round that measured it
- dangowrt/comrade@822d30a session: say what each STUN round concluded about the mapping
- dangowrt/comrade@813213f session, nsfacts: keep the one fact a full queue must not lose
- dangowrt/comrade@df71e42 session, sshc: ask the session, not the path, whether it is still
  there
- dangowrt/comrade@5f1b0c4 host: do not fill the mailbox with an offer nothing off-segment can
  aim at
- dangowrt/comrade@b97c572 host: let a punch finish before the next ask replaces it
- dangowrt/comrade@55b5faf packaging/arch, README: take jech/dht from the distribution's dht
  package
- dangowrt/comrade@d463db3 session: rebuild the signalling when the rendezvous stops answering
- dangowrt/comrade@967020d host, build: say where a state dir may go, and follow the commit
- dangowrt/comrade@c84d2e9 tests: one swarm for the run
- dangowrt/comrade@dab7687 sshc, tests: hold a session until the thing has happened, not for a
  span
- dangowrt/comrade@75d2ec3 session, sshc: the host says a worker is new, instead of leaving it
  to silence
- dangowrt/comrade@2dec40c session: say it over the segment too
- dangowrt/comrade@d62e7c8 session: write the punch floor against the cadence it defends
- dangowrt/comrade@d028fb2 tests: keep the real DHT out of a run that calls itself private
- dangowrt/comrade@2df12f2 tests: say what failed without publishing an address
- dangowrt/comrade@37d7bd1 session, hostreap: let a worker outlive the claimant's second attempt
- dangowrt/comrade@f701217 sig, session: let the node say the rendezvous is gone
- dangowrt/comrade@14ff56e session: wind a client up between attempts, not only while it holds
- dangowrt/comrade@fc526c8 session, claimlog: do not punch a claim the mailbox is handing back
- dangowrt/comrade@ffa4af0 session, hbeat: judge silence against the round-trip that was
  measured
- dangowrt/comrade@d601f5a netstate: write the source poll's ceiling as the window it waits on
- dangowrt/comrade@c9ac094 netstate: refuse a prove window narrower than what it asks for
- dangowrt/comrade@1cd4fc7 session, claimlog: keep the claim rule that answers a question
- dangowrt/comrade@0072936 tests: mask every address a workflow log would carry, not only global
  ones
- dangowrt/comrade@48f25e3 session: say a session is live before it starts, not half a second
  after
- dangowrt/comrade@3f14590 session, claimlog: tell only a claimant that had a session to lose
- dangowrt/comrade@5f353a0 session, candpolicy: let ICE keep a candidate that names one of our
  own
- dangowrt/comrade@51c5784 tests: start the swarm where setsid does not exist, and say when one
  will not
- dangowrt/comrade@61722c3 tests, ci: give a failing run minutes rather than the whole job
- dangowrt/comrade@74c8170 tests, packaging: let the portable tests build where the library
  builds
- dangowrt/comrade@65688c5 ci: fetch the Windows toolchain at the speed the link can carry
- dangowrt/comrade@115e4c9 tests, ci: run the tests on Windows

### v0.1.16

- dangowrt/comrade@afc222b netstate: let an answer confirm the anchor, not only a tick
- dangowrt/comrade@f515cb5 session, ui: show the link's round trip, not the control stream's
- dangowrt/comrade@71b3eea session, ui, candpolicy: three the review found in this week's own
  work
- dangowrt/comrade@7aa3acb session: stop answering our own question, and take an answer only
  from where the question went
- dangowrt/comrade@c46b99b session: take stream bytes only from an endpoint we hold
- dangowrt/comrade@f5a9e52 session: count as liveness only what authenticated
- dangowrt/comrade@bd26ccb session: a probe from a stranger takes a spare slot, never a warm one
- dangowrt/comrade@61dfb64 path, session, replay: act on a probe once
- dangowrt/comrade@0e59438 session: the notice that ends a session comes from where the session
  is
- dangowrt/comrade@acd211f path: hear a peer's view of a path, within reason
- dangowrt/comrade@63db96f path: an address that answers nothing is not kept for ever
- dangowrt/comrade@c2efc8a session: a flood from one address starves only itself
- dangowrt/comrade@dc8edb4 lanlink, sig_mcast: come back for the rest next turn
- dangowrt/comrade@3df1215 keys, sig: bind an announcement to the slot it was sent under
- dangowrt/comrade@21c73f6 keys, path, session: stop announcing what this datagram is
- dangowrt/comrade@d01bf1f session, conn: what one thread owns, another reads a copy of
- dangowrt/comrade@5c1dbb7 path, session, dbg: a peer says where it is, not everywhere
- dangowrt/comrade@3737b96 path: say what the seal establishes, and what it does not
- dangowrt/comrade@ad021b3 doc: the four the patches do not reach
- dangowrt/comrade@671767a session: ask at every door whether an endpoint is our own
- dangowrt/comrade@30bc04b keys, path: say what the tag is, not what it is not
- dangowrt/comrade@2a2127d doc: the part of the outage finding that is a defect
- dangowrt/comrade@d4c5835 session, path: an agent that went quiet is set aside, not destroyed
- dangowrt/comrade@3a52b98 doc: three architectural findings, not four
- dangowrt/comrade@a691906 keys, ctlproto, session: key the probes to the two ends, not the
  invitation
- dangowrt/comrade@c3d5b62 dataauth, stream, session: say who sent a stream datagram
- dangowrt/comrade@8e32194 doc: what the review's four findings are now
- dangowrt/comrade@e344cb4 doc: what a per-class rendezvous would actually cost
- dangowrt/comrade@221a7f1 doc: measure the data-plane tag on the target it was chosen for
- dangowrt/comrade@da9cd27 doc: a second mailbox does not need a second DHT node
- dangowrt/comrade@1215ed2 doc: what a view-only guest can actually see in the mailbox
- dangowrt/comrade@0fdce2f doc: the read-only crowd is the worst case, and the class split
  misses it
- dangowrt/comrade@32530a3 doc: how a host-sealed claim is actually built
- dangowrt/comrade@fdc8742 doc: where the mailbox line is drawn
- dangowrt/comrade@85ec1e8 ccrypto, keys, sig: seal a claim to the host, not to the invitation
- dangowrt/comrade@2ecbcc8 doc, tests: the mailbox is closed, and X25519 is pinned to the
  standard
- dangowrt/comrade@1af60ca doc: bring the protocol spec back to what the code does
- dangowrt/comrade@e8891b9 doc, cmake: say what a second holder of the invitation can and cannot
  do
- dangowrt/comrade@c01400e sshc: keep the user's ssh configuration out of the tunnel
- dangowrt/comrade@ff019f4 sandbox: confine the joining client to what it needs
- dangowrt/comrade@141705c sandbox: give the client a filesystem it cannot leave
- dangowrt/comrade@3c1face sandbox: tighten the confined view and add the Landlock fallback
- dangowrt/comrade@6b531d1 sandbox: bind the resolver's directory so a roam is followed
- dangowrt/comrade@7b1d20b spawner: a pre-forked tmux broker for the sandboxed host service
- dangowrt/comrade@c8776f1 cpty, sshd: serve a client's shell through the spawner when there is
  one
- dangowrt/comrade@4cfc6fb host: sandbox the connection service and serve tmux through the
  spawner
- dangowrt/comrade@09d4789 host: take the network away from the operator's foreground
- dangowrt/comrade@8ddd37b sandbox: implement the macOS Seatbelt profiles
- dangowrt/comrade@24281d3 sandbox: implement the Windows job object and mitigation policies
- dangowrt/comrade@9bbb13b doc: a brief note on the per-OS self-sandboxing
- dangowrt/comrade@14e3a9b sandbox, spawner: satisfy a fortified libc's must-use returns
- dangowrt/comrade@236772a sandbox: surface a broken confinement, and never pivot into one
- dangowrt/comrade@75b8d0b tests, cmake: build the sandbox and spawner tests on Unix only
- dangowrt/comrade@66c86ea sig: a released answer slot is new business, whatever it holds next
- dangowrt/comrade@7409a7a session: a claim that lost its round waits before starting over
- dangowrt/comrade@65b2cf2 session: a punch stops naming its claimant once it is over
- dangowrt/comrade@b7ab0bf session, tests: hold rdvsync open for everything it asserts

---

## 🧪 Run Testing Details

- **OpenWrt Version:** -
- **OpenWrt Target/Subtarget:** -
- **OpenWrt Device:** -

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
