### PR TITLE
zabbix: remove unneeded postinsts

### DIFF
--- a/admin/zabbix/Makefile
+++ b/admin/zabbix/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zabbix
 PKG_VERSION:=7.0.30
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://cdn.zabbix.com/zabbix/sources/stable/$(basename $(PKG_VERSION))/ \
@@ -498,12 +498,6 @@ define Package/zabbix-agentd/conffiles
 /etc/config/zabbix_agentd
 endef
 
-define Package/zabbix-agentd/postinst
-#!/bin/sh
-[ -n "$${IPKG_INSTROOT}" ] || (. /etc/uci-defaults/90_zabbix_agentd) && rm -f /etc/uci-defaults/90_zabbix_agentd
-exit 0
-endef
-
 define Package/zabbix-agentd/install
 	$(INSTALL_DIR) $(1)/etc/zabbix_agentd.conf.d
 	$(INSTALL_DIR) $(1)/usr/share/zabbix_agentd.openwrt-params.d
@@ -517,7 +511,6 @@ define Package/zabbix-agentd/install
 endef
 
 Package/zabbix-agentd-basic/conffiles=$(call Package/zabbix-agentd/conffiles)
-Package/zabbix-agentd-basic/postinst=$(call Package/zabbix-agentd/postinst)
 
 define Package/zabbix-agentd-basic/install
 	$(call Package/zabbix-agentd/install,$(1))
@@ -527,12 +520,6 @@ define Package/zabbix-proxy/conffiles
 /etc/zabbix_proxy.conf
 /etc/zabbix_proxy.conf.d/
 /etc/config/zabbix_proxy
-endef
-
-define Package/zabbix-proxy/postinst
-#!/bin/sh
-[ -n "$${IPKG_INSTROOT}" ] || (. /etc/uci-defaults/90_zabbix_proxy) && rm -f /etc/uci-defaults/90_zabbix_proxy
-exit 0
 endef
 
 define Package/zabbix-proxy/install
@@ -547,7 +534,6 @@ define Package/zabbix-proxy/install
 endef
 
 Package/zabbix-proxy-basic-sqlite/conffiles=$(call Package/zabbix-proxy/conffiles)
-Package/zabbix-proxy-basic-sqlite/postinst=$(call Package/zabbix-proxy/postinst)
 
 define Package/zabbix-proxy-basic-sqlite/install
 	$(call Package/zabbix-proxy/install,$(1))
@@ -568,12 +554,6 @@ define Package/zabbix-server/install
 	$(INSTALL_CONF) ./files/zabbix_server.config $(1)/etc/config/zabbix_server
 	$(INSTALL_DIR) $(1)/etc/uci-defaults
 	$(INSTALL_BIN) ./files/zabbix_server.defaults $(1)/etc/uci-defaults/90_zabbix_server
-endef
-
-define Package/zabbix-server/postinst
-#!/bin/sh
-[ -n "$${IPKG_INSTROOT}" ] || (. /etc/uci-defaults/90_zabbix_server) && rm -f /etc/uci-defaults/90_zabbix_server
-exit 0
 endef
 
 define Package/zabbix-get/install


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @danielfdickinson 

**Description:**
Handling uci-defaults scripts in postinst is not needed in modern OpenWrt and in fact results in error messages on install since the common postinst processes and deletes uci-defaults scripts before package-specific postinsts are executed.

Therefore remove the unneeded postinsts in this package.

In response to: https://forum.openwrt.org/t/zabbix-agentd-fails-to-properly-install-with-newest-version/253198

---

## 🧪 Run Testing Details

- **OpenWrt Version:** OpenWrt SNAPSHOT r35960-1ad2e78e6a
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** OpenWrt One

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
