### PR TITLE
mutt: update to 2.4.2

### DIFF
--- a/mail/mutt/Makefile
+++ b/mail/mutt/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mutt
-PKG_VERSION:=2.1.5
-PKG_RELEASE:=2
+PKG_VERSION:=2.4.2
+PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=http://ftp.mutt.org/pub/mutt/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=92a309e47e363a97d62425bcb71adceae5ab5c4c413dbcac37fa98ed70c12be0
+PKG_HASH:=2703ff1a51a99c3163d4fd998ac22e982bbd5493d512a7c5bde716a8adba0394
 
 PKG_MAINTAINER:=Phil Eichinger <phil@zankapfel.net>
 PKG_LICENSE:=GPL-2.0-or-later


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @philenotfound
**Description:** Changelog since last version: https://gitlab.com/muttmua/mutt/-/compare/mutt-2-1-5-rel...mutt-2-4-2-rel

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT, r35836-20d94d5a2b
- **OpenWrt Target/Subtarget:** Filogic 8x0 (MT798x)
- **OpenWrt Device:** Bananapi BPi-R4

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.