### PR TITLE
udp-proxy-2020: add package

### DIFF
--- a/net/udp-proxy-2020/Makefile
+++ b/net/udp-proxy-2020/Makefile
@@ -1,0 +1,58 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=udp-proxy-2020
+PKG_VERSION:=0.1.4
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/synfinatic/udp-proxy-2020/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=d0beb56b478e280a719fe59ee5bdc0f88a8b92c240cc0510661e599bd0250c3b
+
+PKG_MAINTAINER:=Bruno HiFi <router.openwrt24@gmail.com>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_DEPENDS:=golang/host
+PKG_BUILD_PARALLEL:=1
+PKG_BUILD_FLAGS:=no-mips16
+
+GO_PKG:=github.com/synfinatic/udp-proxy-2020
+GO_PKG_BUILD_PKG:=github.com/synfinatic/udp-proxy-2020/cmd/udp-proxy-2020
+GO_PKG_LDFLAGS_X:=main.Version=$(PKG_VERSION)
+
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/golang/golang-package.mk
+
+define Package/udp-proxy-2020
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=UDP broadcast proxy for routed networks
+  URL:=https://github.com/synfinatic/udp-proxy-2020
+  DEPENDS:=$(GO_ARCH_DEPENDS) +libpcap
+endef
+
+define Package/udp-proxy-2020/description
+  udp-proxy-2020 forwards UDP broadcast traffic between configured
+  network interfaces. It can be used to relay discovery traffic across
+  routed networks or VPNs, including Roon discovery traffic between
+  a LAN and WireGuard interface.
+endef
+
+define Package/udp-proxy-2020/conffiles
+/etc/config/udp-proxy-2020
+endef
+
+define Package/udp-proxy-2020/install
+	$(call GoPackage/Package/Install/Bin,$(1))
+
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/udp-proxy-2020.init \
+		$(1)/etc/init.d/udp-proxy-2020
+
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_CONF) ./files/udp-proxy-2020.config \
+		$(1)/etc/config/udp-proxy-2020
+endef
+
+$(eval $(call GoBinPackage,udp-proxy-2020))
+$(eval $(call BuildPackage,udp-proxy-2020))

--- a/net/udp-proxy-2020/files/udp-proxy-2020.config
+++ b/net/udp-proxy-2020/files/udp-proxy-2020.config
@@ -1,0 +1,5 @@
+config udp_proxy 'main'
+	option enabled '0'
+	option interfaces 'br-lan,wg0'
+	option port '9003'
+	option log_level 'info'

--- a/net/udp-proxy-2020/files/udp-proxy-2020.init
+++ b/net/udp-proxy-2020/files/udp-proxy-2020.init
@@ -1,0 +1,41 @@
+#!/bin/sh /etc/rc.common
+
+START=95
+STOP=10
+
+USE_PROCD=1
+
+PROG=/usr/bin/udp-proxy-2020
+
+start_service() {
+	local enabled
+	local interfaces
+	local port
+	local log_level
+
+	config_load udp-proxy-2020
+
+	config_get_bool enabled main enabled 0
+	[ "$enabled" -eq 1 ] || return 0
+
+	config_get interfaces main interfaces "br-lan,wg0"
+	config_get port main port "9003"
+	config_get log_level main log_level "info"
+
+	procd_open_instance
+
+	procd_set_param command "$PROG" \
+		-i "$interfaces" \
+		-p "$port" \
+		-L "$log_level"
+
+	procd_set_param respawn
+	procd_set_param stdout 1
+	procd_set_param stderr 1
+
+	procd_close_instance
+}
+
+service_triggers() {
+	procd_add_reload_trigger "udp-proxy-2020"
+}


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @Bruno-HiFi

**Description:**

Add `udp-proxy-2020`, a UDP proxy/relay utility used to forward UDP traffic
between network interfaces.

It can be used, for example, to relay Roon discovery traffic on UDP port
`9003` between a LAN and a WireGuard interface.

Upstream project:
https://github.com/synfinatic/udp-proxy-2020

Packaged version:
`0.1.4`

The package includes:

- the `udp-proxy-2020` binary
- an OpenWrt `procd` init script
- a UCI configuration file
- `libpcap` runtime dependency
- persistent configuration via `/etc/config/udp-proxy-2020`

The service is disabled by default and can be enabled through the supplied
UCI configuration.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** `25.12-SNAPSHOT`
- **OpenWrt Revision:** `r33191-b6a820ea85`
- **OpenWrt Target/Subtarget:** `mediatek/filogic`
- **OpenWrt Device:** `Zyxel EX5601-T0`
- **Architecture:** `aarch64_cortex-a53`

The package was built from source using the OpenWrt SDK and installed on the
target device.

The generated package:

`udp-proxy-2020-0.1.4-r1.apk`

The resulting binary was verified to link against `libpcap` and was tested successfully under `procd`.

Runtime configuration used for testing:

```text
interfaces: br-lan,wg0
port: 9003
log level: info