### PR TITLE
curl: add optional krb5 support

### DIFF
--- a/net/curl/Config.in
+++ b/net/curl/Config.in
@@ -128,6 +128,10 @@ config LIBCURL_TLS_SRP
 	bool "Enable TLS-SRP authentication"
 	default n
 
+config LIBCURL_KERBEROS_AUTH
+	bool "Enable Kerberos authentication"
+	default n
+
 config LIBCURL_LIBIDN2
 	bool "Enable IDN2 support"
 	default n

--- a/net/curl/Makefile
+++ b/net/curl/Makefile
@@ -10,7 +10,7 @@ include $(INCLUDE_DIR)/nls.mk
 
 PKG_NAME:=curl
 PKG_VERSION:=8.21.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/curl/curl/releases/download/curl-$(subst .,_,$(PKG_VERSION))/ \
@@ -62,6 +62,7 @@ PKG_CONFIG_DEPENDS:= \
   CONFIG_LIBCURL_COOKIES \
   CONFIG_LIBCURL_CRYPTO_AUTH \
   CONFIG_LIBCURL_HTTP_AUTH \
+  CONFIG_LIBCURL_KERBEROS_AUTH \
   CONFIG_LIBCURL_LIBCURL_OPTION \
   CONFIG_LIBCURL_PROXY \
   CONFIG_LIBCURL_THREADED_RESOLVER \
@@ -97,6 +98,7 @@ define Package/libcurl
   DEPENDS:= +LIBCURL_WOLFSSL:libwolfssl +LIBCURL_OPENSSL:libopenssl +LIBCURL_GNUTLS:libgnutls +LIBCURL_MBEDTLS:libmbedtls
   DEPENDS += +LIBCURL_ZLIB:zlib +LIBCURL_ZSTD:libzstd +LIBCURL_THREADED_RESOLVER:libpthread +LIBCURL_LDAP:libopenldap
   DEPENDS += +LIBCURL_LIBIDN2:libidn2 +LIBCURL_SSH2:libssh2 +LIBCURL_HTTP2:libnghttp2 +LIBCURL_HTTP3:libnghttp3 +LIBCURL_HTTP3:libngtcp2 +ca-bundle
+  DEPENDS += +LIBCURL_KERBEROS_AUTH:krb5-libs
   TITLE:=A client-side URL transfer library
   MENU:=1
   ABI_VERSION:=4
@@ -139,6 +141,7 @@ CONFIGURE_ARGS += \
 	$(if $(CONFIG_LIBCURL_ZSTD),--with-zstd="$(STAGING_DIR)/usr",--without-zstd) \
 	$(if $(CONFIG_LIBCURL_HTTP2),--with-nghttp2="$(STAGING_DIR)/usr",--without-nghttp2) \
 	$(if $(CONFIG_LIBCURL_HTTP3),--with-nghttp3="$(STAGING_DIR)/usr" --with-ngtcp2="$(STAGING_DIR)/usr",--without-nghttp3 --without-ngtcp2) \
+	$(if $(CONFIG_LIBCURL_KERBEROS_AUTH),--with-gssapi="$(STAGING_DIR)/usr",--without-gssapi) \
 	\
 	$(call autoconf_bool,CONFIG_LIBCURL_DICT,dict) \
 	$(call autoconf_bool,CONFIG_LIBCURL_FILE,file) \


### PR DESCRIPTION


## 📦 Package Details

**Maintainer:** @hnyman @BKPepe ?


**Description:**

Enable Kerberos authentication support in curl by including krb5-libs. This allows curl to handle GSSAPI/Kerberos authentication protocols, enhancing compatibility with enterprise environments.

The feature is disabled by default to avoid unnecessary dependencies.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** master
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** Banana PI

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
