### PR TITLE
ufp: add ucode-mod-rtnl as dependency

### DIFF
--- a/utils/ufp/Makefile
+++ b/utils/ufp/Makefile
@@ -26,7 +26,13 @@ define Package/ufp
   SECTION:=utils
   CATEGORY:=Utilities
   TITLE:=Device fingerprinting daemon
-  DEPENDS:=+ucode +ucode-mod-fs +ucode-mod-struct +libubox +udhcpsnoop +unetmsg
+  DEPENDS:= \
+  	    +ucode \
+  	    +ucode-mod-fs \
+  	    +ucode-mod-struct \
+  	    +libubox \
+  	    +udhcpsnoop \
+  	    +unetmsg
 endef
 
 define Package/ufp-neigh

--- a/utils/ufp/Makefile
+++ b/utils/ufp/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ufp
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>

--- a/utils/ufp/Makefile
+++ b/utils/ufp/Makefile
@@ -30,6 +30,7 @@ define Package/ufp
   	    +ucode \
   	    +ucode-mod-fs \
   	    +ucode-mod-struct \
+  	    +ucode-mod-rtnl \
   	    +libubox \
   	    +udhcpsnoop \
   	    +unetmsg


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @feckert 


**Description:**
We need `ucode-mod-rtnl`as a dependency, because it is used in ufp.
This was forgotten in previous commits.

https://github.com/openwrt/luci/pull/7931#issuecomment-5546297297
<!-- Briefly describe what this package does or what changes are introduced -->

---

## 🧪 Run Testing Details

- **OpenWrt Version:** openwrt-25.12
- **OpenWrt Target/Subtarget:** x86/64

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.