### PR TITLE
golang: add support for host-only version series

### DIFF
--- a/lang/golang/golang-version.mk
+++ b/lang/golang/golang-version.mk
@@ -33,6 +33,7 @@ define Package/$(PKG_NAME)/Default
   TITLE:=Go programming language
   URL:=https://go.dev/
   DEPENDS:=$(GO_ARCH_DEPENDS)
+  $(if $(PKG_HOST_ONLY),BUILDONLY:=1)
 endef
 
 define Package/$(PKG_NAME)/Default/description


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me

**Description:**

Support configuring major version series as host-only (i.e. no target packages) to reduce strain on buildbots in release branches. The goal is to have one major target series and multiple host-only ones. E.g. 25.12 uses 1.26 as the default host/target series and 1.27 and beyond as host-only for packages that require these.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT, 25.12.5
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** QEMU

Tested building and running Syncthing.

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.