### PR TITLE
modemmanager: fix user in custom initial EPS bearer settings

### DIFF
--- a/net/modemmanager/Makefile
+++ b/net/modemmanager/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=modemmanager
 PKG_VERSION:=1.24.0
-PKG_RELEASE:=12
+PKG_RELEASE:=13
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://gitlab.freedesktop.org/mobile-broadband/ModemManager.git

--- a/net/modemmanager/files/lib/netifd/proto/modemmanager.sh
+++ b/net/modemmanager/files/lib/netifd/proto/modemmanager.sh
@@ -286,7 +286,7 @@ proto_modemmanager_init_config() {
 	proto_config_add_string init_iptype
 	proto_config_add_string 'init_allowedauth:list(string)'
 	proto_config_add_string init_password
-	proto_config_add_string init_user
+	proto_config_add_string init_username
 	proto_config_add_string init_apn
 	proto_config_add_defaults
 }
@@ -443,7 +443,7 @@ modemmanager_check_state_locked() {
 	}
 
 	# Give the modem time to change to the initializing state after
-	# unlocking 
+	# unlocking
 	sleep 1
 
 	return 0
@@ -581,7 +581,7 @@ proto_modemmanager_setup() {
 
 	local init_epsbearer
 	local init_iptype init_allowedauth
-	local init_password init_user init_apn
+	local init_password init_username init_apn
 
 	local address prefix gateway mtu dns1 dns2
 
@@ -591,7 +591,7 @@ proto_modemmanager_setup() {
 
 	json_get_vars init_epsbearer
 	json_get_vars init_iptype init_allowedauth
-	json_get_vars init_password init_user init_apn
+	json_get_vars init_password init_username init_apn
 
 	# validate sysfs path given in config
 	[ -n "${device}" ] || {


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @feckert 

**Description:**

The proto handler reads the init_user option but references the undefined variable init_username when building the connect args, so the username is never passed to mmcli.

---