### PR TITLE
net-snmp: do not override sysName with a static default

### DIFF
--- a/net/net-snmp/Makefile
+++ b/net/net-snmp/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=net-snmp
 PKG_VERSION:=5.9.5.2
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/net-snmp

--- a/net/net-snmp/files/snmpd.conf
+++ b/net/net-snmp/files/snmpd.conf
@@ -82,7 +82,7 @@ config access private_access
 config system
 	option sysLocation	'office'
 	option sysContact	'bofh@example.com'
-	option sysName		'HeartOfGold'
+#	option sysName		'HeartOfGold'
 #	option sysServices	72
 #	option sysDescr		'adult playground'
 #	option sysObjectID	'1.2.3.4'


### PR DESCRIPTION
## Problem

The default UCI config (`net/net-snmp/files/snmpd.conf`) ships:

```
config system
	option sysLocation	'office'
	option sysContact	'bofh@example.com'
	option sysName		'HeartOfGold'
```

net-snmp only falls back to the system hostname for `SNMPv2-MIB::sysName.0` (`1.3.6.1.2.1.1.5.0`) when **no** `sysName` is configured. Because the packaged default hardcodes `sysName 'HeartOfGold'`, the agent permanently reports `HeartOfGold` instead of the device's real hostname — for every SNMP version (v1/v2c/v3), since `sysName` lives in the agent's system group and is independent of the security model.

This makes the common "obtain the hostname via SNMP" use case fail out of the box, and diverges from net-snmp's own example config, which deliberately omits `sysName` so it auto-derives from the hostname.

## Change

Comment out the `sysName` option so the agent reports the actual hostname by default. This matches the style of the already-commented optional `sysServices`/`sysDescr`/`sysObjectID` lines right below it. Users who want a static `sysName` can simply uncomment and edit it.

`PKG_RELEASE` is bumped (2 → 3) since the conffile content changed.

## Testing

On a running device, removing the static `sysName` and restarting snmpd makes `sysName.0` return the real hostname:

```
# before
SNMPv2-MIB::sysName.0 = STRING: HeartOfGold
# after (uci delete snmpd.@system[0].sysName; /etc/init.d/snmpd restart)
SNMPv2-MIB::sysName.0 = STRING: <actual-hostname>
```

Verified via SNMPv3 (authPriv) and SNMPv2c.