### PR TITLE
bpftune: add new package

### DIFF
--- a/net/bpftune/Makefile
+++ b/net/bpftune/Makefile
@@ -1,0 +1,113 @@
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=bpftune
+PKG_VERSION:=0.4.2
+PKG_RELEASE:=1
+
+PKG_SOURCE:=bpftune-0.4-2.tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/oracle/bpftune/tar.gz/0.4-2?
+PKG_HASH:=96a7de8491fa8b3b8f96a21784aac6d7e303f606a7b8622bed8568ff0143e6db
+PKG_BUILD_DIR:=$(BUILD_DIR)/bpftune-0.4-2
+
+PKG_LICENSE:=GPL-2.0-or-later
+PKG_LICENSE_FILES:=COPYING
+PKG_MAINTAINER:=Shon Sebastian <fluffball3@proton.me>
+
+PKG_BUILD_DEPENDS:=bpf-headers
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/bpf.mk
+
+define Package/bpftune/default
+  SECTION:=net
+  CATEGORY:=Network
+  URL:=https://github.com/oracle/bpftune
+endef
+
+define Package/bpftune
+  $(call Package/bpftune/default)
+  TITLE:=BPF driven auto-tuning (needs TCP_CONG_HTCP and TCP_CONG_DCTCP)
+  DEPENDS:=+@KERNEL_BPF_EVENTS +@KERNEL_CGROUPS +@KERNEL_CGROUP_BPF \
+	   +kmod-tcp-bbr +libnl-route +libcap +libbpf \
+	   $(BPF_DEPENDS)
+endef
+
+define Package/bpftune-full
+  $(call Package/bpftune/default)
+  TITLE:=bpftune with BTF support (might cause crashloops on limited hardware).
+  DEPENDS:=+bpftune +@KERNEL_DEBUG_INFO +@KERNEL_DEBUG_INFO_BTF \
+	   +@KERNEL_NAMESPACES +@KERNEL_NET_NS
+endef
+
+define Package/bpftune/description
+  bpftune aims to provide lightweight, always-on auto-tuning of system
+  behaviour. By using BPF observability features, we can continuously
+  monitor and adjust system behaviour at a fine grain. (Needs TCP_CONG_HTCP
+  and TCP_CONG_DCTCP from target/linux/generic/config-<version> manually enabled
+  to function correctly. Runs on no-BTF mode).
+endef
+
+define Package/bpftune-full/description
+  bpftune with BTF support for intended functionality. Needs TCP_CONG_HTCP
+  and TCP_CONG_DCTCP from target/linux/generic/config-<version> manually enabled
+  to function, and KERNEL_DEBUG_INFO_REDUCED disabled manually. This package enables
+  KERNEL_NET_NS and KERNEL_DEBUG_INFO_BTF as well which might cause crashloops on
+  limited hardware eg. single core cpu routers.
+endef
+
+bpf_srcarch=$(subst \
+  aarch64,arm64,$(subst \
+  armeb,arm,$(subst \
+  i386,x86,$(subst \
+  x86_64,x86,$(subst \
+  loongarch64,loongarch,$(subst \
+  mipsel,mips,$(subst \
+  mips64,mips,$(subst \
+  powerpc64,powerpc,$(subst \
+  riscv64,riscv,$(1))))))))))
+
+BPF_SRCARCH:=$(call bpf_srcarch,$(ARCH))
+
+MAKE_FLAGS += \
+	BPFTUNE_VERSION="$(PKG_VERSION)-$(PKG_RELEASE)" \
+	SRCARCH="$(BPF_SRCARCH)" \
+	BPF_TARGET="$(BPF_TARGET)" \
+	BPF_CLANG="$(CLANG)" \
+	LLVM_STRIP="$(LLVM_STRIP)" \
+	PKG_BUILD_DIR=$(PKG_BUILD_DIR)
+
+define Package/bpftune/conffiles
+/etc/config/bpftune
+endef
+
+define Package/bpftune/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/bpftune $(1)/usr/sbin/bpftune
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/libbpftune.so.0.4.2 $(1)/usr/lib/libbpftune.so.0.4.2
+	$(LN) libbpftune.so.0.4.2 $(1)/usr/lib/libbpftune.so
+	$(INSTALL_DIR) $(1)/usr/lib/bpftune
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/tcp_buffer_tuner.so $(1)/usr/lib/bpftune
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/route_table_tuner.so $(1)/usr/lib/bpftune
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/neigh_table_tuner.so $(1)/usr/lib/bpftune
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/sysctl_tuner.so $(1)/usr/lib/bpftune
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/tcp_conn_tuner.so $(1)/usr/lib/bpftune
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/netns_tuner.so $(1)/usr/lib/bpftune
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/net_buffer_tuner.so $(1)/usr/lib/bpftune
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/ip_frag_tuner.so $(1)/usr/lib/bpftune
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/udp_buffer_tuner.so $(1)/usr/lib/bpftune
+	$(INSTALL_DIR) $(1)/etc
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_DATA) ./files/bpftune.confd $(1)/etc/config/bpftune
+	$(INSTALL_BIN) ./files/bpftune.initd $(1)/etc/init.d/bpftune
+endef
+
+$(eval $(call BuildPackage,bpftune))
+
+$(eval $(call BuildPackage,bpftune-full))

--- a/net/bpftune/files/bpftune.confd
+++ b/net/bpftune/files/bpftune.confd
@@ -1,0 +1,2 @@
+config defaults 'defaults'
+	option command_args "-R -c /sys/fs/cgroup"

--- a/net/bpftune/files/bpftune.initd
+++ b/net/bpftune/files/bpftune.initd
@@ -1,0 +1,37 @@
+#!/bin/sh /etc/rc.common
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+USE_PROCD=1
+
+START=81
+STOP=81
+
+NAME=bpftune
+PROG=/usr/sbin/bpftune
+CONFIG=/etc/config/bpftune
+
+ARGS="-R -c /sys/fs/cgroup"
+EXTRA_COMMANDS="checkconf"
+
+checkconf() {
+	config_load 'bpftune'
+	config_get ARGS defaults command_args "$ARGS"
+	$PROG -S $ARGS 2>&1
+}
+
+start_pre() {
+	checkconf > /dev/null 2>&1
+}
+
+start_service()
+{
+	if ! start_pre; then
+		return 1
+	fi
+
+	procd_open_instance
+	procd_set_param file $CONFIG
+	procd_set_param command $PROG $ARGS
+	procd_set_param respawn
+	procd_close_instance
+}

--- a/net/bpftune/patches/build-src-only.patch
+++ b/net/bpftune/patches/build-src-only.patch
@@ -1,0 +1,25 @@
+From 3670ec5ddc3238892e79ce28e15fe4b613320bda Mon Sep 17 00:00:00 2001
+From: Shon Sebastian <fluffball3@proton.me>
+Date: Wed, 2 Sep 2026 04:32:06 +0530
+Subject: [PATCH] build src only
+
+---
+ Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index 5e93dc0..c23a5f0 100644
+--- a/Makefile
++++ b/Makefile
+@@ -33,7 +33,7 @@ INSTALLPATH = $(installprefix)
+ 
+ .PHONY: all clean
+ 
+-all: srcdir docdir testdir
++all: srcdir
+ 	
+ srcdir:
+ 	cd src; make
+-- 
+2.55.0
+

--- a/net/bpftune/patches/fix-Makefile.patch
+++ b/net/bpftune/patches/fix-Makefile.patch
@@ -1,0 +1,104 @@
+From 24e9ec3d73e387e970f45083683129521db8f8b7 Mon Sep 17 00:00:00 2001
+From: Shon Sebastian <fluffball3@proton.me>
+Date: Sun, 6 Sep 2026 20:26:28 +0530
+Subject: [PATCH] fix Makefile
+
+---
+ src/Makefile | 43 +++++++++++++++++++++----------------------
+ 1 file changed, 21 insertions(+), 22 deletions(-)
+
+diff --git a/src/Makefile b/src/Makefile
+index b42f945..0577bbb 100644
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -15,26 +15,22 @@
+ # License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ 
+-ARCH ?= $(shell uname -m)
+-SRCARCH ?= $(shell uname -m | sed -e s/i.86/x86/ -e s/x86_64/x86/ \
+-				  -e /arm64/!s/arm.*/arm/ -e s/sa110/arm/ \
+-				  -e s/aarch64.*/arm64/ )
+-
+ CLANG ?= clang
+ GCC_BPF ?=
+ LLC ?= llc
+ LLVM_STRIP ?= llvm-strip
+ BPFTOOL ?= bpftool
+-BPF_INCLUDE := /usr/include
+-BPF_LOCAL_INCLUDE := /usr/local/include
+-BPF_CFLAGS := -g -fno-stack-protector -Wall -Wno-incompatible-pointer-types-discards-qualifiers
+-NL_INCLUDE := /usr/include/libnl3
+-INCLUDES := -I../include -I$(BPF_INCLUDE) -I$(BPF_LOCAL_INCLUDE) -I$(NL_INCLUDE) -I../include/uapi
++BPF_CFLAGS += -g -fno-stack-protector -Wall -Wno-incompatible-pointer-types-discards-qualifiers
++
++INCLUDES := -I../include \
++	    -I$(STAGING_DIR)/usr/include \
++	    -I$(STAGING_DIR)/usr/include/libnl3
++
+ INSTALL ?= install
+ 
+ DESTDIR ?= /
+ prefix ?= /usr
+-libdir ?= lib64
++libdir ?= lib
+ installprefix = $(DESTDIR)/$(prefix)
+ 
+ INSTALLPATH = $(installprefix)
+@@ -57,7 +53,7 @@ endif
+ VERSION = 0.4.2
+ VERSION_SCRIPT  := libbpftune.map
+ 
+-CFLAGS = -fPIC -Wall -Wextra -g -I../include -std=c99
++CFLAGS += -fPIC -Wall -Wextra -g -std=c99
+ 
+ CFLAGS += -DBPFTUNE_VERSION='"$(BPFTUNE_VERSION)"' \
+ 	  -DBPFTUNER_PREFIX_DIR='"$(prefix)"' \
+@@ -74,12 +70,12 @@ VMLINUX_BTF_PATHS := /sys/kernel/btf/vmlinux /boot/vmlinux-$(KERNEL_REL)
+ VMLINUX_BTF_PATH := $(or $(VMLINUX_BTF),$(firstword			       \
+ 					  $(wildcard $(VMLINUX_BTF_PATHS))))
+ 
+-# Some systems ship with a vmlinux.h; use it.
+-VMLINUX_H_PATH ?= /usr/include/$(ARCH)-linux-gnu/linux/bpf/
+-VMLINUX_H_FILE := $(wildcard $(VMLINUX_H_PATH)/vmlinux.h)
++# Try to reach generated vmlinux.h if it exists
++VMLINUX_H_FILE := $(wildcard $(PKG_BUILD_DIR)/vmlinux.h)
+ 
++# Defaults to ../include/bpftune/vmlinux_aarch64.h as the best available fallback.
+ ifneq ($(VMLINUX_H_FILE),)
+-BPF_CFLAGS += -DVMLINUX_H -I$(VMLINUX_H_PATH)
++BPF_CFLAGS += -DVMLINUX_H -I$(PKG_BUILD_DIR)
+ endif
+ 
+ OPATH :=
+@@ -191,18 +187,21 @@ $(OPATH)bpftune.o: $(OPATH)libbpftune.so
+ # check if GCC_BPF flag is set, otherwise use CLANG
+ ifeq ($(GCC_BPF),)
+ $(BPF_OBJS): $(patsubst %.o,%.c,$(BPF_OBJS)) ../include/bpftune/bpftune.bpf.h
+-	$(CLANG) $(BPF_CFLAGS) -D__TARGET_ARCH_$(SRCARCH) -O2 -target bpf \
+-		$(INCLUDES) -c $(patsubst %.o,%.c,$(@)) -o $(@)
++	$(BPF_CLANG) $(BPF_CFLAGS) -D__TARGET_ARCH_$(SRCARCH) -O2 -target $(BPF_TARGET) \
++		-I../include -c $(patsubst %.o,%.c,$(@)) -o $(@)
++	$(LLVM_STRIP) --strip-debug $(@)
+ 
+ $(LEGACY_BPF_OBJS): $(patsubst %.legacy.o,%.c,$(LEGACY_BPF_OBJS)) ../include/bpftune/bpftune.bpf.h
+-	$(CLANG) $(BPF_CFLAGS) -D__TARGET_ARCH_$(SRCARCH) -DBPFTUNE_LEGACY -O2 -target bpf \
+-		$(INCLUDES) -c $(patsubst %.legacy.o,%.c,$(@)) \
++	$(BPF_CLANG) $(BPF_CFLAGS) -D__TARGET_ARCH_$(SRCARCH) -DBPFTUNE_LEGACY -O2 -target $(BPF_TARGET) \
++		-I../include -c $(patsubst %.legacy.o,%.c,$(@)) \
+ 		-o $(@)
++	$(LLVM_STRIP) --strip-debug $(@)
+ 
+ $(NOBTF_BPF_OBJS): $(patsubst %.nobtf.o,%.c,$(NOBTF_BPF_OBJS)) ../include/bpftune/bpftune.bpf.h
+-	$(CLANG) $(BPF_CFLAGS) -D__TARGET_ARCH_$(SRCARCH) -DBPFTUNE_NOBTF -O2 -target bpf \
+-		$(INCLUDES) -c $(patsubst %.nobtf.o,%.c,$(@)) \
++	$(BPF_CLANG) $(BPF_CFLAGS) -D__TARGET_ARCH_$(SRCARCH) -DBPFTUNE_NOBTF -O2 -target $(BPF_TARGET) \
++		-I../include -c $(patsubst %.nobtf.o,%.c,$(@)) \
+ 		-o $(@)
++	$(LLVM_STRIP) --strip-debug $(@)
+ else
+ GCC_BPF_FLAGS := -g -O2 \
+ 	$(BPF_CFLAGS) -D__TARGET_ARCH_$(SRCARCH) \
+-- 
+2.55.0
+

--- a/net/bpftune/patches/libbpftune-musl-fixes.patch
+++ b/net/bpftune/patches/libbpftune-musl-fixes.patch
@@ -1,0 +1,46 @@
+From 35bac551c41c590be1289038b565b228c1562750 Mon Sep 17 00:00:00 2001
+From: Shon Sebastian <fluffball3@proton.me>
+Date: Wed, 2 Sep 2026 04:32:00 +0530
+Subject: [PATCH] libbpftune: musl fixes
+
+Fixes for compiling with musl
+
+Signed-off-by: Shon Sebastian <fluffball3@proton.me>
+---
+ src/libbpftune.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/libbpftune.c b/src/libbpftune.c
+index 2983060..fc867d6 100644
+--- a/src/libbpftune.c
++++ b/src/libbpftune.c
+@@ -2007,7 +2007,7 @@ static void bpftuner_strategy_update(struct bpftuner *tuner)
+ 		bpftuner_strategy_set(tuner, max_strategy);
+ }
+ 
+-static void bpftuner_strategy_timeout(sigval_t sigval)
++static void bpftuner_strategy_timeout(union sigval sigval)
+ {
+ 	struct bpftuner *tuner = sigval.sival_ptr;
+ 
+@@ -2423,7 +2423,7 @@ void *bpftune_server_thread(void *arg)
+ 	if (port == 0) {
+ 		len = sizeof(saddr);
+ 
+-		if (!getsockname(fd, &saddr, &len))
++		if (!getsockname(fd, (struct sockaddr *)&saddr, &len))
+ 			port = ntohs(saddr.sin_port);
+ 	}
+ 	if (port != 0) {
+@@ -2444,7 +2444,7 @@ void *bpftune_server_thread(void *arg)
+ 		char buf[BPFTUNE_SERVER_MSG_MAX];
+ 		char req[80];
+ 		struct sockaddr_in caddr;
+-		int cfd = accept(fd, (struct sockaddr_in *)&caddr, &len);
++		int cfd = accept(fd, (struct sockaddr *)&caddr, &len);
+ 		unsigned long i;
+ 
+ 		if (cfd < 0) {
+-- 
+2.55.0
+

--- a/net/bpftune/patches/vmlinux-fallback.patch
+++ b/net/bpftune/patches/vmlinux-fallback.patch
@@ -1,0 +1,31 @@
+From 684fd49115270c02001c11b89e0b404c72f82292 Mon Sep 17 00:00:00 2001
+From: Shon Sebastian <fluffball3@proton.me>
+Date: Fri, 4 Sep 2026 13:20:58 +0530
+Subject: [PATCH] vmlinux fallback
+
+---
+ include/bpftune/bpftune.bpf.h | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/include/bpftune/bpftune.bpf.h b/include/bpftune/bpftune.bpf.h
+index 42466a6..23e3039 100644
+--- a/include/bpftune/bpftune.bpf.h
++++ b/include/bpftune/bpftune.bpf.h
+@@ -30,12 +30,13 @@
+ 	__builtin_preserve_access_index(&obj->field)
+ #endif
+ 
++// select atleast one vmlinux.h file
+ #ifdef VMLINUX_H
+ #include <vmlinux.h>
+ #else
+ #if defined(__TARGET_ARCH_x86)
+ #include <bpftune/vmlinux_x86_64.h>
+-#elif defined(__TARGET_ARCH_arm64)
++#else
+ #include <bpftune/vmlinux_aarch64.h>
+ #endif
+ #endif /* VMLIMUX_H */
+-- 
+2.55.0
+


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @fluffball3

**Description:**
bpftune aims to provide lightweight, always-on auto-tuning of system behaviour. By using BPF observability features, we can continuously monitor and adjust system behaviour at a fine grain.

Packaged version:
0.4-2 release tag

Upstream project:
https://github.com/oracle/bpftune

The package includes:

- the bpftune binary
- an OpenWrt procd init script
- persistent configuration via /etc/config/bpftune
- The service is enabled by default and can be disabled through the supplied init script.

Additional kconfigs required:
- KERNEL_BPF_EVENTS
- KERNEL_CGROUPS 
- KERNEL_CGROUP_BPF 

Kconfigs required for running bpftune:
- PACKAGE_kmod-tcp-bbr
- TCP_CONG_HTCP
- TCP_CONG_DCTCP

Optional ones: 
- KERNEL_NAMESPACES 
- KERNEL_NET_NS
- KERNEL_DEBUG_INFO
- KERNEL_DEBUG_INFO_BTF

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12.5 and snapshot
- **OpenWrt Target/Subtarget:** ramips/mt76x8
- **OpenWrt Device:** MiWifi 3C

Tested and confirmed legacy and no-BTF modes working using `bpftune -dS` but couldn't achieve full support as mentioned [here](https://github.com/oracle/bpftune/blob/main/TROUBLESHOOTING.md) atleast on my device. 

---

Things needing to be fixed:

- The vmlinux.h that is being used for compilation is the aarch64 one provided in the upstream project itself because I couldn't figure out how to use the generated one during kernel compilation and so even though it seems to be covering the majority of wanted symbols it could have mismatches.
- Full functionality has not been confirmed partly because of no per-netns policy (via netns cookie)
- bpftune-full package might not pull necessary kconfig dependency automatically (KERNEL_DEBUG_INFO_BTF ) since it depends on !KERNEL_DEBUG_INFO_REDUCED.

Legacy mode working:

```
root@OpenWrt:~# bpftune -dS
bpftune: set caps (count 1)
bpftune: set caps (count 2)
bpftune: drop caps (count 1)
bpftune: set caps (count 2)
bpftune: libbpf: loading object 'probe_bpf' from buffer
bpftune: libbpf: elf: section(3) fentry/setup_net, size 88, link 0, flags 6, type=1
bpftune: libbpf: sec 'fentry/setup_net': found program 'entry__setup_net' at insn offset 0 (0 bytes), code size 11 insns (88 bytes)
bpftune: libbpf: elf: section(4) iter/tcp, size 128, link 0, flags 6, type=1
bpftune: libbpf: sec 'iter/tcp': found program 'probe_cong_iter' at insn offset 0 (0 bytes), code size 16 insns (128 bytes)
bpftune: libbpf: elf: section(5) tp_btf/neigh_create, size 16, link 0, flags 6, type=1
bpftune: libbpf: sec 'tp_btf/neigh_create': found program 'bpftune_neigh_create' at insn offset 0 (0 bytes), code size 2 insns (16 bytes)
bpftune: libbpf: elf: section(6) cgroup/sysctl, size 16, link 0, flags 6, type=1
bpftune: libbpf: sec 'cgroup/sysctl': found program 'sysctl_write' at insn offset 0 (0 bytes), code size 2 insns (16 bytes)
bpftune: libbpf: elf: section(7) .data, size 4, link 0, flags 3, type=1
bpftune: libbpf: elf: section(8) license, size 7, link 0, flags 3, type=1
bpftune: libbpf: license of probe_bpf is GPL v2
bpftune: libbpf: elf: section(9) .rodata, size 24, link 0, flags 2, type=1
bpftune: libbpf: elf: section(10) .bss, size 25, link 0, flags 3, type=8
bpftune: libbpf: elf: section(11) .maps, size 168, link 0, flags 3, type=1
bpftune: libbpf: elf: section(12) .BTF, size 63905, link 0, flags 0, type=1
bpftune: libbpf: elf: section(14) .BTF.ext, size 428, link 0, flags 0, type=1
bpftune: libbpf: elf: section(17) .symtab, size 552, link 1, flags 0, type=2
bpftune: libbpf: looking for externs among 23 symbols...
bpftune: libbpf: collected 0 externs total
bpftune: libbpf: map 'ring_buffer_map': at sec_idx 11, offset 0.
bpftune: libbpf: map 'ring_buffer_map': found type = 27.
bpftune: libbpf: map 'ring_buffer_map': found max_entries = 131072.
bpftune: libbpf: map 'netns_map': at sec_idx 11, offset 16.
bpftune: libbpf: map 'netns_map': found type = 1.
bpftune: libbpf: map 'netns_map': found key [12], sz = 8.
bpftune: libbpf: map 'netns_map': found value [12], sz = 8.
bpftune: libbpf: map 'netns_map': found max_entries = 65536.
bpftune: libbpf: map 'netns_map': found map_flags = 0x0.
bpftune: libbpf: map 'corr_map': at sec_idx 11, offset 56.
bpftune: libbpf: map 'corr_map': found type = 1.
bpftune: libbpf: map 'corr_map': found key [21], sz = 16.
bpftune: libbpf: map 'corr_map': found value [24], sz = 48.
bpftune: libbpf: map 'corr_map': found max_entries = 1024.
bpftune: libbpf: map 'corr_map': found map_flags = 0x0.
bpftune: libbpf: map 'last_event_map': at sec_idx 11, offset 96.
bpftune: libbpf: map 'last_event_map': found type = 1.
bpftune: libbpf: map 'last_event_map': found key [12], sz = 8.
bpftune: libbpf: map 'last_event_map': found value [12], sz = 8.
bpftune: libbpf: map 'last_event_map': found max_entries = 65536.
bpftune: libbpf: map 'probe_hash_map': at sec_idx 11, offset 128.
bpftune: libbpf: map 'probe_hash_map': found type = 1.
bpftune: libbpf: map 'probe_hash_map': found key [12], sz = 8.
bpftune: libbpf: map 'probe_hash_map': found value [12], sz = 8.
bpftune: libbpf: map 'probe_hash_map': found max_entries = 65536.
bpftune: libbpf: map 'probe_hash_map': found map_flags = 0x0.
bpftune: libbpf: map 'probe_bp.data' (global data): at sec_idx 7, offset 0, flags 400.
bpftune: libbpf: map 5 is "probe_bp.data"
bpftune: libbpf: map 'probe_bp.rodata' (global data): at sec_idx 9, offset 0, flags 480.
bpftune: libbpf: map 6 is "probe_bp.rodata"
bpftune: libbpf: map 'probe_bp.bss' (global data): at sec_idx 10, offset 0, flags 400.
bpftune: libbpf: map 7 is "probe_bp.bss"
bpftune: libbpf: object 'probe_bpf': failed (-1) to create BPF token from '/sys/fs/bpf', skipping optional step...
bpftune: libbpf: loaded kernel BTF from '/sys/kernel/btf/vmlinux'
bpftune: libbpf: sec 'fentry/setup_net': found 2 CO-RE relocations
bpftune: libbpf: CO-RE relocating [36] struct net: found target candidate [1463] struct net in [vmlinux]
bpftune: libbpf: prog 'entry__setup_net': relo #0: <field_exists> [36] struct net.net_cookie (0:48 @ offset 4352)
bpftune: libbpf: prog 'entry__setup_net': relo #0: matching candidate #0 <field_exists> [1463] struct net.net_cookie (0:43 @ offset 1640)
bpftune: libbpf: prog 'entry__setup_net': relo #0: patched insn #0 (ALU/ALU64) imm 1 -> 1
bpftune: libbpf: prog 'entry__setup_net': relo #1: <byte_off> [36] struct net.net_cookie (0:48 @ offset 4352)
bpftune: libbpf: prog 'entry__setup_net': relo #1: matching candidate #0 <byte_off> [1463] struct net.net_cookie (0:43 @ offset 1640)
bpftune: libbpf: prog 'entry__setup_net': relo #1: patched insn #2 (ALU/ALU64) imm 4352 -> 1640
bpftune: libbpf: sec 'iter/tcp': found 1 CO-RE relocations
bpftune: libbpf: CO-RE relocating [800] struct bpf_iter__tcp: found target candidate [19872] struct bpf_iter__tcp in [vmlinux]
bpftune: libbpf: prog 'probe_cong_iter': relo #0: <byte_off> [800] struct bpf_iter__tcp.sk_common (0:1:0 @ offset 8)
bpftune: libbpf: prog 'probe_cong_iter': relo #0: matching candidate #0 <byte_off> [19872] struct bpf_iter__tcp.sk_common (0:1:0 @ offset 8)
bpftune: libbpf: prog 'probe_cong_iter': relo #0: patched insn #0 (LDX/ST/STX) off 8 -> 8
bpftune: libbpf: prog 'probe_cong_iter': relo #0: patched insn #0 (LDX/ST/STX) mem_sz 8 -> 4
bpftune: libbpf: map 'ring_buffer_map': created successfully, fd=4
bpftune: libbpf: map 'netns_map': created successfully, fd=5
bpftune: libbpf: map 'corr_map': created successfully, fd=6
bpftune: libbpf: map 'last_event_map': created successfully, fd=7
bpftune: libbpf: map 'probe_hash_map': created successfully, fd=8
bpftune: libbpf: map 'probe_bp.data': created successfully, fd=9
bpftune: libbpf: map 'probe_bp.rodata': created successfully, fd=10
bpftune: libbpf: map 'probe_bp.bss': created successfully, fd=11
bpftune: libbpf: prog 'probe_cong_iter': BPF program load failed: -EACCES
bpftune: libbpf: prog 'probe_cong_iter': -- BEGIN PROG LOAD LOG --
0: R1=ctx() R10=fp0
; struct sock_common *skc = ctx->sk_common; @ probe.bpf.c:38
0: (61) r1 = *(u32 *)(r1 +8)
func 'bpf_iter_tcp' size 4 must be 8
invalid bpf_context access off=8 size=4
processed 1 insns (limit 1000000) max_states_per_insn 0 total_states 0 peak_states 0 mark_read 0
-- END PROG LOAD LOG --
bpftune: libbpf: prog 'probe_cong_iter': failed to load: -EACCES
bpftune: libbpf: failed to load object 'probe_bpf'
bpftune: libbpf: failed to load BPF skeleton 'probe_bpf': -EACCES
bpftune: full bpftune support not available: No error information
bpftune: libbpf: loading object 'probe_bpf_legacy' from buffer
bpftune: libbpf: elf: section(3) kprobe/setup_net, size 88, link 0, flags 6, type=1
bpftune: libbpf: sec 'kprobe/setup_net': found program 'entry__setup_net' at insn offset 0 (0 bytes), code size 11 insns (88 bytes)
bpftune: libbpf: elf: section(4) raw_tracepoint/neigh_create, size 16, link 0, flags 6, type=1
bpftune: libbpf: sec 'raw_tracepoint/neigh_create': found program 'bpftune_neigh_create' at insn offset 0 (0 bytes), code size 2 insns (16 bytes)
bpftune: libbpf: elf: section(5) cgroup/sysctl, size 16, link 0, flags 6, type=1
bpftune: libbpf: sec 'cgroup/sysctl': found program 'sysctl_write' at insn offset 0 (0 bytes), code size 2 insns (16 bytes)
bpftune: libbpf: elf: section(6) .data, size 4, link 0, flags 3, type=1
bpftune: libbpf: elf: section(7) license, size 7, link 0, flags 3, type=1
bpftune: libbpf: license of probe_bpf_legacy is GPL v2
bpftune: libbpf: elf: section(8) .rodata, size 24, link 0, flags 2, type=1
bpftune: libbpf: elf: section(9) .bss, size 25, link 0, flags 3, type=8
bpftune: libbpf: elf: section(10) .maps, size 168, link 0, flags 3, type=1
bpftune: libbpf: elf: section(11) .BTF, size 64024, link 0, flags 0, type=1
bpftune: libbpf: elf: section(13) .BTF.ext, size 284, link 0, flags 0, type=1
bpftune: libbpf: elf: section(16) .symtab, size 504, link 1, flags 0, type=2
bpftune: libbpf: looking for externs among 21 symbols...
bpftune: libbpf: collected 0 externs total
bpftune: libbpf: map 'ring_buffer_map': at sec_idx 10, offset 0.
bpftune: libbpf: map 'ring_buffer_map': found type = 27.
bpftune: libbpf: map 'ring_buffer_map': found max_entries = 131072.
bpftune: libbpf: map 'netns_map': at sec_idx 10, offset 16.
bpftune: libbpf: map 'netns_map': found type = 1.
bpftune: libbpf: map 'netns_map': found key [12], sz = 8.
bpftune: libbpf: map 'netns_map': found value [12], sz = 8.
bpftune: libbpf: map 'netns_map': found max_entries = 65536.
bpftune: libbpf: map 'netns_map': found map_flags = 0x0.
bpftune: libbpf: map 'corr_map': at sec_idx 10, offset 56.
bpftune: libbpf: map 'corr_map': found type = 1.
bpftune: libbpf: map 'corr_map': found key [21], sz = 16.
bpftune: libbpf: map 'corr_map': found value [24], sz = 48.
bpftune: libbpf: map 'corr_map': found max_entries = 1024.
bpftune: libbpf: map 'corr_map': found map_flags = 0x0.
bpftune: libbpf: map 'last_event_map': at sec_idx 10, offset 96.
bpftune: libbpf: map 'last_event_map': found type = 1.
bpftune: libbpf: map 'last_event_map': found key [12], sz = 8.
bpftune: libbpf: map 'last_event_map': found value [12], sz = 8.
bpftune: libbpf: map 'last_event_map': found max_entries = 65536.
bpftune: libbpf: map 'probe_hash_map': at sec_idx 10, offset 128.
bpftune: libbpf: map 'probe_hash_map': found type = 1.
bpftune: libbpf: map 'probe_hash_map': found key [12], sz = 8.
bpftune: libbpf: map 'probe_hash_map': found value [12], sz = 8.
bpftune: libbpf: map 'probe_hash_map': found max_entries = 65536.
bpftune: libbpf: map 'probe_hash_map': found map_flags = 0x0.
bpftune: libbpf: map 'probe_bp.data' (global data): at sec_idx 6, offset 0, flags 400.
bpftune: libbpf: map 5 is "probe_bp.data"
bpftune: libbpf: map 'probe_bp.rodata' (global data): at sec_idx 8, offset 0, flags 480.
bpftune: libbpf: map 6 is "probe_bp.rodata"
bpftune: libbpf: map 'probe_bp.bss' (global data): at sec_idx 9, offset 0, flags 400.
bpftune: libbpf: map 7 is "probe_bp.bss"
bpftune: libbpf: object 'probe_bpf_legac': failed (-1) to create BPF token from '/sys/fs/bpf', skipping optional step...
bpftune: libbpf: loaded kernel BTF from '/sys/kernel/btf/vmlinux'
bpftune: libbpf: sec 'kprobe/setup_net': found 3 CO-RE relocations
bpftune: libbpf: CO-RE relocating [50] struct net: found target candidate [1463] struct net in [vmlinux]
bpftune: libbpf: prog 'entry__setup_net': relo #0: <field_exists> [50] struct net.net_cookie (0:48 @ offset 4352)
bpftune: libbpf: prog 'entry__setup_net': relo #0: matching candidate #0 <field_exists> [1463] struct net.net_cookie (0:43 @ offset 1640)
bpftune: libbpf: prog 'entry__setup_net': relo #0: patched insn #0 (ALU/ALU64) imm 1 -> 1
bpftune: libbpf: prog 'entry__setup_net': relo #1: <byte_off> [50] struct net.net_cookie (0:48 @ offset 4352)
bpftune: libbpf: prog 'entry__setup_net': relo #1: matching candidate #0 <byte_off> [1463] struct net.net_cookie (0:43 @ offset 1640)
bpftune: libbpf: prog 'entry__setup_net': relo #1: patched insn #2 (ALU/ALU64) imm 4352 -> 1640
bpftune: libbpf: CO-RE relocating [34] struct pt_regs: found target candidate [203] struct pt_regs in [vmlinux]
bpftune: libbpf: prog 'entry__setup_net': relo #2: <byte_off> [34] struct pt_regs.regs[4] (0:0:1:0:4 @ offset 32)
bpftune: libbpf: prog 'entry__setup_net': relo #2: matching candidate #0 <byte_off> [203] struct pt_regs.regs[4] (0:1:4 @ offset 48)
bpftune: libbpf: prog 'entry__setup_net': relo #2: patched insn #3 (LDX/ST/STX) off 32 -> 48
bpftune: libbpf: prog 'entry__setup_net': relo #2: patched insn #3 (LDX/ST/STX) mem_sz 8 -> 4
bpftune: libbpf: map 'ring_buffer_map': created successfully, fd=4
bpftune: libbpf: map 'netns_map': created successfully, fd=5
bpftune: libbpf: map 'corr_map': created successfully, fd=6
bpftune: libbpf: map 'last_event_map': created successfully, fd=7
bpftune: libbpf: map 'probe_hash_map': created successfully, fd=8
bpftune: libbpf: map 'probe_bp.data': created successfully, fd=9
bpftune: libbpf: map 'probe_bp.rodata': created successfully, fd=10
bpftune: libbpf: map 'probe_bp.bss': created successfully, fd=11
bpftune: netns cookie not supported, cannot monitor per-netns events
bpftune: netns cookie not supported
bpftune: drop caps (count 1)
bpftune: bpftune works in legacy mode
bpftune: netns cookie not supported, cannot monitor per-netns events
bpftune: bpftune does not support per-netns policy (via netns cookie)
bpftune: set caps (count 2)
bpftune: drop caps (count 1)
root@OpenWrt:~#
```