### PR TITLE
comrade: update to 0.1.17

### DIFF
--- a/net/comrade/Makefile
+++ b/net/comrade/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=comrade
-PKG_VERSION:=0.1.16
+PKG_VERSION:=0.1.17
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/dangowrt/comrade/releases/download/v$(PKG_VERSION)
-PKG_HASH:=1054b4b3df410401caa0b35d64b35c0f95c5dce91f617f25fbccb03bdd60553a
+PKG_HASH:=7824d2d475647456529256ad912ad7378a432da769777986d424b08e22de1329
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=AGPL-3.0-or-later


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @dangowrt

**Description:**
Update net/comrade to 0.1.17.

### v0.1.17

- dangowrt/comrade@d06bc7b cmake: serialise the newer e2e tests on the network lock
- dangowrt/comrade@03e1c7a keys, sig_mcast: derive the link-local port from the invitation
- dangowrt/comrade@383f4ea bep44, netstate, sig: let both families prove their rendezvous
- dangowrt/comrade@c901fe4 ui: the header line names the build
- dangowrt/comrade@64b5c27 ci: raise the matrix burst caps to six
- dangowrt/comrade@6da5c94 path: near-equal paths do not drift, and a switch carries its verdict

---

## 🧪 Run Testing Details

- **OpenWrt Version:** -
- **OpenWrt Target/Subtarget:** -
- **OpenWrt Device:** -

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
