### PR TITLE
[25.12] bsbf-resources: update to GIT HEAD of 2026-08-29

### DIFF
--- a/net/bsbf-resources/Makefile
+++ b/net/bsbf-resources/Makefile
@@ -4,16 +4,16 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bsbf-resources
-PKG_RELEASE:=2
+PKG_RELEASE:=1
 
 PKG_LICENSE:=AGPL-3.0-or-later
 PKG_MAINTAINER:=Chester A. Unal <chester.a.unal@arinc9.com>
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/bondingshouldbefree/bsbf-resources.git
-PKG_SOURCE_DATE:=2026-06-24
-PKG_SOURCE_VERSION:=8d0b6ee9b4a0f99c50e63a005c41fc7ddaa46045
-PKG_MIRROR_HASH:=e91a54270cf7e4fd0ef3f4ba3dd2c31f15854b7fc05fcaaa1b68d1627ef20ae2
+PKG_SOURCE_DATE:=2026-08-29
+PKG_SOURCE_VERSION:=60f0d20f2f36059519abbc0881836e44a0cb8930
+PKG_MIRROR_HASH:=a8c57684c0ec2bc752dcfae52ac4b64f59b41cc93be4081e33c20b6a567ade3a
 
 include $(INCLUDE_DIR)/package.mk
 

--- a/net/bsbf-resources/files/usr/sbin/bsbf-bonding
+++ b/net/bsbf-resources/files/usr/sbin/bsbf-bonding
@@ -35,9 +35,8 @@ case "$1" in
 	      -D id="$uuid" \
 	      -e '
 	  let j = json(fs.readfile(infile));
-	  j.outbounds[0].settings.address = addr;
-	  j.outbounds[0].settings.port = port;
 	  j.outbounds[0].settings.id = id;
+	  j.outbounds[1].settings.redirect = `${addr}:${port}`;
 	  fs.writefile(outfile, sprintf("%.2J\n", j));'
 
 	# Flush the MPTCP endpoint table.


### PR DESCRIPTION
## 🧪 Run Testing Details

- **OpenWrt Version: 25.12.5**
- **OpenWrt Target/Subtarget: mvebu/cortexa9**
- **OpenWrt Device: linksys_wrt32x**