### PR TITLE
sqm-scripts: update to 1.8.0

### DIFF
--- a/net/sqm-scripts/Makefile
+++ b/net/sqm-scripts/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sqm-scripts
-PKG_SOURCE_VERSION:=20ba92639546075d8e39346dcb88a3cdfe8ee903
-PKG_VERSION:=1.7.2
+PKG_SOURCE_VERSION:=77cf89e82ced9b215cc02f64fd471f5278b7d031
+PKG_VERSION:=1.8.0
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/tohojo/sqm-scripts
-PKG_MIRROR_HASH:=578f7cbf5268a9f7e1689fd6365c11d8d9baebf46773237f46393088d792d8ce
+PKG_MIRROR_HASH:=65322cd90305838d6aab49b433e37b4601b603184bfe2442bee6c996d2bf7ade
 
 PKG_MAINTAINER:=Toke Høiland-Jørgensen <toke@toke.dk>
 PKG_LICENSE:=GPL-2.0-only
@@ -24,7 +24,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/sqm-scripts
   SECTION:=net
   CATEGORY:=Base system
-  DEPENDS:=+tc +ip +kmod-sched-cake +kmod-ifb +iptables +iptables-mod-ipopt
+  DEPENDS:=+tc +ip +kmod-sched-cake +kmod-ifb +nftables
   TITLE:=SQM Scripts (QoS)
   PKGARCH:=all
 endef


### PR DESCRIPTION
Update sqm-scripts to the 1.8.0 release.

This release replaces the iptables-based marking rules with native nftables
rules. Replace the iptables dependencies with nftables to match.

## 📦 Package Details

**Maintainer:** @tohojo

**Description:**

Update sqm-scripts to version 1.8.0 and adjust its dependencies for the new
native nftables implementation.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** OpenWrt 25.12.2 (r32802-f505120278)
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** x86 vm

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
