### PR TITLE
msmtp: update to 1.8.34

### DIFF
--- a/mail/msmtp/Makefile
+++ b/mail/msmtp/Makefile
@@ -9,12 +9,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=msmtp
-PKG_VERSION:=1.8.32
+PKG_VERSION:=1.8.34
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://marlam.de/msmtp/releases
-PKG_HASH:=20cd58b58dd007acf7b937fa1a1e21f3afb3e9ef5bbcfb8b4f5650deadc64db4
+PKG_HASH:=84e8fe2a5a80a1ee7802013b3fbdb846a3f27a4163cf37a1c6d7c7f888873ead
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=GPL-3.0-or-later


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @commodo
**Description:** Release note: https://marlam.de/msmtp/news/msmtp-1-8-34/

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT, r35836-20d94d5a2b
- **OpenWrt Target/Subtarget:** Filogic 8x0 (MT798x)
- **OpenWrt Device:** Bananapi BPi-R4

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.