### PR TITLE
batman-adv: update packages to version 2026.3

### DIFF
--- a/net/alfred/Makefile
+++ b/net/alfred/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=alfred
-PKG_VERSION:=2026.2
+PKG_VERSION:=2026.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)
-PKG_HASH:=d995748be5f62a42091525ccc102df5ac642186e9b9014698a955a4469b69b96
+PKG_HASH:=1f81505481aa4888e97116b374f2953aa42c25da1062984672269dc591bb0431
 
 PKG_MAINTAINER:=Simon Wunderlich <sw@simonwunderlich.de>
 PKG_LICENSE:=GPL-2.0-only MIT

--- a/net/batctl/Makefile
+++ b/net/batctl/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=batctl
-PKG_VERSION:=2026.2
+PKG_VERSION:=2026.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)
-PKG_HASH:=c1d580afb066d3165c239b67430b94c69932619c06a90b1295e828cb5081b122
+PKG_HASH:=2c8443fae7b3471a500837f8cfbbc2b7bbab602e43ce8c61b100560dec1d9ee0
 
 PKG_MAINTAINER:=Simon Wunderlich <sw@simonwunderlich.de>
 PKG_LICENSE:=GPL-2.0-only ISC MIT

--- a/net/batman-adv/Makefile
+++ b/net/batman-adv/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=batman-adv
-PKG_VERSION:=2026.2
+PKG_VERSION:=2026.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)
-PKG_HASH:=4e17fced2c80945e22609be87534481733ff1b5d17050de4e4f323c171418135
+PKG_HASH:=c3524e7d8f148786a052654a7b1090e394746d3a71ee5d657f986dd7af161762
 PKG_EXTMOD_SUBDIRS:=net/batman-adv
 
 PKG_MAINTAINER:=Simon Wunderlich <sw@simonwunderlich.de>

--- a/net/batman-adv/patches/0001-fix-batadv_is_cfg80211_netdev.patch
+++ b/net/batman-adv/patches/0001-fix-batadv_is_cfg80211_netdev.patch
@@ -8,7 +8,7 @@ macro to use when building under backports.
 
 --- a/net/batman-adv/hard-interface.c
 +++ b/net/batman-adv/hard-interface.c
-@@ -320,8 +320,7 @@ static bool batadv_is_cfg80211_netdev(st
+@@ -332,8 +332,7 @@ static bool batadv_is_cfg80211_netdev(st
  {
  	if (!net_device)
  		return false;

--- a/net/batman-adv/src/compat-hacks.h
+++ b/net/batman-adv/src/compat-hacks.h
@@ -67,6 +67,44 @@ static inline u32 batadv_skb_crc32c(struct sk_buff *skb, int offset,
 
 #endif /* < KERNEL_VERSION(7, 0, 0) */
 
+#if LINUX_VERSION_IS_LESS(7, 3, 0)
+
+#include <linux/skbuff.h>
+
+static inline bool __must_check
+batadv_skb_set_transport_header_careful(struct sk_buff *skb, const int offset)
+{
+	long thoff = skb->data - skb->head + offset;
+
+	if (unlikely(thoff != (typeof(skb->transport_header))thoff))
+		return false;
+
+	if (unlikely(thoff == (typeof(skb->transport_header))~0U))
+		return false;
+
+	skb->transport_header = thoff;
+	return true;
+}
+
+#define skb_set_transport_header_careful batadv_skb_set_transport_header_careful
+
+#endif /* LINUX_VERSION_IS_LESS(7, 3, 0) */
+
+/* <VERSION> */
+
+#include <linux/utsname.h>
+
+#define init_utsname() batadv_init_utsname()
+
+extern struct new_utsname batadv_version_name;
+
+static inline struct new_utsname *batadv_init_utsname(void)
+{
+	return &batadv_version_name;
+}
+
+/* </VERSION> */
+
 /* <DECLARE_EWMA> */
 
 #include <linux/version.h>


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @simonwunderlich

**Description:**

Update to the batman-adv (and related tools) [release 2026.3](https://www.open-mesh.org/news/129)

batman-adv
----------

* support latest kernels (5.15 - 7.3)
* coding style cleanups and refactoring
* reduce memory and runtime overhead by only handling attached interfaces
* optimize throughput meters unacked packets handling
* bugs squashed:
  - clean untagged VLAN on netdev registration failure
  - ensure minimal ethernet header on TX
  - fix VLAN priority offset
  - bla: avoid CRC corruption due to parallel claim add
  - bla: fix freeing of claims on meshif deletion
  - bla: prevent CRC corruptions after claim flush
  - dat: atomically update mac addresses
  - dat: avoid unaligned fault in IP extraction
  - dat: fix tie-break for candidate selection
  - frag: fix primary_if leak on failed linearization
  - frag: fix stale receive device on merged fragments
  - frag: free unfragmentable packet
  - mcast: avoid OOB read of num_dests header
  - mcast: fix TX priority extraction for BATADV_FORW_MCAST
  - mcast: ensure unshared skb for multicast packets
  - mcast: linearize skbuff for packet generation
  - mcast: reject unrepresentable TVLV offsets
  - tt: avoid request storms during pending request
  - tt: prevent TVLV OOB check overflow
  - tvlv: handle negative tvlv processing return codes


batctl
------

* coding style cleanups and refactoring
* bugs squashed:
  - bat-hosts: compare full path for deduplication
  - bat-hosts: free bat_host when hash_add fails
  - dat_cache: fix multicast/unicast filter for MAC address
  - debug: avoid endless getopt loop for attached '-w' argument
  - debug: reject non-finite/negative interval/timeout values
  - debug: reject trailing garbage for intervals
  - debug: use strict interval/timeout parsing
  - event: don't print timestamp prefix for skipped events
  - fix parsing of parameters with arguments
  - genl_json: avoid negative chars in sanitize_string
  - genl_json: escape non-printable characters as valid JSON
  - genl_json: reject unknown options in handle_json_query
  - handle netlink callback object on error
  - icmp_helper: attach socket filter before packets can arrive
  - icmp_helper: fail send when the primary mac is unknown
  - icmp_helper: return only initialized icmp destination unreached bytes
  - icmp_helper: return proper errno on syscall failures
  - improve number parsing error handling
  - interface: report rtnl query failures
  - interface: return fail for non-existing interface
  - isolation_mark: fix error message for invalid mark/mask values
  - netlink: abort netlink_print_common when message allocation fails
  - netlink: always 0-terminate hardif name
  - netlink: check for BATADV_ATTR_MESH_ADDRESS before accessing it
  - netlink: detect receive errors in netlink_print_common
  - netlink: detect receive errors in netlink_simple_request
  - netlink: detect receive errors in query_rtnl_link
  - netlink: detect receive errors in query_rtnl_link_single
  - netlink: don't format NULL extra_info in info_callback
  - netlink: free header lines after error
  - netlink: report dump errors signalled in the NLMSG_DONE message
  - netlink: report error on query_rtnl_link send failure
  - netlink: report kernel errors when writing settings
  - netlink: report send errors in netlink_simple_request
  - originators: fix throughput lines with bat_hosts
  - ping/traceroute: don't restart RTT timer on stray replies
  - ping: count sent and not received pings
  - ping: fix rtt minimum tracking when a sample is 0.0
  - ping: keep huge '-i' intervals from turning into a flood ping
  - ping: reject invalid packet count argument
  - ping: reject invalid timeout argument
  - tcpdump: check frame length before reading the ethernet header
  - tcpdump: correct output of VLAN IDs
  - tcpdump: don't label unknown ICMPv6 types as unreachable
  - tcpdump: fix "subtybe" typo in 4ADDR output
  - tcpdump: fix coded packet mac dest mac addresses
  - tcpdump: fix endianness of fragmentation sequence number
  - tcpdump: fix reported length for ICMP6_TIME_EXCEEDED
  - tcpdump: fix source address selection for 802.11 data frames
  - tcpdump: handle TCP packet with bogus data offset
  - tcpdump: print the unreachable host for ICMP port unreachable
  - tcpdump: reject invalid packet type arguments
  - tcpdump: resolve bat-host name for ROAMv1 client
  - tcpdump: return EXIT_SUCCESS on normal termination
  - tcpdump: skip partial line for oversized ICMPv6 errors
  - tpmeter: abort result wait on receive errors
  - tpmeter: don't cancel test from the signal handler
  - tpmeter: fix Gbps output
  - tpmeter: label sub-kByte/s rate in bits per second
  - tpmeter: reject invalid test duration argument
  - traceroute: handle fast replies
  - traceroute: probe the advertised maximum number of hops
  - traceroute: return EXIT_NOSUCCESS when destination not reached
  - translate: don't overwrite the search key
  - version: avoid use of uninitialized read buffer


alfred
------

* bugs squashed:
  - seed the random() generator for transaction IDs


---

## 🧪 Run Testing Details

- **OpenWrt Version:** main (r35985-347ea96b26)
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** DEVICE_generic

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
  - **this requirement cannot be fulfilled. A patch to get it working against a problem with (only) the OpenWrt build system is nothing I will ever accept upstream**
