### PR TITLE
mstflint: update to 4.37.0-1

### DIFF
--- a/utils/mstflint/Makefile
+++ b/utils/mstflint/Makefile
@@ -8,14 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mstflint
-PKG_VERSION:=4.36.0
+PKG_VERSION:=4.37.0
 PKG_SUBVERSION:=1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SUBVERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/Mellanox/$(PKG_NAME)/releases/download/v$(PKG_VERSION)-$(PKG_SUBVERSION)
-PKG_SOURCE_DATE:=2026-05-14
-PKG_HASH:=55f334ddefce39fe93b320786374c7c9868966b191b257327fe2c9b3b41ece26
+PKG_SOURCE_DATE:=2026-09-01
+PKG_HASH:=89299633cc78c17032547aa78b9df1d9bf08c5bd6279cde7750bd4d4367afb81
 
 PKG_MAINTAINER:=Til Kaiser <mail@tk154.de>
 PKG_LICENSE:=GPL-2.0-only
@@ -113,6 +113,7 @@ define Package/mstflint/install
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/mstconfig $(1)/usr/bin/
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/mstcongestion $(1)/usr/bin/
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/mstdevices_info $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/mstefuse $(1)/usr/bin/
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/mstflint $(1)/usr/bin/
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/mstfwctrl $(1)/usr/bin/
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/mstfwmanager $(1)/usr/bin/


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @tk154 

**Description:**
Update the `mstflint` package to the latest 4.37.0-1 release.
Also add the newly introduced `mstefuse` binary, which prints fuse voltage readings, to the package installation.

Release notes: https://github.com/Mellanox/mstflint/releases/tag/v4.37.0-1

---

## 🧪 Run Testing Details

- **OpenWrt Version:** Snapshot
- **OpenWrt Target/Subtarget:** `x86/64`
- **OpenWrt Device:** Mellanox Spectrum, Gowin BS-1UR2-25G

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.