### PR TITLE
radicale3: bump version to v3.8.0

### DIFF
--- a/net/radicale3/Makefile
+++ b/net/radicale3/Makefile
@@ -4,7 +4,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=radicale3
-PKG_VERSION:=3.7.8
+PKG_VERSION:=3.8.0
 PKG_RELEASE:=1
 
 PKG_LICENSE:=GPL-3.0-or-later
@@ -13,7 +13,7 @@ PKG_CPE_ID:=cpe:/a:radicale:radicale
 
 PYPI_NAME:=Radicale
 PYPI_SOURCE_NAME:=radicale
-PKG_HASH:=8b7345606bf13ded08dc81d4fddefbbe3461baa11b2fe77caba355a0978f8e9c
+PKG_HASH:=5969cea023db339be7363f3b512a569e857d00ae73b30108d2f44562a6545669
 
 PKG_MAINTAINER:=Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>
 


### PR DESCRIPTION

## 📦 Package Details

**Maintainer:** @danielfdickinson 

**Description:**
GitHub release page: https://github.com/Kozea/Radicale/releases/tag/v3.8.0

As usual, Radicale is a messy upstream as the release title illustrates:

>3.8.0 Features+Fixes+Improvements+Adjutments[sic]+Extensions

For details, see the release page (above).

---

## 🧪 Run Testing Details

- **OpenWrt Version:** OpenWrt SNAPSHOT r36048-2b263a395
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** OpenWrt One

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
