### PR TITLE
mwan3: strip dead flag from copied routes

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
 PKG_VERSION:=2.12.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
 PKG_LICENSE:=GPL-2.0

--- a/net/mwan3/files/lib/mwan3/common.sh
+++ b/net/mwan3/files/lib/mwan3/common.sh
@@ -157,7 +157,7 @@ mwan3_get_mwan3track_status()
 
 mwan3_init()
 {
-	local bitcnt mmdefault source_routing
+	local bitcnt mmdefault route_modifiers source_routing
 
 	config_load mwan3
 
@@ -180,10 +180,14 @@ mwan3_init()
 		LOG debug "Max interface count is ${MWAN3_INTERFACE_MAX}"
 	fi
 
-	# remove "linkdown", expiry and source based routing modifiers from route lines
+	# remove unsupported flags, expiry and source based routing modifiers
 	config_get_bool source_routing globals source_routing 0
 	[ $source_routing -eq 1 ] && unset source_routing
-	MWAN3_ROUTE_LINE_EXP="s/offload//; s/linkdown //; s/expires [0-9]\+sec//; s/error [0-9]\+//; ${source_routing:+s/default\(.*\) from [^ ]*/default\1/;} p"
+	route_modifiers="s/offload//; s/ dead / /; s/ dead$/ /;"
+	route_modifiers="$route_modifiers s/ linkdown / /; s/ linkdown$/ /;"
+	route_modifiers="$route_modifiers s/expires [0-9]\+sec//;"
+	route_modifiers="$route_modifiers s/error [0-9]\+//;"
+	MWAN3_ROUTE_LINE_EXP="$route_modifiers ${source_routing:+s/default\(.*\) from [^ ]*/default\1/;} p"
 
 	# mark mask constants
 	bitcnt=$(mwan3_count_one_bits MMX_MASK)

--- a/net/mwan3/test.sh
+++ b/net/mwan3/test.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+# shellcheck shell=busybox
+
+IPKG_INSTROOT=${IPKG_INSTROOT:-}
+export IPKG_INSTROOT
+
+. /lib/functions.sh
+. /lib/mwan3/mwan3.sh
+
+set -e
+
+mwan3_init
+
+sanitize_route()
+{
+	printf '%s\n' "$1" | sed -ne "$MWAN3_ROUTE_LINE_EXP"
+}
+
+expected='192.0.2.0/24 dev eth0 scope link src 192.0.2.1 '
+
+for flags in 'dead linkdown' 'linkdown dead' 'dead' 'linkdown'; do
+	actual=$(sanitize_route "$expected$flags")
+	[ "$actual" = "$expected" ] || {
+		echo "failed to sanitize route flags: $flags" >&2
+		echo "expected: '$expected'" >&2
+		echo "actual:   '$actual'" >&2
+		exit 1
+	}
+done
+
+ipv6_route='fd00:1::/64 via fe80::dead dev eth0 proto static metric 1024 pref medium'
+actual=$(sanitize_route "$ipv6_route")
+[ "$actual" = "$ipv6_route" ] || {
+	echo "failed to preserve an IPv6 address ending in dead" >&2
+	echo "expected: '$ipv6_route'" >&2
+	echo "actual:   '$actual'" >&2
+	exit 1
+}


### PR DESCRIPTION
## Description

Routes for devices without carrier may be reported as:

```
192.0.2.0/24 dev eth0 scope link src 192.0.2.1 dead linkdown
```

`mwan3` removes `linkdown` before copying the route to its policy tables,
but retains `dead`. `ip route replace table ...` rejects that token with:

```
Error: either "to" is duplicate, or "dead" is garbage.
```

The connected route is then missing from the WAN policy tables. Marked reply
traffic follows the table's default route back to the WAN instead of reaching
the LAN client.

Strip both flags, whether followed by whitespace or present at the end of the
line. Bump the package release because an installed support file changes.

## Testing

- Added a runtime test for `dead` and `linkdown`, individually and in both
  orders.
- Ran the test successfully on OpenWrt 25.12.5 with BusyBox 1.37.0.
- Reproduced missing policy-table routes before the patch and confirmed that
  routes for link-down devices populate tables 1, 2, and 3 after the patch.
- Confirmed affected client TCP sessions can establish after restarting
  `mwan3` with the patch applied.
- Built `package/mwan3/compile` successfully with the OpenWrt 25.12.5 SDK.
