### PR TITLE
fscrypt: update to 0.3.7

### DIFF
--- a/utils/fscrypt/Makefile
+++ b/utils/fscrypt/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fscrypt
-PKG_VERSION:=0.3.6
+PKG_VERSION:=0.3.7
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/google/fscrypt/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=6d71e17ef3e48cd5df22190df6925f39ee4a5b24e672f0fa616f3b57f52b2a12
+PKG_HASH:=9cd8913293572709e122a7c7fa1463fb0e0cf9b38f1d3bf633939564d8cc6245
 
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
@@ -18,6 +18,7 @@ PKG_BUILD_PARALLEL:=1
 PKG_BUILD_FLAGS:=no-mips16
 
 GO_PKG:=github.com/google/fscrypt
+GO_PKG_LDFLAGS_X:=main.version=v$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk
 include ../../lang/golang/golang-package.mk

--- a/utils/fscrypt/test-version.sh
+++ b/utils/fscrypt/test-version.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#
+# Version check override for the fscrypt package.
+#
+# fscrypt does not support --version, -V, or --help flags for reporting its
+# version; it only prints the version via the "fscrypt version" subcommand.
+# pam_fscrypt.so is a PAM module, not a standalone executable, so it has no
+# version output either.
+
+case "$1" in
+fscrypt)
+	fscrypt --version 2>&1 | grep -F "$2"
+	;;
+*)
+	echo "Untested package: $1" >&2
+	exit 1
+	;;
+esac


### PR DESCRIPTION

## 📦 Package Details

**Maintainer:** me
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

Changelog:
- Upgraded various dependencies, including golang.org/x/crypto to resolve the usual CVEs in it (but as usual, not actually affecting fscrypt's use of it).
- When selecting password hashing parameters, fscrypt now takes cgroup limitations into consideration.
- fscrypt encrypt no longer follows trailing symlinks when writing the recovery instructions.
- fscrypt unlock no longer enters an infinite loop when an incorrect key file is specified using --key=FILE, --quiet isn't specified, and standard input is a terminal.
- fscrypt unlock no longer enters an infinite loop when an incorrect password is specified, --quiet isn't specified, and standard input isn't a terminal.
- The error message when multiple protectors are available now mentions --unlock-with in addition to --protector.
- Documented the udev dependency for /dev/disk/by-uuid/ links.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT
- **OpenWrt Target/Subtarget:** x86/64-glibc
- **OpenWrt Device:** N150

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
