### PR TITLE
podman, netavark: nftables firewall on OpenWrt

### DIFF
--- a/net/netavark/Makefile
+++ b/net/netavark/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netavark
 PKG_VERSION:=1.17.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/containers/netavark/tar.gz/v$(PKG_VERSION)?
@@ -23,7 +23,7 @@ include ../../lang/rust/rust-package.mk
 define Package/netavark
   SECTION:=net
   CATEGORY:=Network
-  DEPENDS:=$(RUST_ARCH_DEPENDS)
+  DEPENDS:=$(RUST_ARCH_DEPENDS) +nftables-json +kmod-nft-nat
   TITLE:=A container network stack
   URL:=https://github.com/containers/netavark
 endef
@@ -34,7 +34,8 @@ define Package/netavark/description
 endef
 
 CARGO_PKG_VARS += \
-	PROTOC=$(STAGING_DIR_HOSTPKG)/bin/protoc
+	PROTOC=$(STAGING_DIR_HOSTPKG)/bin/protoc \
+	NETAVARK_DEFAULT_FW=nftables
 
 define Package/netavark/install
 	$(INSTALL_DIR) $(1)/etc/config $(1)/usr/lib/podman

--- a/utils/podman/Makefile
+++ b/utils/podman/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=podman
 PKG_VERSION:=5.8.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/podman-container-tools/podman/archive/v$(PKG_VERSION)

--- a/utils/podman/Makefile
+++ b/utils/podman/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=podman
 PKG_VERSION:=5.8.4
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/podman-container-tools/podman/archive/v$(PKG_VERSION)
@@ -108,6 +108,8 @@ define Package/podman/install
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/vendor/go.podman.io/common/pkg/seccomp/seccomp.json $(1)/usr/share/containers/
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/podman.init $(1)/etc/init.d/podman
+	$(INSTALL_DIR) $(1)/etc/uci-defaults
+	$(INSTALL_BIN) ./files/podman.defaults $(1)/etc/uci-defaults/90-podman
 	$(SED) 's/driver = \"\"/driver = \"overlay\"/g' $(1)/etc/containers/storage.conf
 endef
 

--- a/utils/podman/files/containers.conf
+++ b/utils/podman/files/containers.conf
@@ -74,7 +74,7 @@ network_backend = "netavark"
 #  "/usr/local/lib/netavark",
 #  "/usr/lib/netavark",
 #]
-#firewall_driver = "none"
+firewall_driver = "nftables"
 network_config_dir = "/etc/containers/networks/"
 default_network = "podman"
 #default_subnet = "10.88.0.0/16"

--- a/utils/podman/files/podman.defaults
+++ b/utils/podman/files/podman.defaults
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+changed=0
+
+if uci -q get dhcp.@dnsmasq[0] >/dev/null; then
+	case " $(uci -q get dhcp.@dnsmasq[0].notinterface) " in
+	*" podman* "*) ;;
+	*)
+		uci add_list dhcp.@dnsmasq[0].notinterface='podman*'
+		uci commit dhcp
+		changed=1
+		;;
+	esac
+fi
+
+if ! uci -q get firewall.podman >/dev/null; then
+	uci -q batch <<-UCI
+		set firewall.podman=zone
+		set firewall.podman.name='podman'
+		add_list firewall.podman.device='podman+'
+		set firewall.podman.input='REJECT'
+		set firewall.podman.output='ACCEPT'
+		set firewall.podman.forward='REJECT'
+		set firewall.podman_wan=forwarding
+		set firewall.podman_wan.src='podman'
+		set firewall.podman_wan.dest='wan'
+		set firewall.podman_dns=rule
+		set firewall.podman_dns.name='Allow-DNS-podman'
+		set firewall.podman_dns.src='podman'
+		set firewall.podman_dns.proto='tcp udp'
+		set firewall.podman_dns.dest_port='53'
+		set firewall.podman_dns.target='ACCEPT'
+		commit firewall
+	UCI
+	changed=1
+fi
+
+[ "$changed" = 1 ] && reload_config
+
+exit 0


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @oskarirauta

**Description:**
OpenWrt is nftables-only, so netavark's iptables default fails for every runtime (podman, runc, crun alike). Build netavark with the nftables driver, select it in podman's `containers.conf`, and add a uci-defaults script that frees the podman0 gateway `:53` for aardvark-dns and forwards the podman subnet to `wan` via fw4.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** snapshot
- **OpenWrt Target/Subtarget:** x86/64
- **OpenWrt Device:** qemu

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
