### PR TITLE
nut: fix hotplug access and other bugs

### DIFF
--- a/net/nut/Makefile
+++ b/net/nut/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nut
 PKG_VERSION:=2.8.5
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.networkupstools.org/source/2.8/

--- a/net/nut/files/libhid-ups.hotplug
+++ b/net/nut/files/libhid-ups.hotplug
@@ -202,7 +202,8 @@ nut_driver_config() {
 			return 0
 		fi
 		if [ "$(printf "%04x" 0x"$pvendid")" = "$cfg_vendorid" ] &&
-			[ "$(printf "%04x" 0x"$pprodid")" = "$cfg_productid" ]; then
+			[ "$(printf "%04x" 0x"$pprodid")" = "$cfg_productid" ] &&
+			[ -n "$DEVNAME" ] && [ -n "$ups" ]; then
 			# Round 1: If we have a match for hotplug event and the UCI config
 			# start this UPS and record that fact, otherwise skip this UCI UPS
 			# for this round

--- a/net/nut/files/libhid-ups.hotplug
+++ b/net/nut/files/libhid-ups.hotplug
@@ -208,7 +208,7 @@ nut_driver_config() {
 			# for this round
 			# Initscript should have its own logging
 			if ! start_stop_driver "$ups" "/dev/$DEVNAME"; then
-				log_error "Error starting matched driver instance (UPS) in nut_driver_config" libhid-ups nut-usb-hotplug
+				log_error "Failed to start/stop matched driver instance (UPS) in nut_driver_config" libhid-ups nut-usb-hotplug
 				nd_driver_config_error=true
 				return 0
 			fi
@@ -226,6 +226,9 @@ perform_libhid_action() {
 	local nd_found=false
 	local nd_driver_config_error=false
 	local pvendid pprodid
+
+	[ -n "$DEVNAME" ] || return 0
+	[ -n "$ACTION" ] || return 0
 
 	# Only find statepath and runas once per event
 	# defines STATEPATH
@@ -268,6 +271,12 @@ perform_libhid_action() {
 	config_foreach nut_driver_config driver yes
 
 	[ "$nd_driver_config_error" = "false" ] || return 1
+
+	# Only do a second search that does not need to match a known device
+	# when ACTION is "add". We don't want to stop all UPSes on the removal
+	# of only one.
+	[ "$ACTION" = "add" ] || return 0
+
 	# Only if we cannot find a matching UPS (driver instance) configuration
 	# do we try again, this time restarting all UPS (driver) instances
 	# This is for the event the device matching configuration for NUT does

--- a/net/nut/files/libhid-ups.hotplug
+++ b/net/nut/files/libhid-ups.hotplug
@@ -228,9 +228,6 @@ perform_libhid_action() {
 	local nd_driver_config_error=false
 	local pvendid pprodid
 
-	[ -n "$DEVNAME" ] || return 0
-	[ -n "$ACTION" ] || return 0
-
 	# Only find statepath and runas once per event
 	# defines STATEPATH
 	find_statepath "upsd" "nut_server" || {
@@ -313,24 +310,28 @@ perform_libhid_action() {
 	# return) and shellcheck will complain if we do.
 }
 
+# Ignore incomplete (for our purposes) events
+[ -n "$DEVNAME" ] || exit 0
+[ -n "$ACTION" ] || exit 0
+
 # PRODUCT comes from the calling hotplug event, and
 # is of the form vendorid/productid/other
 
 # This is an incomplete script which gets filled by libhid-ups.parsed-usermap.
+
+# The result is cases of the form
+# "vendorid/productid/other" ) | \
+# to be matched against the PRODUCT from the calling hotplug event
+# The empty string matches when PRODUCT is empty, but does not match
+# when PRODUCT is neither empty nor one of the case targets, above
+
 # This confuses shellcheck and reviewers, hence the disables below.
 # shellcheck disable=SC1073,SC1072
 case "$PRODUCT" in
 ### insert libhid-ups.parsed-usermap content here ###
-# The result is cases of the form
-# "vendorid/productid/other" ) | \
-# to be matched against the PRODUCT from the calling hotplug event
-# and does NOT use ';;' (so falls through to code below).
-# The empty string matches when PRODUCT is empty, but does not match
-# when PRODUCT is neither empty nor one of the case targets, above
-
 "")
 	# Skip hotplug actions if NUT hotplug is disabled
-	# Uses NUT_DISABLE_HOTPLUG_PATH,  defined in nut-service.sh and sourced
+	# Uses NUT_DISABLE_HOTPLUG_PATH, defined in nut-service.sh and sourced
 	# NUT_DISABLE_HOTPLUG_PATH is an external sentinel used to indicate NUT
 	# hotplug is disabled.
 	if ! allow_hotplug_restart; then

--- a/net/nut/files/libhid-ups.hotplug
+++ b/net/nut/files/libhid-ups.hotplug
@@ -76,6 +76,9 @@ start_stop_driver() {
 		# We check enabled again here, in case of a race condition since
 		# our last check.
 		if /etc/init.d/nut-server enabled; then
+			# As the driver start goes through the initscript's start which has a
+			# procd_lock, the driver should not be started twice, even if hotplug
+			# fires as soon as hotplugging is allowed in initscript's boot()
 			if ! /etc/init.d/nut-server start "$ups"; then
 				log_error "Failed to start '$ups' processing '$ACTION' for '$DEVNAME'" "libhid-ups" nut-usb-hotplug
 				return 0
@@ -252,7 +255,7 @@ perform_libhid_action() {
 	# PRODUCT comes from the calling hotplug event, and
 	# is of the form vendorid/productid/other
 	# The code below uses shell parameter expansion to split out
-	# vendorid as pvendid and  productid as pprodid
+	# vendorid as pvendid and productid as pprodid
 
 	# We disable the check for possible misspelling as the variables names
 	# are similar, but PRODUCT, pvendid, and pprodid are correct.

--- a/net/nut/files/libhid-ups.hotplug
+++ b/net/nut/files/libhid-ups.hotplug
@@ -229,16 +229,25 @@ perform_libhid_action() {
 	local pvendid pprodid
 
 	# Only find statepath and runas once per event
-	# defines STATEPATH
-	find_statepath "upsd" "nut_server" || {
+	STATEPATH="$(find_statepath "upsd" "nut_server")" || {
 		log_error "Failed to set STATEPATH" "libhid-ups" nut-usb-hotplug
 		return 1
 	}
-	# sets RUNAS
-	find_runas "upsd" "nut_server" || {
+	[ -n "$STATEPATH" ] || {
+		log_error "Failed to set STATEPATH" "libhid-ups" nut-usb-hotplug
+		return 1
+	}
+	export STATEPATH
+
+	RUNAS="$(find_runas "upsd" "nut_server")" || {
 		log_error "Failed to set RUNAS" "libhid-ups" nut-usb-hotplug
 		return 1
 	}
+	[ -n "$RUNAS" ] || {
+		log_error "Failed to set RUNAS" "libhid-ups" nut-usb-hotplug
+		return 1
+	}
+	export RUNAS
 
 	# PRODUCT comes from the calling hotplug event, and
 	# is of the form vendorid/productid/other

--- a/net/nut/files/nut-monitor-config.sh.functions
+++ b/net/nut/files/nut-monitor-config.sh.functions
@@ -61,7 +61,8 @@ nut_get_notifications() {
 	if [ "${event_types#*" $event "}" != "${event_types}" ]; then
 		config_get val "$event" message
 		if [ -n "$val" ]; then
-			if ! printf 'NOTIFYMSG %s %s\n' "$event" "$val" >>"$config_file"; then
+			val="$(printf '%s' "$val" | tr -d '"')"
+			if ! printf 'NOTIFYMSG %s "%s"\n' "$event" "$val" >>"$config_file"; then
 				log_error "upsmon section '$event' failed to write 'NOTIFYMSG' for '$event'" nut-monitor-config.sh nut-monitor-config
 				return 1
 			fi

--- a/net/nut/files/nut-serial.hotplug
+++ b/net/nut/files/nut-serial.hotplug
@@ -36,6 +36,9 @@
 	exit 1
 }
 
+# Group of RUNAS user; used to allow access to the USB serial device
+DEVICE_GROUP=""
+
 # 'shellcheck' does not understand config_foreach and therefore treats
 # functions and variables referenced only from config_foreach as not reachable,
 # or never invoked.
@@ -43,18 +46,11 @@
 nut_set_serial_port_permissions() {
 	local devname="$1" # Must be full path (e.g. /dev/...)
 	local ups="$2"
-	local device_group
-
-	# Get group of RUNAS user, to set the group of the hotplugged device node
-	# If RUNAS user does not exist, exit with an error.
-	device_group="$(id -gn "${RUNAS:-nut}")" || {
-		log_error "Unable to find group for '$RUNAS'. Skipping ups '$ups'" nut-serial nut-serial-hotplug
-		return 1
-	}
 
 	# Guard against disappearing device (e.g. due to 'bouncing' device)
 	if [ -e "$devname" ]; then
-		if ! chgrp "$device_group" "$devname"; then
+		# Allow RUNAS user (which is user of driver process) to access device
+		if ! chgrp "$DEVICE_GROUP" "$devname"; then
 			log_error "Unable to set group on '$devname'" nut-serial nut-serial-hotplug
 			return 1
 		fi
@@ -124,11 +120,22 @@ nut_on_hotplug_add() {
 		exit 1
 	}
 
-	# Only find statepath and runas once per event
-	# sets RUNAS
-	find_runas "upsd" "nut_server" || {
+	# Only find runas once per event
+	RUNAS="$(find_runas "upsd" "nut_server")" || {
 		log_error_exit "Failed to set RUNAS" nut-serial nut-serial-hotplug
 	}
+	[ -n "$RUNAS" ] || {
+		log_error_exit "Failed to set RUNAS" nut-serial nut-serial-hotplug
+	}
+	export RUNAS
+
+	# Get group of RUNAS user, to set the group of the hotplugged device node
+	# If RUNAS user does not exist, exit with an error.
+	DEVICE_GROUP="$(id -gn "${RUNAS}")" || {
+		log_error "Unable to find group for RUNAS user '$RUNAS'. Skipping serial usb hotplug." nut-serial nut-serial-hotplug
+		return 1
+	}
+	export DEVICE_GROUP
 
 	# Check if serial USB UPS for each NUT driver instance (UPS), and if so
 	# configure permissions to allow NUT to access the port

--- a/net/nut/files/nut-serial.hotplug
+++ b/net/nut/files/nut-serial.hotplug
@@ -162,8 +162,12 @@ nut_on_hotplug_add() {
 # Do not do any hotplug actions if hotplug is disabled. Not an error but log
 # for information
 if ! allow_hotplug_restart; then
-	# Informational and not an error
-	log_msg "Did not set permissions on serial port hotplug as NUT hotplug is disabled" nut-serial nut-serial-hotplug notice
+	# Don't spam logs on initial boot
+	# (before NUT_HOTPLUG_BOOT_COMPLETE_PATH exists)
+	if [ -f "$NUT_HOTPLUG_BOOT_COMPLETE_PATH" ]; then
+		# Informational and not an error
+		log_msg "Did not set permissions on serial port hotplug as NUT hotplug is disabled" nut-serial nut-serial-hotplug notice
+	fi
 	exit 0
 fi
 

--- a/net/nut/files/nut-serial.hotplug
+++ b/net/nut/files/nut-serial.hotplug
@@ -194,6 +194,8 @@ if [ "$ACTION" = "add" ] && [ -n "$DEVNAME" ]; then
 	# ttyUSB* or ttyAMA* or ttyACM* or ttyGS*
 	case "$DEVNAME" in
 	ttyUSB* | ttyAMA* | ttyACM* | ttyGS*)
+		# As we are at the top-level of the hotplug event, this only aborts this
+		# hotplug event, not hotplug events for other devices
 		nut_on_hotplug_add || exit 1
 		;;
 	esac

--- a/net/nut/files/nut-serial.hotplug
+++ b/net/nut/files/nut-serial.hotplug
@@ -159,6 +159,10 @@ nut_on_hotplug_add() {
 	return 0
 }
 
+# Ignore incomplete (for our purposes) events
+[ -n "$DEVNAME" ] || exit 0
+[ -n "$ACTION" ] || exit 0
+
 # Do not do any hotplug actions if hotplug is disabled. Not an error but log
 # for information
 if ! allow_hotplug_restart; then

--- a/net/nut/files/nut-server.init
+++ b/net/nut/files/nut-server.init
@@ -103,6 +103,10 @@ basescript=$(readlink "$initscript")
 has_running_driver() {
 	local instances instance
 
+	# have_driver_instance and have_upsd_instance are 'pseudo-globals' -
+	# they are local to the _caller_ and visible/modifiable in this
+	# function in order to get the value back to the caller.
+
 	instances="$(list_running_instances "nut-server")"
 	[ -n "$instances" ] || return 0
 	set -f
@@ -244,14 +248,24 @@ stop_no_longer_configured_instances() {
 	local instance instances
 
 	# Stop any driver instances which are no longer configured
+	# This can occur when the configuration is changed and the service
+	# is restarted or reloaded, as this script is not notified of what has
+	# changed if the configuration changes; the script will simply
+	# generate a new configuration in that event.
 	# We can only reliably do this for instances managed by procd
 	instances="$(list_running_instances "nut-server")"
 	[ -n "$instances" ] || return 0
 	set -f
+	# Check that all instances are associated with a configured driver or
+	# the upsd daemon
 	for instance in $instances; do
+		# upsd should be stopped last, if it is stopped at all
 		if [ "$instance" = "upsd" ]; then
 			continue
 		fi
+		# Set to true if any instance was running, whether stopped here, or left
+		# running. have_driver_instance (set in has_running_driver) lets us know
+		# if any driver is still running.
 		had_running_instance="true"
 		config_get driver "$instance" driver
 		# Only stop not configured but running instances
@@ -271,7 +285,8 @@ stop_no_longer_configured_instances() {
 
 	# If we have no UPS instances we must stop upsd or it will crash
 	# The "nut-server" service remains active and will 'see' configuration
-	# changes and execute reload_service when they are detected
+	# changes and execute reload_service when they are detected, but avoid
+	# signalling upsd if it is not running ('had_running_instance' != "true")
 	if [ "$have_upsd_instance" = "true" ] && [ "$have_driver_instance" = "false" ] && [ "$had_running_instance" = "true" ]; then
 		log_msg "Stopping upsd because no driver instances configured" "nut-server" "nut-server" "notice"
 		signal_instance "upsd" "upsd" "stop" "TERM" "${STATEPATH}/upsd.pid" "" "nut-server" "procd_kill" "nut-server" "upsd"
@@ -520,6 +535,9 @@ manage_service() {
 			fi
 			;;
 		esac
+		# Ensure drivers no longer present in config, but which are still running
+		# get stopped. This is required because we are not notified of what was
+		# removed when configuration is removed.
 		stop_no_longer_configured_instances
 		return $ret
 		;;

--- a/net/nut/files/nut-server.init
+++ b/net/nut/files/nut-server.init
@@ -14,7 +14,19 @@
 START=70
 STOP=30
 
-USE_PROCD=1
+# We use the script functions and variables definitions from
+# /etc/rc.common that are added by USE_PROCD except with a modified
+# start and rc_procd. We cannot simply override USE_PROCD's
+# implementation of start and rc_procd as rc.common sources this
+# initscript before the definitions are applied by USE_PROCD
+#
+# The modified rc_procd uses "set" for procd_close_service, which
+# registers the service with procd, if the service for this
+# initscript (nut-server) is not registered with procd (active) at all,
+# otherwise it uses "add" which adds an instance to the registered
+# (active) service.
+#
+# USE_PROCD=1
 
 # IPKG_INSTROOT is intentionally only set when building an image and
 # is intentionally empty on a live OpenWrt device
@@ -73,32 +85,70 @@ USE_PROCD=1
 	exit 1
 }
 
+# shellcheck source=/dev/null
+. "${IPKG_INSTROOT}"/lib/functions/procd.sh || {
+	log_source_error "procd.sh" "nut-server" "nut-server"
+	exit 1
+}
+
 restore_umask_on_exit
 
-# Start a ups driver instance
-start_ups_driver() {
-	local ups="$1"
-	local requested="$2"
-	local driver=""
+extra_command "running" "Check if service is running"
+extra_command "status" "Service status"
+extra_command "trace" "Start with syscall trace"
+extra_command "info" "Dump procd service info"
 
-	# If wanting a specific instance, only start that instance
-	if [ -n "$requested" ] && [ "$requested" != "$ups" ]; then
-		return 0
+basescript=$(readlink "$initscript")
+
+has_running_driver() {
+	local instances instance
+
+	instances="$(list_running_instances "nut-server")"
+	[ -n "$instances" ] || return 0
+	set -f
+	for instance in $instances; do
+		if [ "$instance" = "upsd" ]; then
+			have_upsd_instance="true"
+			continue
+		fi
+		have_driver_instance="true"
+		break
+	done
+	set +f
+}
+
+start_server_service() {
+	procd_open_instance upsd
+	procd_set_param respawn
+	procd_set_param stderr 1
+	procd_set_param stdout 1
+	procd_set_param env NUT_DEBUG_SYSLOG="stderr"
+	procd_set_param env NUT_QUIET_INIT_UPSNOTIFY=true
+	procd_set_param env NUT_STATEPATH="$STATEPATH"
+	procd_set_param command /usr/sbin/upsd
+	procd_append_param command -FF
+	procd_append_param command -u "$RUNAS"
+	procd_close_instance
+}
+
+# Start upsd instance
+start_server_instance() {
+	if [ -f "$NUT_KILLPOWER" ]; then
+		return 1
 	fi
 
-	# For non-USB devices this is effectively a no-op
-	# For USB devices, if the USB productid and USB vendorid of the configured
-	# driver instance (UPS) match a USB device in sysfs, set the permissions
-	# on the USB device node in /dev/bus/usb/... to allow NUT to access and
-	# control the device.
-	ensure_usb_ups_access "$ups" || return 1
-	config_get driver "$ups" driver
+	local have_driver_instance="false"
+	local have_upsd_instance="false"
+	has_running_driver
 
-	[ -n "$driver" ] || {
-		log_error "Missing driver when starting UPS '$ups'" "nut-server" "nut-server"
-		return 1
-	}
+	# upsd will crash if started with no available UPS, so only start if
+	# we have one, and we do not already have a upsd instance
+	if [ "$have_driver_instance" = "true" ] && [ "$have_upsd_instance" = "false" ]; then
+		rc_procd start_server_service || return 1
+	fi
+}
 
+start_ups_service() {
 	procd_open_instance "$ups"
 	procd_set_param respawn
 	procd_set_param stderr 1
@@ -110,22 +160,42 @@ start_ups_driver() {
 	procd_append_param command -FF -a "$ups"
 	procd_append_param command -u "$RUNAS"
 	procd_close_instance
-
-	# If upsd is running, reload it to pick up new driver
-	if procd_running "nut-server" "upsd" >/dev/null 2>&1; then
-		signal_instance "upsd" "upsd" "reload" "HUP" "${STATEPATH}/upsd.pid" "" "nut-server"
-	else
-		start_server_instance
-	fi
 }
 
-# On reload, we need to use rpc_procd to add an instance to an already running
-# service, as procd_open_service is not called by default when doing a
-# reload vs start
-add_ups_driver() {
+# Start a ups driver instance
+start_ups_driver() {
 	local ups="$1"
 	local requested="$2"
-	rc_procd start_ups_driver "$ups" "$requested"
+	local driver=""
+
+	# If wanting a specific instance, only start that instance; this is a normal
+	# operating event, so do not log and do not error
+	if [ -n "$requested" ] && [ "$requested" != "$ups" ]; then
+		return 0
+	fi
+
+	# For non-USB devices this is effectively a no-op
+	# For USB devices, if the USB productid and USB vendorid of the configured
+	# driver instance (UPS) match a USB device in sysfs, set the permissions
+	# on the USB device node in /dev/bus/usb/... to allow NUT to access and
+	# control the device.
+	ensure_usb_ups_access "$ups" || {
+		usb_ups_access_error="true"
+		log_error "Error enabling USB access for UPS '$ups'" "nut-server" "nut-server"
+		return 1
+	}
+
+	config_get driver "$ups" driver
+
+	[ -n "$driver" ] || {
+		log_error "Missing driver when starting UPS '$ups'" "nut-server" "nut-server"
+		return 1
+	}
+
+	rc_procd start_ups_service "$@" || {
+		return 1
+	}
+	return 0
 }
 
 have_upsd_section() {
@@ -170,58 +240,52 @@ common_preconditions() {
 stop_no_longer_configured_instances() {
 	local have_driver_instance=false
 	local have_upsd_instance=false
+	local had_running_instance="false"
 	local instance instances
 
 	# Stop any driver instances which are no longer configured
 	# We can only reliably do this for instances managed by procd
-	set -f
 	instances="$(list_running_instances "nut-server")"
 	[ -n "$instances" ] || return 0
+	set -f
 	for instance in $instances; do
 		if [ "$instance" = "upsd" ]; then
 			continue
 		fi
+		had_running_instance="true"
 		config_get driver "$instance" driver
 		# Only stop not configured but running instances
 		if [ -z "$driver" ] && [ -n "$instance" ] && procd_running "nut-server" "$instance" >/dev/null 2>&1; then
-			procd_kill "nut-server" "$instance" 2>&1 | logger -t nut-server
+			log_msg "Stopping no longer configured ups '$instance'" "nut-server" "nut-server" notice
+			procd_kill "nut-server" "$instance"
 		fi
 	done
 	set +f
 
 	# Need to stop drivers before stopping upsd
-	# The second loop is required in case some instances failed to stop in the
-	# first loop (so we cannot just track instances in the above loop).
-	# In addition, it is possible for hotplug triggered drivers start to start
+	# The has_running_driver check is required in case some instances failed to
+	# stop in the first loop (so we cannot just track instances in the above loop).
+	# In addition, it is possible for hotplug triggered drivers starting to start
 	# instances between the stop above, and this loop.
-	set -f
-	instances="$(list_running_instances "nut-server")"
-	[ -n "$instances" ] || return 0
-	for instance in $instances; do
-		if [ "$instance" = "upsd" ]; then
-			have_upsd_instance="true"
-			continue
-		fi
-		have_driver_instance="true"
-		break
-	done
-	set +f
+	has_running_driver
 
 	# If we have no UPS instances we must stop upsd or it will crash
 	# The "nut-server" service remains active and will 'see' configuration
 	# changes and execute reload_service when they are detected
-	if [ "$have_upsd_instance" = "true" ] && [ "$have_driver_instance" = "false" ]; then
-		# stop_server_instance
+	if [ "$have_upsd_instance" = "true" ] && [ "$have_driver_instance" = "false" ] && [ "$had_running_instance" = "true" ]; then
+		log_msg "Stopping upsd because no driver instances configured" "nut-server" "nut-server" "notice"
 		signal_instance "upsd" "upsd" "stop" "TERM" "${STATEPATH}/upsd.pid" "" "nut-server" "procd_kill" "nut-server" "upsd"
+	elif [ "$have_upsd_instance" = "false" ] && [ "$have_driver_instance" = "true" ]; then
+		start_server_instance
 	fi
 }
 
 stop_all_instances() {
 	local instance instances
 
-	set -f
 	instances="$(list_running_instances "nut-server")"
 	[ -n "$instances" ] || return 0
+	set -f
 	for instance in $instances; do
 		# stop upsd last
 		if [ "$instance" = "upsd" ]; then
@@ -305,25 +369,6 @@ service_preconditions() {
 	return 0
 }
 
-# Start upsd instance
-start_server_instance() {
-	if [ -f "$NUT_KILLPOWER" ]; then
-		return 1
-	fi
-
-	procd_open_instance upsd
-	procd_set_param respawn
-	procd_set_param stderr 1
-	procd_set_param stdout 1
-	procd_set_param env NUT_DEBUG_SYSLOG="stderr"
-	procd_set_param env NUT_QUIET_INIT_UPSNOTIFY=true
-	procd_set_param env NUT_STATEPATH="$STATEPATH"
-	procd_set_param command /usr/sbin/upsd
-	procd_append_param command -FF
-	procd_append_param command -u "$RUNAS"
-	procd_close_instance
-}
-
 remove_var_config() {
 	for rm_file in "$USERS_C" "$UPS_C" "$UPSD_C" \
 		"$USERS_C.new" "$UPS_C.new" "$UPSD_C.new"; do
@@ -390,8 +435,12 @@ reload_ups_driver() {
 	# If the driver instance (UPS) was terminated, or stopped 'naturally',
 	# start it up again
 	if ! procd_running "nut-server" "$ups" >/dev/null 2>&1; then
-		add_ups_driver "$ups" "$ups"
+		start_ups_driver "$ups" "$ups"
 	fi
+
+	# If the server instance (upsd) was terminated, or stopped 'naturally',
+	# start it up again
+	start_server_instance
 	return 0
 }
 
@@ -412,14 +461,13 @@ manage_instances() {
 	case "$action" in
 	start)
 		config_foreach start_ups_driver driver
+		start_server_instance
 		;;
 	reload)
 		if service_active_no_instances "nut-server"; then
 			log_msg "nut-server active with no instances. Reloading." "nut-server" "nut-server" "info"
 		fi
-		if procd_running "nut-server" upsd >/dev/null 2>&1; then
-			signal_instance "upsd" "upsd" "reload" "HUP" "${STATEPATH}/upsd.pid" "" "nut-server" "procd_kill" "nut-server" "upsd"
-		fi
+
 		config_foreach reload_ups_driver driver
 		stop_no_longer_configured_instances
 		;;
@@ -444,16 +492,14 @@ manage_service() {
 	# instances, we act only on one instance).
 	local instance="$1"
 	local ret=0
+	local service_active
 
 	case "$action" in
 	start)
+		service_preconditions "$action"
+		ret=$?
 		case "$instance" in
 		"")
-			service_preconditions "$action"
-			ret=$?
-
-			stop_no_longer_configured_instances
-
 			if [ "$ret" = "0" ]; then
 				manage_instances start
 			else
@@ -462,27 +508,20 @@ manage_service() {
 			;;
 		# We only start one service (upsd or one driver) from a given invocation
 		upsd)
-			service_preconditions "$action"
-			ret=$?
 			if [ "$ret" = "0" ]; then
 				start_server_instance
 			fi
-			stop_no_longer_configured_instances
-
-			return $ret
 			;;
 		# We only start one service (upsd or one driver) from a given invocation
 		*)
-			service_preconditions "$action"
-			ret=$?
 			if [ "$ret" = "0" ]; then
 				config_foreach start_ups_driver driver "$instance"
+				start_server_instance
 			fi
-			stop_no_longer_configured_instances
-
-			return $ret
 			;;
 		esac
+		stop_no_longer_configured_instances
+		return $ret
 		;;
 	reload)
 		service_preconditions "$action"
@@ -492,8 +531,6 @@ manage_service() {
 			manage_instances reload
 		fi
 
-		stop_no_longer_configured_instances
-
 		if [ "$ret" = "1" ]; then
 			return 1
 		fi
@@ -502,17 +539,27 @@ manage_service() {
 		case "$instance" in
 		"")
 			manage_instances stop
+			ret=$?
+
+			service_active_no_instances "$(basename "${basescript:-$initscript}")"
+			service_active=$?
+
+			if [ "$service_active" -eq 1 ]; then
+				# Prevent NUT hotplug events when service is not running
+				rm -f "$NUT_HOTPLUG_BOOT_COMPLETE_PATH"
+			elif [ "$service_active" -eq 3 ]; then
+				return 1
+			fi
+			return $ret
 			;;
 		upsd)
 			if procd_running "nut-server" upsd >/dev/null 2>&1; then
 				signal_instance "upsd" "upsd" "stop" "TERM" "${STATEPATH}/upsd.pid" "" "nut-server" "procd_kill" "nut-server" "upsd"
 			fi
-			stop_service_if_no_instances
 			;;
 		*)
 			# We only handle the first parameter, so do not pass in all parameters
 			config_foreach stop_ups_driver driver "$instance"
-			stop_service_if_no_instances
 			;;
 		esac
 		;;
@@ -535,14 +582,61 @@ manage_service() {
 	esac
 }
 
+allow_hotplug() {
+	local ret="$1"
+
+	[ "$ret" -eq 0 ] || return "$ret"
+
+	# Allow hotplug events to (re)start drivers/upsd only if starting
+	# nut-server service was successful
+	touch "$NUT_HOTPLUG_BOOT_COMPLETE_PATH"
+
+	# Ensure drivers/upsd started once hotplug has been allowed
+	local usb_ups_access_error="false"
+	config_foreach start_ups_driver driver
+	if [ "$usb_ups_access_error" = "false" ]; then
+		start_server_instance
+		ret=$?
+	else
+		ret=1
+	fi
+
+	# Re-disable hotplug if starting drivers and/or upsd failed after
+	# enabling hotplug.
+	if [ "$ret" -ne 0 ]; then
+		rm -f "$NUT_HOTPLUG_BOOT_COMPLETE_PATH"
+	fi
+
+	return "$ret"
+}
+
 # Start NUT drivers and upsd (NUT server)
 start_service() {
+	local ret
 	manage_service start "$@"
+	ret=$?
+
+	# Only change allowing hotplug events for the
+	# start all instances case
+	if [ -z "$1" ]; then
+		allow_hotplug "$ret"
+	fi
 }
 
 # Reload NUT drivers and upsd (NUT server)
 reload_service() {
+	local ret
+
 	manage_service reload "$@"
+	ret=$?
+
+	# Only change allowing hotplug events for the
+	# reload all instances case
+	if [ -z "$1" ]; then
+		# Allow hotplug events to (re)start drivers/upsd when reloading
+		# (successfully) after a failed start
+		allow_hotplug "$ret"
+	fi
 }
 
 # Stop NUT drivers and upsd (NUT server)
@@ -567,4 +661,91 @@ service_triggers() {
 		log_error "Failed to add interface triggers" nut-server nut-server
 	}
 	procd_add_reload_trigger "nut_server"
+}
+
+rc_procd() {
+	local method service_active
+
+	service_active_no_instances "$(basename "${basescript:-$initscript}")"
+	service_active=$?
+
+	# Always use set if nut-server service is not active, even if this
+	# function is executed from reload or restart. In the default
+	# implementation from USE_PROCD=1, rc_procd is only called from
+	# start, so set is only used on a start action. In addition, the
+	# default rc_procd only uses add when called with a second parameter
+	if [ "$service_active" -eq 1 ]; then
+		log_msg "$(basename "${basescript:-$initscript}") was not active, so start it" "nut-server" "nut-server" "debug"
+		method="set"
+	elif [ "$service_active" -eq 3 ]; then
+		# log error message was already issued in service_active_no_instances
+		return 1
+	elif [ "$service_active" -eq 0 ] || [ "$service_active" -eq 2 ]; then
+		method="add"
+	else
+		log_error "Unexpected return value from 'service_active_no_instances'" "nut-server" "nut-server"
+		return 1
+	fi
+	procd_open_service "$(basename "${basescript:-$initscript}")" "$initscript"
+	"$@"
+	procd_close_service "$method"
+
+	return 0
+}
+
+# Define start in a way that avoids nesting rc_procd
+start() {
+	# Ensure start actions occur one at a time
+	procd_lock
+
+	# Ensure service is started even if no instances are started
+	if rc_procd :; then
+		start_service "$@"
+	fi
+}
+
+boot() {
+	start
+}
+
+trace() {
+	TRACE_SYSCALLS=1
+	start "$@"
+}
+
+info() {
+	json_init
+	json_add_string name "$(basename "${basescript:-$initscript}")"
+	json_add_boolean verbose "1"
+	_procd_ubus_call list
+}
+
+stop() {
+	procd_lock
+	stop_service "$@"
+	procd_kill "$(basename "${basescript:-$initscript}")" "$1"
+	if eval "type service_stopped" 2>/dev/null >/dev/null; then
+		service_stopped
+	fi
+}
+
+reload() {
+	if eval "type reload_service" 2>/dev/null >/dev/null; then
+		procd_lock
+		reload_service "$@"
+	else
+		start
+	fi
+}
+
+running() {
+	service_running "$@"
+}
+
+status() {
+	if eval "type status_service" 2>/dev/null >/dev/null; then
+		status_service "$@"
+	else
+		_procd_status "$(basename "${basescript:-$initscript}")" "$1"
+	fi
 }

--- a/net/nut/files/nut-service.sh.functions
+++ b/net/nut/files/nut-service.sh.functions
@@ -21,6 +21,8 @@ NUT_KILLPOWER="/var/run/killpower"
 
 # Disable NUT hotplug path
 NUT_DISABLE_HOTPLUG_PATH="/var/run/nut/disable-hotplug"
+# Must be present to allow hotplug
+NUT_HOTPLUG_BOOT_COMPLETE_PATH="/var/run/nut-hotplug-boot-complete"
 
 # Fallback STATEPATH setting
 NUT_BASE_STATEPATH="/var/run/nut"
@@ -48,6 +50,9 @@ allow_hotplug_restart() {
 	# or nutshutdown
 	[ ! -f "$NUT_DISABLE_HOTPLUG_PATH" ] || return 1
 
+	# Initial boot complete; NUT hotplug allowed sentinel
+	# Created by nut-server initscript
+	[ -f "$NUT_HOTPLUG_BOOT_COMPLETE_PATH" ] || return 1
 	return 0
 }
 
@@ -211,14 +216,23 @@ find_runas() {
 	) || return $?
 }
 
-# Detect if service is running under procd, with no instances
-# (e.g. upsd with no UPS drivers running)
+# Detect if a service is active with procd, and if it has
+# any instances.
+#
+# Returns:
+#  0 - service is registered (active) but has no instances
+#  1 - service is not registered (active) at all
+#  2 - service is registered (active) and has instances
+#  3 - error condition encountered
 service_active_no_instances() {
 	local service="$1"
 	local active_instances
 	local active_var service_filter
 
-	check_safe_uci_name "$service" || return 1
+	check_safe_uci_name "$service" || {
+		log_error "Invalid service name '$service' in service_active_no_instances" nut-service.sh nut-service
+		return 3
+	}
 
 	service_filter="@['""${service}""']"
 	active_instances="$(_procd_ubus_call list "{\"name\":\"$service\"}" | jsonfilter -l 1 -e active_var="$service_filter")"
@@ -232,14 +246,16 @@ service_active_no_instances() {
 		;;
 	*)
 		log_error "Unexpected value '$active_instances' for 'active_instances' from jsonfilter in service_active_no_instances" nut-service.sh nut-service
-		return 1
+		return 3
 		;;
 	esac
 
 	# active_var is only empty, but present, if there are no instances for the service
 	[ -z "$active_var" ] && return 0
 
-	return 1
+	# otherwise there are instances, in any state, for the service; to check if
+	# any are running use procd_running
+	return 2
 }
 
 # Setup triggers in procd for changes to specified network interfaces


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @danielfdickinson 

**Description:**

On boot, hotplug events were causing excessive start and stop action
for the upsd daemon and driver daemons. We fix that with two primary
actions:
  1. Don't restart service daemons on hotplug until after first boot
     has completed.
  2. Use more robust handling of procd instance starts by ensuring
     that the first start starts the nut-server service and all
     others add to the nut-server service (rather than replacing it).

In addition clean up some logging.

In the process, this fixes #30375 "hotplugging for setting usb access
right[s] doesn't work anymore"
    
Closes: #30375

We also fix configuration of custom notification messages

Short-circuit not applicable portions of hotplug script on remove, and
make sure we ignore events with incomplete information (no DEVNAME
or no ACTION).

The match against known device was badly formatted, and was
not being used as a result. Fix that.

Finally, a previous PR missed updating the hotplug scripts for the
new find_runas and find_statepath functions which emit
the value on stdout instead of setting a variable in the
caller's cope. Update that usage.

---

## 🧪 Run Testing Details

### Server and Self-client (with and without SSL)

- **OpenWrt Version:** OpenWrt SNAPSHOT r35906-3d1645ee26
- **OpenWrt Target/Subtarget:** bcm27xx/bcm2709
- **OpenWrt Device:** Raspberry Pi 2 Model B Rev 1.1
- **UPS:** Tripp-Lite ECO 550 UPS

### Client (with and without SSL)

- **OpenWrt Version:** OpenWrt SNAPSHOT r35921-f0204d78e1
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** OpenWrt One

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
