### PR TITLE
net/acme-acmesh: prevent concurrent execution of acme.sh instances

### DIFF
--- a/net/acme-acmesh/Makefile
+++ b/net/acme-acmesh/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=acme-acmesh
 PKG_VERSION:=3.1.3
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/acmesh-official/acme.sh/tar.gz/$(PKG_VERSION)?

--- a/net/acme-acmesh/files/hook.sh
+++ b/net/acme-acmesh/files/hook.sh
@@ -105,6 +105,7 @@ get)
 	esac
 
 	log info "Running ACME for $main_domain with validation_method $validation_method"
+        lock_file="$state_dir/acme-sh.lock"
 
 	staging_moved=0
 	if [ -e "$domain_dir" ]; then
@@ -117,7 +118,7 @@ get)
 			log info "$ACME $*"
 			trap "handle_signal renew Renewal" INT TERM
 			add_nft_rule "$main_domain" "$listen_port"
-			$ACME "$@" &
+			flock "$lock_file" $ACME "$@" &
 			wait $!
 			status=$?
 			trap - INT TERM
@@ -200,7 +201,7 @@ get)
 
 	log info "$ACME $*"
 	trap "handle_signal issue Issuance" INT TERM
-	"$ACME" "$@" \
+	flock "$lock_file" "$ACME" "$@" \
 		--pre-hook "$NOTIFY prepare" \
 		--renew-hook "$NOTIFY renewed" &
 	wait $!


### PR DESCRIPTION
After switching ACME to being run through procd, individual ACME instances are now executed in parallel instead of sequentially. This causes acme.sh to become confused in certain cases. Petr reported that certificate files ended up with the wrong contents after updating to OpenWrt 25.12.

Fix this by wrapping the acme.sh execution in a global `flock` keyed on a file in the state directory. The procd instances will still run in parallel, but they'll all serialise on the same lock, so only one acme.sh instance will run at a time.

Fixes: 76b676e4ebbb ("acme.sh: move to procd to ensure logging gets to syslog")
Reported-by: Petr Novák <petrn@me.com>

## 📦 Package Details

**Maintainer:** me