### PR TITLE
snort3: fix --daq overriding daq.modules variables, move fanout_type to afpacket

### DIFF
--- a/net/snort3/Makefile
+++ b/net/snort3/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=snort3
 PKG_VERSION:=3.12.2.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/snort3/snort3/tar.gz/$(PKG_VERSION)?
@@ -103,6 +103,9 @@ define Package/snort3/install
 
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/snort.init $(1)/etc/init.d/snort
+
+	$(INSTALL_DIR) $(1)/etc/uci-defaults
+	$(INSTALL_BIN) ./files/snort.defaults $(1)/etc/uci-defaults/50-snort-afpacket-section
 
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_CONF) ./files/snort.config $(1)/etc/config/snort

--- a/net/snort3/files/main.uc
+++ b/net/snort3/files/main.uc
@@ -15,16 +15,21 @@ TYPE;
 import { cursor } from 'uci';
 let uci = cursor();
 
-function wrn(fmt, ...args) {
+// Non-fatal sibling of wrn(): same QUIET/TTY handling, no exit().
+function inf(fmt, ...args) {
 	if (QUIET)
-		exit(1);
+		return;
 
-	let msg = "ERROR: " + sprintf(fmt, ...args);
+	let msg = sprintf(fmt, ...args);
 
 	if (getenv("TTY"))
 		warn(`\033[33m${msg}\033[m\n`);
 	else
 		warn(`[!] ${msg}\n`);
+}
+
+function wrn(fmt, ...args) {
+	inf("ERROR: " + fmt, ...args);
 	exit(1);
 }
 
@@ -119,11 +124,14 @@ const nfq_config = {
 	queue_count:     config_item("range", [ 1, 16 ], 4),           // Count of queues to allocate in nft chain when method=nfq, usually 2-8.
 	queue_start:     config_item("range", [ 1, 32768], 4),         // Start of queue numbers in nftables.
 	queue_maxlen:    config_item("range", [ 1024, 65536 ], 1024),  // --daq-var queue_maxlen=int
-	fanout_type:     config_item("enum",  [ "hash", "lb", "cpu", "rollover", "rnd", "qm"], "hash"), // See below.
 	thread_count:    config_item("range", [ 0, 32 ], 0),           // 0 = use cpu count
 	chain_type:      config_item("enum",  [ "prerouting", "input", "forward", "output", "postrouting" ], "input"),
 	chain_priority:  config_item("enum",  [ "raw", "filter", "300"], "filter"),
 	include:         config_item("path",  [ "" ]),                 // User-defined rules to include inside queue chain.
+};
+
+const afpacket_config = {
+	fanout_type:     config_item("enum",  [ "hash", "lb", "cpu", "rollover", "rnd", "qm"], ""), // See below.  Empty = kernel PACKET_FANOUT stays off.
 };
 
 
@@ -165,18 +173,18 @@ snort
 nfq - https://github.com/snort3/libdaq/blob/master/modules/nfq/README.nfq.md
     queue_maxlen    - nfq's '--daq-var queue_maxlen=int'
     queue_count     - Count of queues to use when method=nfq, usually 2-8
-    fanout_type     - Sets kernel load balancing algorithm*, one of hash, lb, cpu,
-                      rollover, rnd, qm.
     thread_count    - int snort.-z: <count> maximum number of packet threads
                       (same as --max-packet-threads); 0 gets the number of
                       CPU cores reported by the system; default is 1 { 0:max32 }
     chain_type      - Chain type when generating nft output
     chain_priority  - Chain priority when generating nft output
     include         - Full path to user-defined extra rules to include inside queue chain
+    fanout_type     - Deprecated, moved to the 'afpacket' section below.
 
-    * - for details on fanout_type, see these pages:
-        https://github.com/florincoras/daq/blob/master/README
-        https://www.kernel.org/doc/Documentation/networking/packet_mmap.txt
+afpacket - https://github.com/snort3/libdaq/blob/master/modules/afpacket/README.afpacket.md
+    fanout_type     - Sets kernel load balancing algorithm, one of hash, lb, cpu,
+                      rollover, rnd, qm.  Only applies when method=afpacket.
+                      Empty (default) leaves kernel PACKET_FANOUT off.
 ";
 
 function snort_config_doc(comment) {
@@ -221,11 +229,43 @@ function load(section, config) {
 	return self;
 }
 
-let snort = null;
-let nfq   = null;
+let snort    = null;
+let nfq      = null;
+let afpacket = null;
+
+// snort.nfq.fanout_type moved to snort.afpacket.fanout_type, since it is an
+// afpacket DAQ variable, not an nfq one (the nfq DAQ module ignores it).
+// 'hash' was the old option's stock default for years while it was inert for
+// every method, so treat it the same as unset instead of forcing every
+// upgraded install onto fanout_type=hash (which also flips on kernel
+// PACKET_FANOUT for afpacket users who never asked for it). A genuinely
+// customized old value is still read for backward compatibility; it only
+// becomes effective with method=afpacket, so the advice depends on method.
+function coalesce_fanout_type() {
+	let legacy = uci.get("snort", "nfq", "fanout_type");
+	let modern = uci.get("snort", "afpacket", "fanout_type");
+
+	if (legacy == "hash")
+		legacy = null;
+
+	if (legacy && modern != null)
+		inf("snort.nfq.fanout_type is ignored because snort.afpacket.fanout_type is set; remove snort.nfq.fanout_type to silence this warning.");
+	else if (legacy) {
+		if (! afpacket_config.fanout_type.contains(legacy))
+			wrn(`In option snort.nfq.fanout_type='${legacy}', must be ${afpacket_config.fanout_type.allowed()}`);
+		if (snort.method == "afpacket")
+			inf("snort.nfq.fanout_type is deprecated: set snort.afpacket.fanout_type to keep this value, or remove snort.nfq.fanout_type to disable fanout.");
+		else
+			inf(`snort.nfq.fanout_type is deprecated and has no effect with method=${snort.method}: remove it, or move it to snort.afpacket.fanout_type if you plan to use method=afpacket.`);
+		afpacket.fanout_type = legacy;
+	}
+}
+
 function load_all() {
-	snort = load("snort", snort_config);
-	nfq   = load("nfq", nfq_config);
+	snort    = load("snort", snort_config);
+	nfq      = load("nfq", nfq_config);
+	afpacket = load("afpacket", afpacket_config);
+	coalesce_fanout_type();
 }
 
 function dump_config(settings) {
@@ -239,7 +279,7 @@ function dump_config(settings) {
 }
 
 function render_snort() {
-	include("templates/snort.uc", { snort, nfq, rpad });
+	include("templates/snort.uc", { snort, nfq, afpacket, rpad });
 }
 
 function render_nftables() {
@@ -250,6 +290,7 @@ function render_config() {
 	snort_config_doc("#");
 	dump_config(snort);
 	dump_config(nfq);
+	dump_config(afpacket);
 }
 
 function render_help() {

--- a/net/snort3/files/snort.config
+++ b/net/snort3/files/snort.config
@@ -35,18 +35,18 @@
 # nfq - https://github.com/snort3/libdaq/blob/master/modules/nfq/README.nfq.md
 #     queue_maxlen    - nfq's '--daq-var queue_maxlen=int'
 #     queue_count     - Count of queues to use when method=nfq, usually 2-8
-#     fanout_type     - Sets kernel load balancing algorithm*, one of hash, lb, cpu,
-#                       rollover, rnd, qm.
 #     thread_count    - int snort.-z: <count> maximum number of packet threads
 #                       (same as --max-packet-threads); 0 gets the number of
 #                       CPU cores reported by the system; default is 1 { 0:max32 }
 #     chain_type      - Chain type when generating nft output
 #     chain_priority  - Chain priority when generating nft output
 #     include         - Full path to user-defined extra rules to include inside queue chain
+#     fanout_type     - Deprecated, moved to the 'afpacket' section below.
 #
-#     * - for details on fanout_type, see these pages:
-#         https://github.com/florincoras/daq/blob/master/README
-#         https://www.kernel.org/doc/Documentation/networking/packet_mmap.txt
+# afpacket - https://github.com/snort3/libdaq/blob/master/modules/afpacket/README.afpacket.md
+#     fanout_type     - Sets kernel load balancing algorithm, one of hash, lb, cpu,
+#                       rollover, rnd, qm.  Only applies when method=afpacket.
+#                       Empty (default) leaves kernel PACKET_FANOUT off.
 #
 config snort 'snort'
 	option enabled         '0'              # one of [0, 1]
@@ -70,9 +70,11 @@ config nfq 'nfq'
 	option queue_count     '4'              # 1 <= x <= 16
 	option queue_start     '4'              # 1 <= x <= 32768
 	option queue_maxlen    '1024'           # 1024 <= x <= 65536
-	option fanout_type     'hash'           # one of [hash, lb, cpu, rollover, rnd, qm]
 	option thread_count    '0'              # 0 <= x <= 32
 	option chain_type      'input'          # one of [prerouting, input, forward, output, postrouting]
 	option chain_priority  'filter'         # one of [raw, filter, 300]
 	option include         ''               # a path string
+
+config afpacket 'afpacket'
+	option fanout_type     ''               # one of [hash, lb, cpu, rollover, rnd, qm]
 

--- a/net/snort3/files/snort.defaults
+++ b/net/snort3/files/snort.defaults
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# The afpacket section of /etc/config/snort was added after the file first
+# shipped.  A modified config is kept as-is on upgrade, so it lacks the
+# section, and uci cannot create a section on the fly while setting an
+# option in it.  Append the empty section once, as plain text rather than
+# via uci commit, which would rewrite the whole file and strip its comments.
+# The value itself is read at render time (main.uc, coalesce_fanout_type()).
+# No trailing exit 0: a failed append must fail, so the script is kept and
+# retried on the next boot instead of being removed.
+
+[ -f /etc/config/snort ] || exit 0
+uci -q get snort.afpacket >/dev/null && exit 0
+
+printf "\nconfig afpacket 'afpacket'\n\toption fanout_type     ''               # one of [hash, lb, cpu, rollover, rnd, qm]\n" >> /etc/config/snort

--- a/net/snort3/files/snort.uc
+++ b/net/snort3/files/snort.uc
@@ -13,9 +13,13 @@ let inputs = null;
 let vars   = null;
 switch (snort.method) {
 case "pcap":
-case "afpacket":
 	inputs = `{ '${snort.interface}' }`;
 	vars   = "{}";
+	break;
+
+case "afpacket":
+	inputs = `{ '${snort.interface}' }`;
+	vars   = afpacket.fanout_type ? `{ 'fanout_type=${afpacket.fanout_type}', }` : "{}";
 	break;
 
 case "nfq":
@@ -25,7 +29,7 @@ case "nfq":
 	}
 	inputs += "}";
 
-	vars = `{ 'device=${snort.interface}', 'queue_maxlen=${nfq.queue_maxlen}', 'fanout_type=${nfq.fanout_type}', 'fail_open', }`;
+	vars = `{ 'device=${snort.interface}', 'queue_maxlen=${nfq.queue_maxlen}', 'fail_open', }`;
 	break;
 }
 -%}
@@ -172,7 +176,7 @@ if (snort.include) {
   // We use the ucode include here, so that the included file is also
   // part of the template and can use values passed in from the config.
   printf(rpad(`-- Include from '${snort.include}'`, ">", 80) + "\n");
-  include(snort.include, { snort, nfq });
+  include(snort.include, { snort, nfq, afpacket });
   printf(rpad("-- End of included file.", "<", 80) + "\n");
 }
 %}

--- a/net/snort3/files/snort.uc
+++ b/net/snort3/files/snort.uc
@@ -41,7 +41,6 @@ snort  = {
 {% if (snort.mode == 'ips'): %}
   ['-Q'] = true,
 {% endif %}
-  ['--daq'] = '{{ snort.method }}',
 {% if (snort.method == 'nfq'): %}
   ['--max-packet-threads'] = {{ nfq.thread_count }},
 {% endif %}


### PR DESCRIPTION
Maintainer: @graysky2 

Fixes the bug reported in #30392: `snort.uc` set both `snort['--daq']` and
`daq.modules[1]` for the selected method. Snort applies the `snort` table
before `daq`, so `--daq` becomes a bare DAQ module config and
`SFDAQConfig::overlay()` then replaces the whole `daq.modules` list with
that bare entry, silently dropping every configured variable
(`queue_maxlen`, `fail_open` for nfq). `queue_maxlen` had no effect and
`fail_open` was never applied, regardless of what `/etc/config/snort` said.

## Commits

1. **snort3: fix --daq overriding daq.modules variables** - drops the
   `--daq` line; `daq.modules[1].name` already selects the module for
   pcap, afpacket and nfq.
2. **snort3: move fanout_type from nfq to a new afpacket section** -
   `fanout_type` sets AF_PACKET's `PACKET_FANOUT` algorithm
   (`daq_afpacket.c`), not anything the nfq DAQ module understands (it only
   recognizes `debug`, `fail_open`, `queue_maxlen` and silently ignores the
   rest). It was rendered into the nfq variables regardless of method, so
   it never reached the module it was meant for. Adds `config afpacket
   'afpacket'` with its own `fanout_type`, rendered only for
   `method=afpacket`. The old `nfq.fanout_type` is still read for backward
   compatibility (with a deprecation warning); a value in both sections
   logs a warning and prefers the new one.

## Testing

No CI or hardware here to run the full OpenWrt build, so this was verified
with `utpl` (the same tool `snort-mgr` uses) against the stock templates,
plus `snort -T` on the rendered configs, on OpenWrt 25.12.5 x86/64 with
`snort3 3.10.0.0`:

- All three methods (`pcap`, `afpacket`, `nfq`) x both modes (`ids`,
  `ips`): correct DAQ module selected, `snort -T` validates with 0
  warnings.
- `fanout_type` coalescing: legacy only, new option only, both set,
  invalid legacy value, and legacy option/section entirely absent - each
  produces the expected value/warning/error.
- `TYPE=config` and `TYPE=help` output render correctly with the new
  `afpacket` section.
- Confirmed `daq.modules[1].variables` for nfq no longer contains
  `fanout_type`, and for afpacket now does.

All testing was read-only against a live router's UCI (staged
`uci set`/`uci revert`, never committed) to avoid disturbing the running
service; the config file was restored byte-identical afterward.
