### PR TITLE
strongswan: fix build with wolfSSL 5.9.2

### DIFF
--- a/net/strongswan/Makefile
+++ b/net/strongswan/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=strongswan
 PKG_VERSION:=6.0.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://download.strongswan.org/ https://download2.strongswan.org/

--- a/net/strongswan/patches/0905-wolfssl-Adapt-to-removed-ML-KEM-header.patch
+++ b/net/strongswan/patches/0905-wolfssl-Adapt-to-removed-ML-KEM-header.patch
@@ -1,0 +1,24 @@
+From 98b133c54c5e3f66f46a5bb11c9b09d06fdc8469 Mon Sep 17 00:00:00 2001
+From: Tobias Brunner <tobias@strongswan.org>
+Date: Fri, 26 Jun 2026 08:10:16 +0200
+Subject: [PATCH] wolfssl: Adapt to removed ML-KEM header
+
+The mlkem.h header that mainly defined aliases for the old wc_Kyber* API
+has been removed and its contents moved to the wc_mlkem.h header.
+---
+ src/libstrongswan/plugins/wolfssl/wolfssl_kem.c | 3 ---
+ 1 file changed, 3 deletions(-)
+
+--- a/src/libstrongswan/plugins/wolfssl/wolfssl_kem.c
++++ b/src/libstrongswan/plugins/wolfssl/wolfssl_kem.c
+@@ -25,10 +25,7 @@
+ 
+ #ifdef WOLFSSL_HAVE_MLKEM
+ 
+-#include <wolfssl/wolfcrypt/mlkem.h>
+-#ifdef WOLFSSL_WC_MLKEM
+ #include <wolfssl/wolfcrypt/wc_mlkem.h>
+-#endif
+ 
+ typedef struct private_key_exchange_t private_key_exchange_t;
+ 


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @pprindeville

**Description:**

wolfSSL 5.9.2 removed the `mlkem.h` header, causing strongSwan 6.0.3 to fail to build on the `openwrt-25.12` branch.

Backport the upstream strongSwan change to include `wc_mlkem.h` directly. This is the same fix already merged into the packages master branch.

Fixes #30291

---

## 🧪 Run Testing Details

- **OpenWrt Version:** OpenWrt 25.12
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** Build test only

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets or fuzz using:

  ```bash
  make package/strongswan/refresh V=s
  ```

- [x] It is structured in a way that is potentially upstreamable

The patch is backported from strongSwan upstream commit `98b133c54c5e3f66f46a5bb11c9b09d06fdc8469`.
