### PR TITLE
watchcat: fix interface resolution race

### DIFF
--- a/utils/watchcat/Makefile
+++ b/utils/watchcat/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=watchcat
 PKG_VERSION:=1
-PKG_RELEASE:=25
+PKG_RELEASE:=26
 
 PKG_MAINTAINER:=Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>, Dharmik Parmar <dharmikparmar2004@yahoo.com>
 PKG_LICENSE:=GPL-2.0
@@ -43,6 +43,8 @@ define Package/watchcat/install
 	$(INSTALL_DATA) ./files/watchcat.config $(1)/etc/config/watchcat
 	$(INSTALL_DIR) $(1)/etc/uci-defaults
 	$(INSTALL_BIN) ./files/migrate-watchcat $(1)/etc/uci-defaults/migrate-watchcat
+	$(INSTALL_DIR) $(1)/lib/functions
+	$(INSTALL_DATA) ./files/watchcat.sh.functions $(1)/lib/functions/watchcat.sh
 endef
 
 $(eval $(call BuildPackage,watchcat))

--- a/utils/watchcat/files/watchcat.init
+++ b/utils/watchcat/files/watchcat.init
@@ -9,6 +9,9 @@ USE_PROCD=1
 START=97
 STOP=01
 
+# shellcheck source=/dev/null
+. /lib/functions/watchcat.sh
+
 append_string() {
 	varname="$1"
 	add="$2"
@@ -142,10 +145,55 @@ config_watchcat() {
 }
 
 start_service() {
+	# procd expects $1 to be a specific instance
+	if [ "$2" = "ifup-any" ]; then
+		logger -p daemon.notice -t "watchcat[$$]" "Restarting due to an interface up with any unresolved interface."
+	fi
+
 	config_load watchcat
 	config_foreach config_watchcat watchcat
 }
 
+# Setup trigger in procd for changes to specified network interface
+add_interface_trigger() {
+	local section="$1"
+	local ret=1
+	local interface mode logical
+
+	config_get mode "$section" mode "ping_reboot"
+	config_get interface "$section" interface
+
+	# Fix potential typo in mode and provide backward compatibility.
+	[ "$mode" = "allways" ] && mode="periodic_reboot"
+	[ "$mode" = "always" ] && mode="periodic_reboot"
+	[ "$mode" = "ping" ] && mode="ping_reboot"
+
+	# ping_reboot mode and restart_iface mode specific checks
+	if [ "$mode" = "ping_reboot" ] || [ "$mode" = "restart_iface" ] || [ "$mode" = "run_script" ]; then
+		[ -n "$interface" ] || return
+
+		logical="$(watchcat_resolve_restart_iface "$interface")"
+		ret=$?
+
+		if [ -n "$logical" ] && [ "$ret" -eq 0 ]; then
+			procd_add_interface_trigger "interface.*.up" "$logical" "/etc/init.d/watchcat" "restart"
+		else
+			has_failed_interface_resolve="true"
+		fi
+	fi
+}
+
 service_triggers() {
+	local has_failed_interface_resolve="false"
+
 	procd_add_reload_trigger "watchcat"
+
+	config_load watchcat
+	config_foreach add_interface_trigger watchcat
+
+	if [ "$has_failed_interface_resolve" = "true" ]; then
+		# PROCD_RELOAD_DELAY is defined in /lib/functions/procd.sh, sourced by /etc/rc.common on the live device
+		# procd expects parameter after script action (here, restart) to be a specific instance
+		procd_add_raw_trigger "interface.*.up" "$PROCD_RELOAD_DELAY" "/etc/init.d/watchcat" "restart" "" "ifup-any"
+	fi
 }

--- a/utils/watchcat/files/watchcat.init
+++ b/utils/watchcat/files/watchcat.init
@@ -1,5 +1,9 @@
 #!/bin/sh /etc/rc.common
 
+# In recent (relevant) versions of shellcheck busybox is a valid shell type
+# shellcheck shell=busybox
+
+# shellcheck disable=SC2034
 USE_PROCD=1
 
 START=97
@@ -19,12 +23,13 @@ append_string() {
 time_to_seconds() {
 	time=$1
 
-	{ [ "$time" -ge 1 ] 2> /dev/null && seconds="$time"; } ||
-		{ [ "${time%s}" -ge 1 ] 2> /dev/null && seconds="${time%s}"; } ||
-		{ [ "${time%m}" -ge 1 ] 2> /dev/null && seconds=$((${time%m} * 60)); } ||
-		{ [ "${time%h}" -ge 1 ] 2> /dev/null && seconds=$((${time%h} * 3600)); } ||
-		{ [ "${time%d}" -ge 1 ] 2> /dev/null && seconds=$((${time%d} * 86400)); }
+	{ [ "$time" -ge 1 ] 2>/dev/null && seconds="$time"; } ||
+		{ [ "${time%s}" -ge 1 ] 2>/dev/null && seconds="${time%s}"; } ||
+		{ [ "${time%m}" -ge 1 ] 2>/dev/null && seconds=$((${time%m} * 60)); } ||
+		{ [ "${time%h}" -ge 1 ] 2>/dev/null && seconds=$((${time%h} * 3600)); } ||
+		{ [ "${time%d}" -ge 1 ] 2>/dev/null && seconds=$((${time%d} * 86400)); }
 
+	# shellcheck disable=SC2086
 	echo $seconds
 	unset seconds
 	unset time
@@ -74,6 +79,7 @@ config_watchcat() {
 				append_string "warn" "pingperiod cannot be a negative value." "; "
 			fi
 
+			# shellcheck disable=SC2154
 			if [ "$mmifacename" != "null" ] && [ "$period" -lt 30 ]; then
 				append_string "error" "Check interval is less than 30s. For robust operation with ModemManager modem interfaces it is recommended to set the period to at least 30s."
 			fi
@@ -105,12 +111,14 @@ config_watchcat() {
 		;;
 	ping_reboot)
 		procd_open_instance "watchcat_${1}"
+		# shellcheck disable=SC2154
 		procd_set_param command /usr/bin/watchcat.sh "ping_reboot" "$period" "$forcedelay" "$pinghosts" "$pingperiod" "$pingsize" "$addressfamily" "$interface"
 		procd_set_param respawn "${respawn_threshold:-3600}" "${respawn_timeout:-5}" "${respawn_retry:-5}"
 		procd_close_instance
 		;;
 	restart_iface)
 		procd_open_instance "watchcat_${1}"
+		# shellcheck disable=SC2154
 		procd_set_param command /usr/bin/watchcat.sh \
 			"restart_iface" "$period" "$pinghosts" "$pingperiod" \
 			"$pingsize" "$interface" "$mmifacename" "$unlockbands" \

--- a/utils/watchcat/files/watchcat.sh
+++ b/utils/watchcat/files/watchcat.sh
@@ -6,6 +6,10 @@
 # This is free software, licensed under the GNU General Public License v2.
 #
 
+# In recent (relevant) versions of shellcheck busybox is a valid shell type
+# shellcheck shell=busybox
+
+# shellcheck source=/dev/null
 . /lib/network/config.sh
 . /lib/functions/network.sh
 
@@ -105,6 +109,7 @@ get_ping_size() {
 		echo "Corresponding ping packet sizes (bytes): small=1, windows=32, standard=56, big=248, huge=1492, jumbo=9000" 1>&2
 		;;
 	esac
+	# shellcheck disable=SC2086
 	echo $ps
 }
 
@@ -124,6 +129,7 @@ get_ping_family_flag() {
 		echo "Error: invalid address_family \"$family\". address_family should be one of: any, ipv4, ipv6" 1>&2
 		;;
 	esac
+	# shellcheck disable=SC2086
 	echo $family
 }
 
@@ -132,8 +138,8 @@ reboot_now() {
 
 	[ "$1" -ge 1 ] && {
 		sleep "$1"
-		echo 1 > /proc/sys/kernel/sysrq
-		echo b > /proc/sysrq-trigger # Will immediately reboot the system without syncing or unmounting your disks.
+		echo 1 >/proc/sys/kernel/sysrq
+		echo b >/proc/sysrq-trigger # Will immediately reboot the system without syncing or unmounting your disks.
 	}
 }
 
@@ -234,12 +240,14 @@ watchcat_monitor_network() {
 		for host in $ping_hosts; do
 			if [ "$ping_iface" != "" ]; then
 				ping_result="$(
-					ping $ping_family -I "$ping_iface" -s "$ping_size" -c 1 "$host" &> /dev/null
+					# shellcheck disable=SC2086
+					ping $ping_family -I "$ping_iface" -s "$ping_size" -c 1 "$host" &>/dev/null
 					echo $?
 				)"
 			else
 				ping_result="$(
-					ping $ping_family -s "$ping_size" -c 1 "$host" &> /dev/null
+					# shellcheck disable=SC2086
+					ping $ping_family -s "$ping_size" -c 1 "$host" &>/dev/null
 					echo $?
 				)"
 			fi
@@ -336,12 +344,14 @@ watchcat_ping() {
 		for host in $ping_hosts; do
 			if [ "$ping_iface" != "" ]; then
 				ping_result="$(
-					ping $ping_family -I "$ping_iface" -s "$ping_size" -c 1 "$host" &> /dev/null
+					# shellcheck disable=SC2086
+					ping $ping_family -I "$ping_iface" -s "$ping_size" -c 1 "$host" &>/dev/null
 					echo $?
 				)"
 			else
 				ping_result="$(
-					ping $ping_family -s "$ping_size" -c 1 "$host" &> /dev/null
+					# shellcheck disable=SC2086
+					ping $ping_family -s "$ping_size" -c 1 "$host" &>/dev/null
 					echo $?
 				)"
 			fi

--- a/utils/watchcat/files/watchcat.sh
+++ b/utils/watchcat/files/watchcat.sh
@@ -10,78 +10,7 @@
 # shellcheck shell=busybox
 
 # shellcheck source=/dev/null
-. /lib/network/config.sh
-. /lib/functions/network.sh
-
-# Accept the historical real-device input while also handling @logical
-# interface references used by other OpenWrt configs.
-watchcat_resolve_ping_iface() {
-	local iface="$1"
-	local logical device network
-
-	[ -n "$iface" ] || return 1
-
-	case "$iface" in
-	@*)
-		logical="${iface#@}"
-		[ -n "$logical" ] || return 1
-		if network_get_device device "$logical"; then
-			printf '%s\n' "$device"
-			return 0
-		fi
-		printf '%s\n' "$iface"
-		return 1
-		;;
-	esac
-
-	network="$(find_config "$iface")"
-	if [ -n "$network" ]; then
-		printf '%s\n' "$iface"
-		return 0
-	fi
-
-	if network_get_device device "$iface"; then
-		printf '%s\n' "$device"
-		return 0
-	fi
-
-	printf '%s\n' "$iface"
-	return 1
-}
-
-watchcat_resolve_restart_iface() {
-	local iface="$1"
-	local network device
-
-	[ -n "$iface" ] || return 1
-
-	case "$iface" in
-	@*)
-		network="${iface#@}"
-		[ -n "$network" ] || return 1
-		if ! network_get_device device "$network"; then
-			printf '%s\n' "$network"
-			return 1
-		fi
-		printf '%s\n' "$network"
-		return 0
-		;;
-	esac
-
-	network="$(find_config "$iface")"
-	if [ -n "$network" ]; then
-		printf '%s\n' "$network"
-		return 0
-	fi
-
-	if network_get_device device "$iface"; then
-		printf '%s\n' "$iface"
-		return 0
-	fi
-
-	printf '%s\n' "$iface"
-	return 1
-}
+. /lib/functions/watchcat.sh
 
 get_ping_size() {
 	ps=$1

--- a/utils/watchcat/files/watchcat.sh.functions
+++ b/utils/watchcat/files/watchcat.sh.functions
@@ -1,0 +1,82 @@
+#!/bin/sh
+# Shebang line included so editors and shellcheck/shfmt know this contains
+# shell code
+
+# In recent (relevant) versions of shellcheck busybox is a valid shell type
+# shellcheck shell=busybox
+
+# Helper functions for watchcat
+
+# shellcheck source=/dev/null
+. /lib/network/config.sh
+. /lib/functions/network.sh
+
+# Accept the historical real-device input while also handling @logical
+# interface references used by other OpenWrt configs.
+watchcat_resolve_ping_iface() {
+	local iface="$1"
+	local logical device network
+
+	[ -n "$iface" ] || return 1
+
+	case "$iface" in
+	@*)
+		logical="${iface#@}"
+		[ -n "$logical" ] || return 1
+		if network_get_device device "$logical"; then
+			printf '%s\n' "$device"
+			return 0
+		fi
+		printf '%s\n' "$iface"
+		return 1
+		;;
+	esac
+
+	network="$(find_config "$iface")"
+	if [ -n "$network" ]; then
+		printf '%s\n' "$iface"
+		return 0
+	fi
+
+	if network_get_device device "$iface"; then
+		printf '%s\n' "$device"
+		return 0
+	fi
+
+	printf '%s\n' "$iface"
+	return 1
+}
+
+watchcat_resolve_restart_iface() {
+	local iface="$1"
+	local network device
+
+	[ -n "$iface" ] || return 1
+
+	case "$iface" in
+	@*)
+		network="${iface#@}"
+		[ -n "$network" ] || return 1
+		if ! network_get_device device "$network"; then
+			printf '%s\n' "$network"
+			return 1
+		fi
+		printf '%s\n' "$network"
+		return 0
+		;;
+	esac
+
+	network="$(find_config "$iface")"
+	if [ -n "$network" ]; then
+		printf '%s\n' "$network"
+		return 0
+	fi
+
+	if network_get_device device "$iface"; then
+		printf '%s\n' "$iface"
+		return 0
+	fi
+
+	printf '%s\n' "$iface"
+	return 1
+}


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @danielfdickinson @dhrm1k

**Description:**
Fixes the interface resolution race described in #30463:

- Add interface trigger handling in watchcat.init
- Log when raw interface trigger is activated by any interface coming up
- Move helper functions to separate file
- Update Makefile to install new functions file

While we are at it (to help reduce code errors):

We use shellcheck even though it is pedantic to assist in reducing
errors. Therefore, we add shellcheck directives to silence false
positives. We keep changes minimal as some shellcheck suggestions
result in watchcat failing to function properly.

    
Also make formatting shmt clean (using -ln=bash due to ash constructs
that shfmt 3.8.0 does not accept for posix shells including busybox).

Closes: #30463

---

## 🧪 Run Testing Details

- **OpenWrt Version:** OpenWrt SNAPSHOT r36072-f1a3f07139
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** OpenWrt One

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
