### PR TITLE
Tq fix typing extensions

### DIFF
--- a/lang/python/python-typing-extensions/Makefile
+++ b/lang/python/python-typing-extensions/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-typing-extensions
 PKG_VERSION:=4.15.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=typing-extensions
 PYPI_SOURCE_NAME:=typing_extensions

--- a/lang/python/python-typing-extensions/Makefile
+++ b/lang/python/python-typing-extensions/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-typing-extensions
-PKG_VERSION:=4.9.0
+PKG_VERSION:=4.15.0
 PKG_RELEASE:=1
 
 PYPI_NAME:=typing-extensions
 PYPI_SOURCE_NAME:=typing_extensions
-PKG_HASH:=23478f88c37f27d76ac8aee6c905017a143b0b1b886c3c9f66bc2fd94f9f5783
+PKG_HASH:=0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec1@gmail.com>, Jeffery To <jeffery.to@gmail.com>
 PKG_LICENSE:=Python-2.0.1 0BSD

--- a/lang/python/python-typing-extensions/Makefile
+++ b/lang/python/python-typing-extensions/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-typing-extensions
-PKG_VERSION:=4.15.0
-PKG_RELEASE:=2
+PKG_VERSION:=4.16.0
+PKG_RELEASE:=1
 
 PYPI_NAME:=typing-extensions
 PYPI_SOURCE_NAME:=typing_extensions
-PKG_HASH:=0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466
+PKG_HASH:=dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec1@gmail.com>, Jeffery To <jeffery.to@gmail.com>
 PKG_LICENSE:=Python-2.0.1 0BSD

--- a/lang/python/python-typing-extensions/patches/010-relax-flit-core-constraint.patch
+++ b/lang/python/python-typing-extensions/patches/010-relax-flit-core-constraint.patch
@@ -1,0 +1,26 @@
+From c4f17c8c6f8a2a7b242e5cc3871a5ea331b60157 Mon Sep 17 00:00:00 2001
+From: Alexandru Ardelean <alex@shruggie.ro>
+Date: Mon, 10 Aug 2026 10:00:00 +0300
+Subject: [PATCH] python-typing-extensions: allow flit_core 4.x as the build
+ backend
+
+Like python-wheel, typing-extensions caps its build backend at
+"flit_core >=3.11,<4", so python-typing-extensions/host fails with
+"Missing dependencies: flit_core<4,>=3.11" now that the feed ships
+flit-core 4.0.2. flit_core 4 builds it unchanged; relax the upper bound.
+
+Signed-off-by: Alexandru Ardelean <alex@shruggie.ro>
+---
+ pyproject.toml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,6 +1,6 @@
+ # Build system requirements.
+ [build-system]
+-requires = ["flit_core >=3.11,<4"]
++requires = ["flit_core >=3.11"]
+ build-backend = "flit_core.buildapi"
+ 
+ # Project metadata


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @commodo

**Description:**
Make python-typing-extensions compatible with python 3.13

fixes #30442

Importing typing-extensions results in an error:

AttributeError: attribute '__default__' of 'typing.ParamSpec' objects is not writable

See https://github.com/python/typing_extensions/issues/404

To fix this, update to version 4.16.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12.5
- **OpenWrt Target/Subtarget:** omap
- **OpenWrt Device:** custom

---

## ✅ Formalities

- [ x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
