### PR TITLE
librespeed: fix the kconfig recursion between common and the clients

### DIFF
--- a/utils/librespeed-cli-rust/Makefile
+++ b/utils/librespeed-cli-rust/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=librespeed-cli-rust
 PKG_VERSION:=0.1.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/BKPepe/speedtest-cli-rust/tar.gz/refs/tags/v$(PKG_VERSION)?
@@ -32,7 +32,7 @@ define Package/librespeed-cli-rust
   TITLE:=Command line client for LibreSpeed (Rust)
   URL:=https://github.com/BKPepe/speedtest-cli-rust
   DEPENDS:=$(RUST_ARCH_DEPENDS) +libopenssl
-  PROVIDES:=librespeed-cli
+  PROVIDES:=@librespeed-cli-any
   CONFLICTS:=librespeed-cli
 endef
 

--- a/utils/librespeed-common/Makefile
+++ b/utils/librespeed-common/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=librespeed-common
 PKG_VERSION:=1.0.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=GPL-2.0-only
@@ -21,8 +21,9 @@ define Package/librespeed-common
   SECTION:=utils
   CATEGORY:=Utilities
   TITLE:=LibreSpeed measurement orchestration
-  DEPENDS:=+librespeed-cli +rpcd-mod-ucode +jsonfilter +ucode +ucode-mod-fs \
-	+ucode-mod-uci +jshn
+  DEPENDS:=+PACKAGE_librespeed-cli:librespeed-cli \
+	+!PACKAGE_librespeed-cli:librespeed-cli-rust \
+	+rpcd-mod-ucode +jsonfilter +ucode +ucode-mod-fs +ucode-mod-uci +jshn
   PKGARCH:=all
 endef
 


### PR DESCRIPTION
Fixes the recursive dependency kconfig reports since librespeed-common was merged:

```
symbol PACKAGE_librespeed-cli-rust depends on PACKAGE_librespeed-cli
symbol PACKAGE_librespeed-cli is selected by PACKAGE_librespeed-common
symbol PACKAGE_librespeed-common depends on PACKAGE_librespeed-cli-rust
```

`librespeed-cli-rust` provided the name of a real package, so `librespeed-cli`
had two providers. For a `+` dependency on such a name, package-metadata.pl
re-emits the default provider's architecture gate under a condition that names
the consuming package, which kconfig reads as a self-dependency. The same error
is minted again for luci-app-librespeed.

The provide becomes virtual and unversioned, as package-pack.mk requires for
cross-package provides, and librespeed-common names a client directly instead
of resolving through the shared name. Both architecture gates are inherited
from the clients, so no list is repeated:

```
depends on !(!PACKAGE_librespeed-cli) || (<rust arch list>)
depends on !(PACKAGE_librespeed-cli) || (<go arch list>)
select PACKAGE_librespeed-cli-rust if !PACKAGE_librespeed-cli
```

Verified in the same SDK container the CI uses, with the whole feed mounted the
way the CI mounts it: no recursion, librespeed-common is enabled and built on
both powerpc_8548 (which picks librespeed-cli-rust, the only client that builds
there) and x86_64 (which picks librespeed-cli). The packaged metadata collapses
the conditional to a single client per architecture.

Approaches that were measured and rejected: dropping the `+` leaves the package
unselectable, and the SDK then logs "Skipping librespeed-common due to
unsupported architecture" on powerpc. Moving CONFLICTS to librespeed-cli breaks
the three-way loop but leaves the direct self-dependency, because that comes
from resolving a name with two providers rather than from CONFLICTS.

CONFLICTS stays: both packages install /usr/bin/librespeed-cli.
