### PR TITLE
acme-acmesh: update to 3.1.4

### DIFF
--- a/net/acme-acmesh/Makefile
+++ b/net/acme-acmesh/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=acme-acmesh
-PKG_VERSION:=3.1.3
-PKG_RELEASE:=3
+PKG_VERSION:=3.1.4
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/acmesh-official/acme.sh/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=efd12b265252f8875269960b6b31830731ccce2b3e6ff8e7ecfbee21fde35ab4
+PKG_HASH:=e5f8e187bbf5251e0cd8891f2622daab9850366bd17bea9f92c2fe2ee091fd32
 PKG_BUILD_DIR:=$(BUILD_DIR)/acme.sh-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Toke Høiland-Jørgensen <toke@toke.dk>


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @tohojo

**Description:**
Update `acme-acmesh` to upstream version 3.1.4.

Release notes: https://github.com/acmesh-official/acme.sh/releases/tag/3.1.4

Among other fixes, this updates the `selfhost.de` DNS API endpoint to `https://account.selfhost.de/cgi-bin/api.pl`.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** N/A (architecture-independent shell script)
- **OpenWrt Target/Subtarget:** all
- **OpenWrt Device:** all

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.