### PR TITLE
umurmur: Update to 0.4.1

### DIFF
--- a/net/umurmur/Makefile
+++ b/net/umurmur/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=umurmur
-PKG_VERSION:=0.3.1
-PKG_RELEASE:=2
+PKG_VERSION:=0.4.1
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/umurmur/umurmur/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=8327dd0b2c5bd187a38d098295e896a6b85d698c9268205bcb27f6244f760a73
+PKG_HASH:=e54e302a31d7ff4197ea6c77742b791d6ea508e0c60c955795f5195f0bec2edc
 
 PKG_MAINTAINER:=Martin Johansson <martin@fatbob.nu>
 PKG_LICENSE:=BSD-3-Clause
@@ -81,7 +81,8 @@ CMAKE_OPTIONS += \
 	-DLIBCONFIG_LIB_DIR="$(STAGING_DIR)/usr/lib" \
 	-DPROTOBUFC_INCLUDE_DIR="$(STAGING_DIR)/usr/include" \
 	-DPROTOBUFC_LIBRARIES="$(STAGING_DIR)/usr/lib/libprotobuf-c.so" \
-	-DPROTOBUFC_LIB_DIR="$(STAGING_DIR)/usr/lib"
+	-DPROTOBUFC_LIB_DIR="$(STAGING_DIR)/usr/lib" \
+	-DCMAKE_INSTALL_BINDIR=sbin
 
 ifeq ($(BUILD_VARIANT),openssl)
 CMAKE_OPTIONS += -DSSL=openssl


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @fatbob313 

**Description:**
Mumble voicechat server. Update from 0.3.1 to 0.4.1. See https://github.com/umurmur/umurmur/blob/master/CHANGELOG.md

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12.5
- **OpenWrt Target/Subtarget:**  mediatek/filogic
- **OpenWrt Device:** GL.iNet GL-MT6000
---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

