### PR TITLE
ocserv: update to 1.5.0

### DIFF
--- a/net/ocserv/Makefile
+++ b/net/ocserv/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2007-2011 OpenWrt.org
+# Copyright (C) 2007-2026 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,25 +8,26 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ocserv
-PKG_VERSION:=1.4.1
-PKG_RELEASE:=2
+PKG_VERSION:=1.5.0
+PKG_RELEASE:=1
 PKG_BUILD_FLAGS:=no-mips16
 
-PKG_BUILD_DIR :=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.infradead.org/ocserv/download/
-PKG_HASH:=54a0e036421ef81556d5a573f13e123166e8fa9679e9a0877f5ef0c472128553
+PKG_HASH:=42ced08958b9576ab134fcb7bdc7f8df5e13214fd147855f99021fedcf0eedbe
 
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=COPYING
-#PKG_FIXUP:=autoreconf
 
 PKG_CONFIG_DEPENDS:= \
 	CONFIG_OCSERV_PAM \
 	CONFIG_OCSERV_SECCOMP \
 	CONFIG_OCSERV_PROTOBUF \
+	CONFIG_OCSERV_RADIUS \
+	CONFIG_OCSERV_LIBOATH
 
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/meson.mk
 
 define Package/ocserv/config
 	source "$(SOURCE)/Config.in"
@@ -52,47 +53,22 @@ define Package/ocserv/description
  as TLS 1.2, and Datagram TLS to provide the secure VPN service.
 endef
 
-EXTRA_CPPFLAGS+=-I$(STAGING_DIR)/usr/include/readline/
-EXTRA_LDFLAGS+=-lncurses
+MESON_ARGS += \
+	-Dpager='' \
+	-Dlibnl=disabled \
+	-Dgssapi=disabled \
+	-Dmaxmind=disabled \
+	-Dlz4=disabled \
+	-Dfirewall-script=nftables \
+	-Dlocal-talloc=true \
+	-Dsock-diag=disabled
 
-CONFIGURE_VARS += \
-	ac_cv_file__proc_self_exe=yes \
-	ac_cv_prog_IPCALC=/bin/true
-
-CONFIGURE_ARGS+= \
-	--with-pager="" \
-	--with-libreadline-prefix="$(STAGING_DIR)/" \
-	--without-libnl \
-	--without-gssapi \
-	--without-maxmind \
-	--with-libcrypt-prefix="$(STAGING_DIR)/" \
-	--with-libev-prefix="$(STAGING_DIR)/" \
-	--without-lz4 \
-	--with-local-talloc \
-
-ifneq ($(CONFIG_OCSERV_PAM),y)
-CONFIGURE_ARGS += --without-pam
-endif
-
-ifneq ($(CONFIG_OCSERV_RADIUS),y)
-CONFIGURE_ARGS += --without-radius
-endif
-
-ifneq ($(CONFIG_OCSERV_SECCOMP),y)
-CONFIGURE_ARGS += --disable-seccomp
-endif
-
-ifneq ($(CONFIG_OCSERV_PROTOBUF),y)
-CONFIGURE_ARGS += --without-protobuf
-endif
-
-ifndef CONFIG_OCSERV_LIBOATH
-CONFIGURE_ARGS += --without-liboath
-endif
-
-ifeq ($(ARCH),arm)                                              
-TARGET_CFLAGS += -flax-vector-conversions
-endif
+# Conditional features derived from Config.in
+MESON_ARGS += -Dpam=$(if $(CONFIG_OCSERV_PAM),enabled,disabled)
+MESON_ARGS += -Dradius=$(if $(CONFIG_OCSERV_RADIUS),enabled,disabled)
+MESON_ARGS += -Dseccomp=$(if $(CONFIG_OCSERV_SECCOMP),enabled,disabled)
+MESON_ARGS += -Dlocal-protobuf=$(if $(CONFIG_OCSERV_PROTOBUF),false,true)
+MESON_ARGS += -Dliboath=$(if $(CONFIG_OCSERV_LIBOATH),enabled,disabled)
 
 define Package/ocserv/conffiles
 /etc/config/ocserv
@@ -100,18 +76,25 @@ endef
 
 define Package/ocserv/install
 	$(INSTALL_DIR) $(1)/usr/sbin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/ocserv $(1)/usr/sbin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/ocserv-worker $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/ocserv $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/ocserv-worker $(1)/usr/sbin/
+
 	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/ocserv-fw $(1)/usr/bin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/ocpasswd/ocpasswd $(1)/usr/bin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/occtl/occtl $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/ocpasswd $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/occtl $(1)/usr/bin/
+
+	$(INSTALL_DIR) $(1)/usr/libexec
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/libexec/ocserv-fw $(1)/usr/libexec/
+
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/ocserv.init $(1)/etc/init.d/ocserv
+
 	$(INSTALL_DIR) $(1)/etc/ocserv
 	$(INSTALL_CONF) ./files/ocserv.conf.template $(1)/etc/ocserv/ocserv.conf.template
+
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_CONF) ./files/config $(1)/etc/config/ocserv
+
 	$(INSTALL_DIR) $(1)/lib/upgrade/keep.d
 	$(INSTALL_DATA) ./files/ocserv.upgrade $(1)/lib/upgrade/keep.d/ocserv
 endef

--- a/net/ocserv/patches/000-disable-tests.patch
+++ b/net/ocserv/patches/000-disable-tests.patch
@@ -1,0 +1,17 @@
+From 0872708eae9f223bb507d8a3fafd2264d25d71d3 Mon Sep 17 00:00:00 2001
+From: SunnyQeen <sunnyqeen@gmail.com>
+Date: Thu, 3 Sep 2026 23:21:53 +0200
+Subject: Disable tests
+
+
+--- a/meson.build
++++ b/meson.build
+@@ -421,7 +421,7 @@ common_inc = include_directories('src/co
+ 
+ subdir('src')
+ subdir('doc')
+-subdir('tests')
++# subdir('tests')
+ 
+ # --------------------------------------------------------------------------
+ # Dist: pre-generate files that autotools used to ship via EXTRA_DIST


### PR DESCRIPTION
switch to meson build system
disable sock-diag which is not enabled in openwrt kernel
drop the arm build workaround
disable tests via patch file

**Maintainer:** @nmav 
