### PR TITLE
[25.12] c-ares: bump to 1.34.8

### DIFF
--- a/libs/c-ares/Makefile
+++ b/libs/c-ares/Makefile
@@ -9,12 +9,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=c-ares
-PKG_VERSION:=1.34.6
+PKG_VERSION:=1.34.8
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/c-ares/c-ares/releases/download/v$(PKG_VERSION)
-PKG_HASH:=912dd7cc3b3e8a79c52fd7fb9c0f4ecf0aaa73e45efda880266a2d6e26b84ef5
+PKG_HASH:=c222b6d681096f9444d2c4863d2c1174019e27cacca0a4a5c114d36dd7d7bf78
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE.md


### PR DESCRIPTION
Update c-ares from 1.34.6 to 1.34.8.

The update includes the security fixes released in 1.34.7:

* CVE-2026-33630 (GHSA-6wfj-rwm7-3542): use-after-free / double-free in query-completion handling.
* CVE-2026-69184 (GHSA-pjmc-gx33-gc76): CPU-exhaustion denial of service via unbounded DNS name compression pointer chains.
* CVE-2026-69186 (GHSA-jv8r-gqr9-68wj): memory-amplification denial of service via unvalidated DNS header record counts.

Version 1.34.7 also fixes the UDP socket exhaustion regression introduced in 1.34.6.

Version 1.34.8 reverts the callback parameter const changes introduced in 1.34.7, which caused an unintended API break.

## 📦 Package Details

Maintainer: @karlp

## 🧪 Run Testing Details

* OpenWrt Version: 25.12.5
* OpenWrt Target/Subtarget: mediatek/filogic
* OpenWrt Device: netcraze_nc-1812

I have also been running c-ares 1.34.8 in regular use on OpenWrt with `https-dns-proxy` and have not observed any issues.

The package I have been using is available here:
https://github.com/karen07/c-ares-openwrt-package
