### PR TITLE
fluent-bit: backport 5.0.8 and musl crash fixes to
25.12

### DIFF
--- a/admin/fluent-bit/Makefile
+++ b/admin/fluent-bit/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fluent-bit
 PKG_VERSION:=5.0.8
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/fluent/fluent-bit.git
@@ -57,6 +57,9 @@ define Package/fluent-bit/install
 
 	$(INSTALL_DIR) $(1)/etc/fluent-bit
 	$(INSTALL_CONF) $(PKG_BUILD_DIR)/conf/parsers.conf $(1)/etc/fluent-bit/parsers.conf
+
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/fluent-bit.init $(1)/etc/init.d/fluent-bit
 endef
 
 $(eval $(call BuildPackage,fluent-bit))

--- a/admin/fluent-bit/Makefile
+++ b/admin/fluent-bit/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fluent-bit
 PKG_VERSION:=5.0.8
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/fluent/fluent-bit.git
@@ -46,6 +46,7 @@ CMAKE_OPTIONS+= \
 	-DFLB_BACKTRACE=No \
 	-DFLB_WASM=No \
 	-DFLB_LUAJIT=No \
+	-DFLB_CORO_STACK_SIZE=65536 \
 	-DWITH_SASL=No \
 	-DWITH_ZLIB=No \
 	-DWITH_ZSTD=No \

--- a/admin/fluent-bit/Makefile
+++ b/admin/fluent-bit/Makefile
@@ -1,14 +1,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fluent-bit
-PKG_VERSION:=4.2.0
+PKG_VERSION:=5.0.8
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/fluent/fluent-bit.git
 PKG_SOURCE_VERSION=v$(PKG_VERSION)
-PKG_MIRROR_HASH:=cad2d94cf7a720a3910c781f80187e2c399aa8acbfa1046aa7445a4d1495fafd
+PKG_MIRROR_HASH:=e512206f301abee2f326a62faeaae258d1a2b3a5d698d6c4dc45909d0a9e0dca
 
+PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 
@@ -35,6 +36,8 @@ endef
 
 TARGET_LDFLAGS +=-lfts -latomic
 
+# Force native __thread TLS: GCC 14 makes upstream's C-TLS probe fail (undeclared
+# __tls_get_addr), and its pthread_key fallback segfaults on musl at startup.
 CMAKE_OPTIONS+= \
 	-DFLB_RELEASE=Yes \
 	-DEXCLUDE_FROM_ALL=true \
@@ -45,7 +48,8 @@ CMAKE_OPTIONS+= \
 	-DFLB_LUAJIT=No \
 	-DWITH_SASL=No \
 	-DWITH_ZLIB=No \
-	-DWITH_ZSTD=No
+	-DWITH_ZSTD=No \
+	-DFLB_HAVE_C_TLS=Yes
 
 define Package/fluent-bit/install
 	$(INSTALL_DIR) $(1)/usr/sbin

--- a/admin/fluent-bit/files/fluent-bit.init
+++ b/admin/fluent-bit/files/fluent-bit.init
@@ -1,0 +1,12 @@
+#!/bin/sh /etc/rc.common
+START=99
+
+USE_PROCD=1
+
+start_service() {
+	procd_open_instance
+	procd_set_param command fluent-bit --supervisor -c /etc/fluent-bit/fluent-bit.yaml
+	procd_set_param file /etc/fluent-bit/fluent-bit.yaml
+	procd_set_param respawn
+	procd_close_instance
+}

--- a/admin/fluent-bit/test.sh
+++ b/admin/fluent-bit/test.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+# Regression test for issue #30113: with too small a coroutine stack the HTTP
+# output plugin overflows and dies (SIGSEGV/abort) on its first flush. Drive the
+# dummy input into the http output and make sure fluent-bit survives a few flush
+# cycles. No server is needed -- the crash happens while composing/sending the
+# request, so a refused local port is enough to exercise it.
+
+case "$1" in
+fluent-bit) ;;
+*) exit 0 ;;
+esac
+
+BIN=/usr/sbin/fluent-bit
+[ -x "$BIN" ] || { echo "FAIL: $BIN not installed"; exit 1; }
+
+cfg=/tmp/fluent-bit-http.conf
+cat > "$cfg" <<'EOF'
+[SERVICE]
+    flush     1
+    daemon    off
+    log_level error
+[INPUT]
+    name      dummy
+    dummy     {"message":"regress-30113"}
+    rate      100
+[OUTPUT]
+    name      http
+    match     *
+    host      127.0.0.1
+    port      5170
+    format    json
+EOF
+
+# A healthy run keeps retrying the refused endpoint until timeout stops it
+# (rc 124); a coroutine-stack overflow dies from a signal (rc >= 128) within
+# the first flush cycle.
+timeout 6 "$BIN" -c "$cfg" >/tmp/fluent-bit-http.out 2>&1
+rc=$?
+
+if [ "$rc" -ge 128 ]; then
+	echo "FAIL: fluent-bit http output died from a signal (rc=$rc) -- coro stack too small"
+	grep -iE 'signal|SIGSEGV' /tmp/fluent-bit-http.out | head -1
+	exit 1
+fi
+
+echo "fluent-bit: http output survived flush cycles (rc=$rc)"


### PR DESCRIPTION
Fixes #28892: on 25.12 (GCC 14 + musl) the C-TLS probe fails to build and
the pthread_key fallback dereferences a NULL TSD array before main(), so
every invocation segfaults. Backports the three master commits:
the 5.0.8 update with -DFLB_HAVE_C_TLS=Yes, the init script,
and the FLB_CORO_STACK_SIZE=65536 fix for the HTTP output SIGSEGV.

Tested on mediatek/filogic (25.12.5): built with the official SDK,
installed on a real router, shipping logs to VictoriaLogs over HTTPS.
