### PR TITLE
openldap: update to 2.6.14

### DIFF
--- a/libs/openldap/Makefile
+++ b/libs/openldap/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openldap
-PKG_VERSION:=2.6.13
+PKG_VERSION:=2.6.14
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tgz
 PKG_SOURCE_URL:=https://mirror.eu.oneandone.net/software/openldap/openldap-release/ \
 	https://www.openldap.org/software/download/OpenLDAP/openldap-release/
-PKG_HASH:=d693b49517a42efb85a1a364a310aed16a53d428d1b46c0d31ef3fba78fcb656
+PKG_HASH:=806dcd21d366428187fba3278da773d5930f774852c9e92517f950d585f19107
 PKG_LICENSE:=OLDAP-2.8
 PKG_LICENSE_FILES:=LICENSE
 PKG_CPE_ID:=cpe:/a:openldap:openldap

--- a/libs/openldap/patches/001-automake-compat.patch
+++ b/libs/openldap/patches/001-automake-compat.patch
@@ -1,3 +1,10 @@
+From 3c78eaff96d7ba286bb0404b9bdc1a2c6aca7ec0 Mon Sep 17 00:00:00 2001
+From: W. Michael Petullo <mike@flyn.org>
+Date: Sun, 6 Aug 2014 11:28:00 +0200
+Subject: [PATCH] automake compat
+
+Signed-off-by: W. Michael Petullo <mike@flyn.org>
+---
 --- a/clients/tools/Makefile.in
 +++ b/clients/tools/Makefile.in
 @@ -13,6 +13,8 @@
@@ -249,7 +256,7 @@
 +
  SLAPTOOLS=slapadd slapcat slapdn slapindex slapmodify slappasswd slaptest slapauth slapacl slapschema
  PROGRAMS=slapd $(SLAPTOOLS)
- XPROGRAMS=sslapd libbackends.a .backend liboverlays.a
+ XPROGRAMS=sslapd libbackends.a liboverlays.a
 --- a/servers/slapd/overlays/Makefile.in
 +++ b/servers/slapd/overlays/Makefile.in
 @@ -13,6 +13,8 @@

--- a/libs/openldap/patches/750-no-strip.patch
+++ b/libs/openldap/patches/750-no-strip.patch
@@ -1,3 +1,10 @@
+From 3c78eaff96d7ba286bb0404b9bdc1a2c6aca7ec0 Mon Sep 17 00:00:00 2001
+From: W. Michael Petullo <mike@flyn.org>
+Date: Sun, 6 Aug 2014 11:28:00 +0200
+Subject: [PATCH] no strip
+
+Signed-off-by: W. Michael Petullo <mike@flyn.org>
+---
 --- a/clients/tools/Makefile.in
 +++ b/clients/tools/Makefile.in
 @@ -131,7 +131,7 @@ install-local:	FORCE
@@ -11,7 +18,7 @@
  	)
 --- a/servers/slapd/Makefile.in
 +++ b/servers/slapd/Makefile.in
-@@ -377,7 +377,7 @@ install-local-srv: install-slapd install
+@@ -366,7 +366,7 @@ install-local-srv: install-slapd install
  install-slapd: FORCE
  	-$(MKDIR) $(DESTDIR)$(libexecdir)
  	-$(MKDIR) $(DESTDIR)$(localstatedir)/run


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @flyn-org 

**Description:**  OpenLDAP Software is an open source implementation of the Lightweight Directory Access Protocol. 
Changelog of the changes in this commit are available at https://openldap.org/software/release/changes_lts.html

 Reworked some patches with headers to comply with patches guidelines.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT, r35836-20d94d5a2b
- **OpenWrt Target/Subtarget:** Filogic 8x0 (MT798x)
- **OpenWrt Device:** Bananapi BPi-R4

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
- [x] It is structured in a way that it is potentially upstreamable
