### PR TITLE
zabbix: bump to version 7.0.30

### DIFF
--- a/admin/zabbix/Makefile
+++ b/admin/zabbix/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zabbix
-PKG_VERSION:=7.0.29
+PKG_VERSION:=7.0.30
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://cdn.zabbix.com/zabbix/sources/stable/$(basename $(PKG_VERSION))/ \
 	https://cdn.zabbix.com/zabbix/sources/oldstable/$(basename $(PKG_VERSION))/
-PKG_HASH:=184d03454d7ff2d49fa1d292082ad335bce907ba22e30d54035d05329708ce32
+PKG_HASH:=c0ca4079119adeec4135e3351d1b849157ade076c352c006728e732f1707232c
 
 PKG_MAINTAINER:=Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>
 PKG_LICENSE:=AGPL-3.0-only


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @danielfdickinson 

**Description:**

Bug-fix update: https://www.zabbix.com/rn/rn7.0.30

---

## 🧪 Run Testing Details

- **OpenWrt Version:** OpenWrt SNAPSHOT r35960-1ad2e78e6a
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** OpenWrt One

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- N/A It is structured in a way that it is potentially upstreamable
