### PR TITLE
csshnpd: bump to c1.1.0 release

### DIFF
--- a/net/csshnpd/Makefile
+++ b/net/csshnpd/Makefile
@@ -4,12 +4,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=csshnpd
-PKG_VERSION:=1.0.20
+PKG_VERSION:=1.1.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-c$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/atsign-foundation/noports/releases/download/c$(PKG_VERSION)
-PKG_HASH:=ffbadc9d0b5b381b2d7c20a607497be3b1994617c88fa3665225e951c6ce9a26
+PKG_HASH:=dc90a7d19562d4e4d3a8dc49911a9b2649484214923f71170aed42fe6a7d47ec
 
 PKG_MAINTAINER:=Chris Swan <chris@atsign.com>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @cpswan 

**Description:**
Added policy support
Added proxy support for root domain and at_activate Added ESCR relay authentication
Adjustable session timeout
Twinned session keys
Security hardening

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT, r35751
- **OpenWrt Target/Subtarget:** x86_64
- **OpenWrt Device:** x86_64 VM

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.