### PR TITLE
libjuice: fix SHA-1 on big-endian targets

### DIFF
--- a/libs/libjuice/Makefile
+++ b/libs/libjuice/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libjuice
 PKG_VERSION:=1.7.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/paullouisageneau/libjuice/tar.gz/v$(PKG_VERSION)?

--- a/libs/libjuice/patches/0001-picohash-guard-the-SHA-1-output-swap-with-the-macro-.patch
+++ b/libs/libjuice/patches/0001-picohash-guard-the-SHA-1-output-swap-with-the-macro-.patch
@@ -1,0 +1,42 @@
+From 44a0f4ae30ac0b62a8cc5aa9f3e2d54d40c31a75 Mon Sep 17 00:00:00 2001
+From: Daniel Golle <daniel@makrotopia.org>
+Date: Tue, 1 Sep 2026 00:25:27 +0100
+Subject: [PATCH] picohash: guard the SHA-1 output swap with the macro picohash
+ defines
+
+The final "swap byte order back" step in _picohash_sha1_final is guarded by
+SHA_BIG_ENDIAN, which nothing defines. picohash detects endianness into
+_PICOHASH_BIG_ENDIAN, and that is what the matching byte store in
+_picohash_sha1_add_uncounted tests. The name comes from liboauth's sha1.c,
+which this SHA-1 implementation is adopted from, and is present upstream in
+kazuho/picohash as well.
+
+On a big-endian target the swap runs when it must not, so every SHA-1 digest
+is emitted with each 32-bit word reversed, and HMAC-SHA1 with it. STUN
+MESSAGE-INTEGRITY therefore never verifies: every ICE connectivity check is
+rejected, no candidate pair is nominated, and no session can be established.
+picohash is the default backend, so this affects any big-endian build that
+does not set USE_NETTLE.
+
+Verified on mips_24kc, a big-endian MIPS 34Kc running OpenWrt with musl.
+Before the change, ICE loops with "STUN integrity check failed" and the agent
+never leaves the connecting state. After it, the agent reaches completed and
+the session comes up. RFC 2202 HMAC-SHA1 test case 1 and the SHA-1 vector for
+"abc" both fail before and pass after.
+
+Signed-off-by: Daniel Golle <daniel@makrotopia.org>
+---
+ src/picohash.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/src/picohash.h
++++ b/src/picohash.h
+@@ -452,7 +452,7 @@ inline void _picohash_sha1_final(_picoha
+     _picohash_sha1_add_uncounted(s, (uint8_t)(s->byteCount >> 5));
+     _picohash_sha1_add_uncounted(s, (uint8_t)(s->byteCount << 3));
+ 
+-#ifndef SHA_BIG_ENDIAN
++#ifndef _PICOHASH_BIG_ENDIAN
+     { // Swap byte order back
+         int i;
+         for (i = 0; i < 5; i++) {


### PR DESCRIPTION
### Maintainer

Myself, `PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>`.

### Description

libjuice's vendored `src/picohash.h` guards the final byte-order swap in `_picohash_sha1_final` with `SHA_BIG_ENDIAN`, a macro nothing defines, while endianness is detected into `_PICOHASH_BIG_ENDIAN`. On big-endian targets the swap runs when it must not, so every SHA-1 digest is emitted with each 32-bit word reversed:

```
sha1("abc") = 363e99a96a81064771253eba6cc250789dd8d09c
   expected   a9993e364706816aba3e25717850c26c9cd0d89d
```

HMAC-SHA1 goes with it, and libjuice uses HMAC-SHA1 for STUN MESSAGE-INTEGRITY. The visible effect on mips, mips64, powerpc and every other big-endian target is that each ICE connectivity check is rejected:

```
ice: STUN integrity check failed, password="a118ff3aec677687897d7d987395a636"
ice: STUN message verification failed
```

No candidate pair is ever nominated, so no peer-to-peer session can be established at all. `USE_NETTLE` is off, so picohash is the backend this package builds against and every big-endian build of it is affected.

`PKG_RELEASE` is bumped, as the resulting binary changes.

### Run tested

Built for lantiq/xrx200 (`mips_24kc`, gcc 14.4.0, musl) and run on real hardware, an o2 Box 6431 with a MIPS 34Kc.

| | before | after |
|---|---|---|
| `sha1("abc")` | `363e99a9...` | `a9993e36...` (correct) |
| RFC 2202 HMAC-SHA1 case 1 | mismatch | correct |
| juice agent state | loops in `connecting` | `connected`, then `completed` |
| STUN integrity failures | hundreds | 0 |

Exercised with comrade, which uses libjuice for ICE: sessions were established in both directions between the xrx200 board and an x86-64 peer, with rendezvous over the BitTorrent mainline DHT and SSH running over the media path. Before the patch neither direction could connect.

Little-endian targets are unaffected: `_PICOHASH_BIG_ENDIAN` is undefined there and the swap still runs, so digests are unchanged.

### Upstream

- libjuice: paullouisageneau/libjuice#353
- picohash, where the vendored copy comes from and where the same line is
  present: kazuho/picohash#13

The upstream libjuice submission carries a second commit for a defect that does not affect OpenWrt builds: the fallback endianness branch in the same header tests `BYTE_ORDER`, which glibc leaves undefined under `-std=c99` or `-std=c11`, so a strict-C build selects big-endian on a little-endian host. OpenWrt does not pass `-std=`, so `_DEFAULT_SOURCE` is in effect and that branch is not reached. It is therefore left out of this patch, which carries only what this package needs.

### Formalities

- [x] tested on real hardware, lantiq/xrx200
- [x] `PKG_RELEASE` bumped
- [x] patch is a `git format-patch` export of the commit submitted upstream
- [x] `Signed-off-by` present, real name and address