### PR TITLE
csshnpd: bump to c1.0.20 release 

### DIFF
--- a/net/csshnpd/Makefile
+++ b/net/csshnpd/Makefile
@@ -4,12 +4,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=csshnpd
-PKG_VERSION:=1.0.18
+PKG_VERSION:=1.0.20
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-c$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/atsign-foundation/noports/releases/download/c$(PKG_VERSION)
-PKG_HASH:=9792b6efc880922d6e0020ae751789c6350e72c339fde9928b2db918adf2a559
+PKG_HASH:=ffbadc9d0b5b381b2d7c20a607497be3b1994617c88fa3665225e951c6ce9a26
 
 PKG_MAINTAINER:=Chris Swan <chris@atsign.com>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @cpswan 

**Description:**
Authentication bypass fix (awaiting issue of CVE)

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT, r35751
- **OpenWrt Target/Subtarget:** x86_64
- **OpenWrt Device:** x86_64 VM

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
