### PR TITLE
netbird: update to 0.78.1

### DIFF
--- a/net/netbird/Makefile
+++ b/net/netbird/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netbird
-PKG_VERSION:=0.73.2
+PKG_VERSION:=0.78.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/netbirdio/netbird/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=ba8d1615a6676e6d17f5d4a3c8027cd2e7437c862da3f963d3b337c09efff423
+PKG_HASH:=2adde8bbd77ea595b5f50174be10574466f1c07fc9fbf827024245aec2f4dabc
 
 PKG_MAINTAINER:=Wesley Gimenes <wehagy@proton.me>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @wehagy
**Description:**

Update netbird to upstream v0.78.1.

Changelog: https://github.com/netbirdio/netbird/compare/v0.73.2...v0.78.1

Notable changes:
- fix local privilege escalation via unauthenticated daemon IPC socket ([GHSA-qcpp-8vwj-hhwr](https://github.com/netbirdio/netbird/security/advisories/GHSA-qcpp-8vwj-hhwr)), affects all client versions < 0.76.0
- fix nftables route rule expression ordering
- fall back to per-IP ACL rules when ipset is unavailable
- client ICEBind / route / fwmark fixes (v0.78.0)
- Go 1.26 toolchain (`openwrt-25.12` ships `GO_DEFAULT_VERSION:=1.26`)

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12.4
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** Hyper-V VM (OpenWrt-dev)

Compile tested: OpenWrt SDK 25.12.5, x86_64 (`make package/netbird/compile` → `netbird-0.78.1-r1.apk`)
Run tested: upgraded installed package on 25.12.4 x86_64 (0.77.1-r1 → 0.78.1-r1), procd service starts, `netbird version` reports 0.78.1, CLI status talks to the running daemon.

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

---

Depends on master landing first: openwrt/packages#30406. This branch intentionally has **no** `cherry picked from` trailer until the master SHA is known; will re-cherry-pick with `-x` after #30406 merges.
