### PR TITLE
led-nightmode: add LED night mode runtime

### DIFF
--- a/utils/led-nightmode/Makefile
+++ b/utils/led-nightmode/Makefile
@@ -1,0 +1,61 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=led-nightmode
+PKG_VERSION:=0.5.1
+PKG_RELEASE:=1
+
+PKG_MAINTAINER:=Mv Go <rapture-ribose6k@icloud.com>
+PKG_LICENSE:=Apache-2.0
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_SOURCE:=luci-app-led-nightmode-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://github.com/mv-go/luci-app-led-nightmode/archive/refs/tags/v$(PKG_VERSION).tar.gz?
+PKG_HASH:=7e7af0c3e6970f47f1af975863ede0339f359a3fafce7d6cdc637e168305c4cc
+PKG_BUILD_DIR:=$(BUILD_DIR)/luci-app-led-nightmode-$(PKG_VERSION)
+
+include $(INCLUDE_DIR)/package.mk
+
+define Build/Compile
+endef
+
+define Package/led-nightmode
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=LED night mode runtime for OpenWrt
+  DEPENDS:=+jshn +procd +rpcd +sunwait +uci
+  PKGARCH:=all
+  URL:=https://github.com/mv-go/luci-app-led-nightmode
+endef
+
+define Package/led-nightmode/description
+  Discovers Linux LED class devices at runtime, preserves their original
+  triggers and brightness, and applies reversible day and night profiles.
+endef
+
+define Package/led-nightmode/conffiles
+/etc/config/led-nightmode
+endef
+
+define Package/led-nightmode/install
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_CONF) $(PKG_BUILD_DIR)/core/root/etc/config/led-nightmode $(1)/etc/config/led-nightmode
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/core/root/etc/init.d/led-nightmode $(1)/etc/init.d/led-nightmode
+	$(INSTALL_DIR) $(1)/etc/uci-defaults
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/core/root/etc/uci-defaults/99-led-nightmode $(1)/etc/uci-defaults/99-led-nightmode
+	$(INSTALL_DIR) $(1)/usr/libexec/rpcd
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/core/root/usr/libexec/led-nightmode-provider-service $(1)/usr/libexec/led-nightmode-provider-service
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/core/root/usr/libexec/led-nightmode-service $(1)/usr/libexec/led-nightmode-service
+	$(LN) led-nightmode-service $(1)/usr/libexec/led-nightmode-schedule
+	$(LN) ../led-nightmode-service $(1)/usr/libexec/rpcd/luci.led-nightmode
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/core/root/usr/sbin/led-nightmode $(1)/usr/sbin/led-nightmode
+endef
+
+define Package/led-nightmode/postinst
+#!/bin/sh
+[ -n "$${IPKG_INSTROOT}" ] || /etc/init.d/rpcd reload 2>/dev/null
+exit 0
+endef
+
+$(eval $(call BuildPackage,led-nightmode))

--- a/utils/led-nightmode/test-version.sh
+++ b/utils/led-nightmode/test-version.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# shellcheck shell=busybox
+
+# The shell runtime does not embed its release number, so the generic CI probe
+# cannot discover PKG_VERSION through --version or --help. Restrict this
+# override to the expected package. The generic executable check still verifies
+# that the installed CLI exists and is executable.
+
+case "$1" in
+led-nightmode)
+	exit 0
+	;;
+*)
+	echo "Untested package: $1" >&2
+	exit 1
+	;;
+esac


### PR DESCRIPTION
## Package Details

**Maintainer:** @mv-go

**Description:**

Add the headless `led-nightmode` runtime for reversible OpenWrt LED night profiles. It discovers Linux LED class devices at runtime, preserves their original triggers and brightness, and restores them after the night profile ends. The package also owns the UCI, procd, rpcd, scheduling, and generic provider boundaries used by the separately submitted LuCI application.

Companion UI Draft PR: openwrt/luci#8998.

The source is signed release `v0.5.1` (`0.5.1-r1`) with archive SHA-256 `7e7af0c3e6970f47f1af975863ede0339f359a3fafce7d6cdc637e168305c4cc`.

The hardware-specific Quectel provider is intentionally not included.

---

## Run Testing Details

- **OpenWrt Version:** 25.12.4 and current snapshot SDK
- **OpenWrt Target/Subtarget:** `mediatek/filogic`; package output verified as `noarch` on `aarch64_cortex-a53`
- **OpenWrt Device:** Banana Pi BPI-R3 Mini for the unchanged runtime through monolithic `0.5.0-r8`; the `0.5.1-r1` package split was upgrade-tested offline with `apk-tools` 3

Validation completed:

- fixture-backed CLI, init, service, schedule, rpcd, UCI migration, and provider lifecycle tests;
- official OpenWrt 25.12.4 SDK build;
- isolated transaction from monolithic `0.5.0-r8` preserving modified UCI, installing the new default as `.apk-new`, and verifying file ownership, symlinks, and installed bytes;
- combined current-snapshot SDK build with the dependent UI-only LuCI package;
- forced-Night reboot and physical power-cycle validation on the first device remain evidence for the unchanged runtime in published `0.5.0-r8`; no new live-router claim is made for the package split.

---

## Formalities

- [x] I have reviewed the `CONTRIBUTING.md` file for detailed contributing guidelines.
- [x] The commit is SSH-signed and has a matching `Signed-off-by: Mv Go <rapture-ribose6k@icloud.com>`.
- [x] No patches are included.