### PR TITLE
ddns-scripts: add Dynway provider

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.8.4
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_LICENSE:=GPL-2.0
 

--- a/net/ddns-scripts/files/usr/share/ddns/default/dynway.eu.json
+++ b/net/ddns-scripts/files/usr/share/ddns/default/dynway.eu.json
@@ -1,0 +1,11 @@
+{
+	"name": "dynway.eu",
+	"ipv4": {
+		"url": "http://[USERNAME]:[PASSWORD]@dynupdate.wayscloud.services/nic/update?hostname=[DOMAIN]&myip=[IP]",
+		"answer": "good|nochg"
+	},
+	"ipv6": {
+		"url": "http://[USERNAME]:[PASSWORD]@dynupdate.wayscloud.services/nic/update?hostname=[DOMAIN]&myip=[IP]",
+		"answer": "good|nochg"
+	}
+}

--- a/net/ddns-scripts/files/usr/share/ddns/list
+++ b/net/ddns-scripts/files/usr/share/ddns/list
@@ -32,6 +32,7 @@ dyndns.it
 dyndns.org
 dynu.com
 dynv6.com
+dynway.eu
 easydns.com
 eurodns.com
 goip.de


### PR DESCRIPTION
Add a DynDNS2 provider definition for dynway.eu.

The service supports IPv4 and IPv6 through `dynupdate.wayscloud.services/nic/update` with HTTP Basic authentication and uses the standard `good` and `nochg` response values. The existing HTTPS option upgrades the endpoint to HTTPS.