### PR TITLE
olsrd: register ubus object per address family

### DIFF
--- a/net/olsrd/Makefile
+++ b/net/olsrd/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=olsrd
 PKG_SOURCE_DATE:=2024-06-09
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/OLSR/olsrd.git

--- a/net/olsrd/files/olsrd6.init
+++ b/net/olsrd/files/olsrd6.init
@@ -52,6 +52,8 @@ start_service() {
 
 	procd_set_param command "$BIN"
 	procd_append_param command -f ${CONF}
+	# force IpVersion 6, the config does not set it
+	procd_append_param command -ipv6
 	procd_append_param command -nofork
 	procd_append_param command -pidfile ${PID}
 

--- a/net/olsrd/src/src/ubus.c
+++ b/net/olsrd/src/src/ubus.c
@@ -180,6 +180,11 @@ static struct ubus_object olsrd_object = {
 static bool ubus_init_object() {
   int ret;
 
+  // one daemon per address family is a common setup, and two of them cannot
+  // both be "olsrd" on the bus
+  if (olsr_cnf->ip_version == AF_INET6)
+    olsrd_object.name = "olsrd6";
+
   ret = ubus_add_object(shared_ctx, &olsrd_object);
   if (ret) {
     olsr_syslog(OLSR_LOG_ERR, "Failed to add object: %s\n", ubus_strerror(ret));

--- a/net/wg-installer/Makefile
+++ b/net/wg-installer/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wg-installer
-PKG_RELEASE:=28
+PKG_RELEASE:=29
 
 PKG_MAINTAINER:=Nick Hainke <vincent@systemli.org>
 

--- a/net/wg-installer/test-version.sh
+++ b/net/wg-installer/test-version.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# shellcheck shell=busybox
+
+# Every executable in these packages is a shell script without a version
+# flag, so nothing can print PKG_VERSION for the generic check.
+case "$1" in
+wg-installer-server|wg-installer-server-hotplug-*|wg-installer-client)
+	echo "$1: shell scripts without a version flag, version $2 not probed"
+	;;
+*)
+	echo "Untested package: $1" >&2
+	exit 1
+	;;
+esac

--- a/net/wg-installer/test.sh
+++ b/net/wg-installer/test.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+# The CI sandbox has no wireguard module, no rpcd session and no peer, so
+# only exercise what runs before a tunnel is created.
+
+case "$1" in
+wg-installer-server)
+	/usr/libexec/rpcd/wginstaller list | grep '"register"'
+	;;
+wg-installer-server-hotplug-olsrd|wg-installer-server-hotplug-babeld)
+	h=/etc/hotplug.d/net/99-mesh-${1#wg-installer-server-hotplug-}
+	# a non-wireguard device and a wireguard device outside the wg_ name
+	# space must both be ignored without touching ubus
+	DEVTYPE=bridge ACTION=add INTERFACE=wg_1 sh "$h" &&
+	DEVTYPE=wireguard ACTION=add INTERFACE=wg0 sh "$h"
+	;;
+wg-installer-client)
+	sh -n /usr/bin/wg-client-installer &&
+	sh -n /usr/share/wginstaller/rpcd_ubus.sh &&
+	sh -n /usr/share/wginstaller/wg.sh
+	;;
+*)
+	exit 1
+	;;
+esac

--- a/net/wg-installer/wg-server/hotplug.d/99-mesh-olsrd
+++ b/net/wg-installer/wg-server/hotplug.d/99-mesh-olsrd
@@ -11,10 +11,15 @@ if [ "${slicedint}" != "wg_" ]; then
 	exit 0
 fi
 
-if [ "${ACTION}" = "add" ]; then
-	ubus call olsrd add_interface '{"ifname":'\""$INTERFACE"\"'}'
-fi
+case "${ACTION}" in
+	add) method=add_interface ;;
+	remove) method=del_interface ;;
+	*) exit 0 ;;
+esac
 
-if [ "${ACTION}" = "remove" ]; then
-	ubus call olsrd del_interface '{"ifname":'\""$INTERFACE"\"'}'
-fi
+# the IPv4 daemon registers as olsrd, the IPv6 one as olsrd6; a node may run
+# either or both, so talk to every one that is on the bus
+for obj in olsrd olsrd6; do
+	ubus -S list "$obj" | grep -qx "$obj" || continue
+	ubus call "$obj" "$method" '{"ifname":'\""$INTERFACE"\"'}'
+done


### PR DESCRIPTION

## 📦 Package Details

**Maintainer:** @PolynomialDivision 


**Description:**
The ubus object is announced as "olsrd" no matter which address family the daemon runs, so a node that runs one daemon per family - olsrd and olsrd6, as the two init scripts in this package are meant for - gets the object registered by whichever came up first and "Failed to add object: Invalid argument" from the other. The interfaces of that second daemon can then only be reached by restarting it.

Name the object after the daemon: olsrd for IPv4, olsrd6 for IPv6.

This PR also contains changes to wg-installer (for supporting interface additions on both olsrd and olsrd6 daemons) and a fix that makes the olsrd6 daemon actually start in IPv6 mode.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** main ca7f2b898f
- **OpenWrt Target/Subtarget:** x86-64
- **OpenWrt Device:** generic on qemu

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
