### PR TITLE
hcxdumptool/hcxtools: update to version 7.1.2

### DIFF
--- a/net/hcxdumptool/Makefile
+++ b/net/hcxdumptool/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=hcxdumptool
-PKG_VERSION:=6.3.4
+PKG_VERSION:=7.1.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/zerbea/hcxdumptool/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=a45140960bd5de28085d549e1a9ccf2c08af143984a138c28ac4092c6a52a5d2
+PKG_HASH:=4d733201bad47be494ce712227c915c668a63b98eebd151d33108a44d08c2efb
 
 PKG_MAINTAINER:=Andreas Nilsen <adde88@gmail.com>
 PKG_LICENSE:=MIT

--- a/net/hcxdumptool/Makefile
+++ b/net/hcxdumptool/Makefile
@@ -24,7 +24,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/hcxdumptool
   SECTION:=net
   CATEGORY:=Network
-  DEPENDS:=+libpcap +libopenssl
+  DEPENDS:=+libpcap
   TITLE:=hcxdumptool
   URL:=https://github.com/ZerBea/hcxdumptool
   SUBMENU:=Wireless

--- a/net/hcxdumptool/Makefile
+++ b/net/hcxdumptool/Makefile
@@ -41,7 +41,8 @@ endef
 define Build/Compile
 	$(MAKE) -C $(PKG_BUILD_DIR)/ \
 		$(TARGET_CONFIGURE_OPTS) \
-		CFLAGS="$(TARGET_CFLAGS)"
+		CFLAGS="$(TARGET_CFLAGS)" \
+		hcxdumptool
 endef
 
 define Package/hcxdumptool/install

--- a/net/hcxdumptool/Makefile
+++ b/net/hcxdumptool/Makefile
@@ -41,7 +41,8 @@ endef
 define Build/Compile
 	$(MAKE) -C $(PKG_BUILD_DIR)/ \
 		$(TARGET_CONFIGURE_OPTS) \
-		CFLAGS="$(TARGET_CFLAGS)" \
+		CFLAGS="$(TARGET_CFLAGS) -std=gnu99" \
+		LDFLAGS="$(TARGET_LDFLAGS) -lpcap" \
 		hcxdumptool
 endef
 

--- a/net/hcxtools/Makefile
+++ b/net/hcxtools/Makefile
@@ -8,24 +8,23 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=hcxtools
-PKG_VERSION:=6.3.2
+PKG_VERSION:=7.1.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/zerbea/hcxtools/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=555e46a59df6a77c5aa73b99ffa8c1e84fa79e24ffaf5180de1d3a7f4ab7a470
+PKG_HASH:=c726b93df32efd3298874b324f820d93cb08a4dae03d9144b0d5062c003fd77f
 
 PKG_MAINTAINER:=Andreas Nilsen <adde88@gmail.com>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=license.txt
 
 include $(INCLUDE_DIR)/package.mk
-include $(INCLUDE_DIR)/meson.mk
 
 define Package/hcxtools
   SECTION:=net
   CATEGORY:=Network
-  DEPENDS:=+libpthread +libpcap +zlib +libcurl +libopenssl
+  DEPENDS:=+libpthread +zlib +libcurl +libopenssl
   TITLE:=hcxtools
   URL:=https://github.com/ZerBea/hcxtools
   SUBMENU:=Wireless
@@ -36,17 +35,24 @@ define Package/hcxtools/description
   for the use with latest hashcat or John the Ripper.
 endef
 
+define Build/Compile
+	$(MAKE) -C $(PKG_BUILD_DIR)/ \
+		$(TARGET_CONFIGURE_OPTS) \
+		CFLAGS="$(TARGET_CFLAGS)"
+endef
+
 define Package/hcxtools/install
 	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/hcxeiutool		$(1)/usr/bin/
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/hcxhash2cap		$(1)/usr/bin/
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/hcxhashtool		$(1)/usr/bin/
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/hcxpcapngtool		$(1)/usr/bin/
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/hcxpmktool		$(1)/usr/bin/
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/hcxpsktool		$(1)/usr/bin/
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/hcxwltool		$(1)/usr/bin/
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/whoismac		$(1)/usr/bin/
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/wlancap2wpasec	$(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/hcxeiutool		$(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/hcxhash2cap		$(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/hcxhashtool		$(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/hcxpcapngtool		$(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/hcxpmktool		$(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/hcxpottool		$(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/hcxpsktool		$(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/hcxwltool		$(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/whoismac		$(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlancap2wpasec	$(1)/usr/bin/
 endef
 
 $(eval $(call BuildPackage,hcxtools))

--- a/net/hcxtools/Makefile
+++ b/net/hcxtools/Makefile
@@ -38,7 +38,8 @@ endef
 define Build/Compile
 	$(MAKE) -C $(PKG_BUILD_DIR)/ \
 		$(TARGET_CONFIGURE_OPTS) \
-		CFLAGS="$(TARGET_CFLAGS)"
+		CFLAGS="$(TARGET_CFLAGS) -std=gnu99" \
+		LDFLAGS="$(TARGET_LDFLAGS)"
 endef
 
 define Package/hcxtools/install


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @adde88>

**Description:**
Full changelog since the last update of hcxdumptool:
https://raw.githubusercontent.com/ZerBea/hcxdumptool/refs/tags/7.1.2/changelog

Full changelog since the last update of hcxtools:
https://raw.githubusercontent.com/ZerBea/hcxtools/refs/tags/7.1.2/changelog

<!-- Briefly describe what this package does or what changes are introduced -->

---

## 🧪 Run Testing Details

- **OpenWrt Version:** OpenWrt 25.12-SNAPSHOT, r32949-54cced5b2f and OpenWrt 25.12-SNAPSHOT, r33164-4a5c6b90d2
- **OpenWrt Target/Subtarget:** Freescale MPC85xx/P1010 and MediaTek ARM/Filogic 8x0 (MT798x) 
- **OpenWrt Device:** TP-Link TL-WDR4900 v1 and Xiaomi Redmi Router AX6000 (OpenWrt U-Boot layout)

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

