### PR TITLE
owut: remove comments and empty lines from the built package

### DIFF
--- a/utils/owut/Makefile
+++ b/utils/owut/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=owut
 PKG_SOURCE_DATE:=2026-07-08
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_VERSION:=db17536ec5cbcc6a76a51e65f3d192b6a2184abb
@@ -65,8 +65,14 @@ define Package/owut/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/owut $(1)/usr/bin
 
-	sed -i -e "s/%%VERSION%%/$(PKG_VERSION)-r$(PKG_RELEASE)/" $(1)/usr/bin/owut
-	sed -i -e "s/%%VERSION%%/$(PKG_VERSION)-r$(PKG_RELEASE)/" $(1)/usr/share/ucode/utils/argparse.uc
+	# Hardcode the package version/release
+	# Remove comments and empty lines preserving package's title, copyright and license
+	sed -i \
+		-e "s/%%VERSION%%/$(PKG_VERSION)-r$(PKG_RELEASE)/" \
+		-e '5,$$$${/^[ \t]*\/\//d}' \
+		-e '/^$$$$/d' \
+		$(1)/usr/bin/owut \
+		$(1)/usr/share/ucode/utils/argparse.uc
 endef
 
 $(eval $(call BuildPackage,owut))


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @efahl 

**Description:**
This allows to save some bytes, while preserving the scripts's
copyright and license information.

In owut at current ref db17536ec5cbcc6a76a51e65f3d192b6a2184abb
the reduction in the size applied to the source code is (e.g. without
the computed "s/%%VERSION%%/$(PKG_VERSION)-r$(PKG_RELEASE)/"):

from:
74330 /usr/bin/owut
10541 /usr/share/ucode/utils/argparse.uc

to:
58640 /usr/bin/owut
8630 /usr/share/ucode/utils/argparse.uc

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12.5
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** cudy_wr3000s-v1

---

## ✅ Formalities

- [ x ] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.