### PR TITLE
hev-socks5-server: update to 2.13.1

### DIFF
--- a/net/hev-socks5-server/Makefile
+++ b/net/hev-socks5-server/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=hev-socks5-server
-PKG_VERSION:=2.13.0
+PKG_VERSION:=2.13.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/heiher/hev-socks5-server/releases/download/$(PKG_VERSION)
-PKG_HASH:=55258482ba9b45e1c358c5e92914fca5ad677e3c94b77933ac0e82b14cd73d68
+PKG_HASH:=aecff4c35d7ffa6458ff55512b04d00c1d102ddc3fbee466534a9b1876022da4
 
 PKG_MAINTAINER:=Ray Wang <git@hev.cc>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @heiher

**Description:** update to 2.13.1

Upstream changelog:
https://github.com/heiher/hev-socks5-server/releases/tag/2.13.1

---

## 🧪 Run Testing Details

- **OpenWrt Version:** snapshot
- **OpenWrt Target/Subtarget:** armv8/generic
- **OpenWrt Device:** armsr

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.