### PR TITLE
sing-box: bump to 1.14.0

### DIFF
--- a/net/sing-box/Makefile
+++ b/net/sing-box/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sing-box
-PKG_VERSION:=1.13.21
+PKG_VERSION:=1.14.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/SagerNet/sing-box/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=c994018d7c2a8fc9fcf6080e4b9cc4f2f915e755342238b77e46fc0806fe96db
+PKG_HASH:=87baf6852e37941cbe40bdd94bec81c957c88a56751cecd6bbf0e6108bc69398
 
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_LICENSE_FILES:=LICENSE
@@ -71,6 +71,9 @@ define Package/sing-box/config
 			bool "Build with Clash API support"
 			default y
 
+		config SINGBOX_WITH_CLOUDFLARED
+			bool "Build with Cloudflare Tunnel inbound support"
+
 		config SINGBOX_WITH_DHCP
 			bool "Build with DHCP support, see DHCP DNS transport."
 
@@ -87,6 +90,12 @@ define Package/sing-box/config
 		config SINGBOX_WITH_OCM
 			bool "Build with OpenAI Codex Multiplexer service support"
 
+		config SINGBOX_WITH_OPENCONNECT
+			bool "Build with OpenConnect client support"
+
+		config SINGBOX_WITH_OPENVPN
+			bool "Build with OpenVPN client and server support"
+
 		config SINGBOX_WITH_QUIC
 			bool "Build with QUIC support"
 			default y
@@ -94,6 +103,9 @@ define Package/sing-box/config
 		config SINGBOX_WITH_TAILSCALE
 			bool "Build with Tailscale support"
 			default y
+
+		config SINGBOX_WITH_USBIP
+			bool "Build with USB/IP service support"
 
 		config SINGBOX_WITH_UTLS
 			bool "Build with uTLS support for TLS outbound"
@@ -112,13 +124,17 @@ PKG_CONFIG_DEPENDS:= \
 	CONFIG_SINGBOX_WITH_ACME \
 	CONFIG_SINGBOX_WITH_CCM \
 	CONFIG_SINGBOX_WITH_CLASH_API \
+	CONFIG_SINGBOX_WITH_CLOUDFLARED \
 	CONFIG_SINGBOX_WITH_DHCP \
 	CONFIG_SINGBOX_WITH_EMBEDDED_TOR \
 	CONFIG_SINGBOX_WITH_GRPC \
 	CONFIG_SINGBOX_WITH_GVISOR \
 	CONFIG_SINGBOX_WITH_OCM \
+	CONFIG_SINGBOX_WITH_OPENCONNECT \
+	CONFIG_SINGBOX_WITH_OPENVPN \
 	CONFIG_SINGBOX_WITH_QUIC \
 	CONFIG_SINGBOX_WITH_TAILSCALE \
+	CONFIG_SINGBOX_WITH_USBIP \
 	CONFIG_SINGBOX_WITH_UTLS \
 	CONFIG_SINGBOX_WITH_V2RAY_API \
 	CONFIG_SINGBOX_WITH_WIREGUARD
@@ -133,13 +149,17 @@ GO_PKG_TAGS:=$(subst $(space),$(comma),$(strip \
 	$(if $(CONFIG_SINGBOX_WITH_ACME),with_acme) \
 	$(if $(CONFIG_SINGBOX_WITH_CCM),with_ccm) \
 	$(if $(CONFIG_SINGBOX_WITH_CLASH_API),with_clash_api) \
+	$(if $(CONFIG_SINGBOX_WITH_CLOUDFLARED),with_cloudflared) \
 	$(if $(CONFIG_SINGBOX_WITH_DHCP),with_dhcp) \
 	$(if $(CONFIG_SINGBOX_WITH_EMBEDDED_TOR),with_embedded_tor) \
 	$(if $(CONFIG_SINGBOX_WITH_GRPC),with_grpc) \
 	$(if $(CONFIG_SINGBOX_WITH_GVISOR),with_gvisor) \
 	$(if $(CONFIG_SINGBOX_WITH_OCM),with_ocm) \
+	$(if $(CONFIG_SINGBOX_WITH_OPENCONNECT),with_openconnect) \
+	$(if $(CONFIG_SINGBOX_WITH_OPENVPN),with_openvpn) \
 	$(if $(CONFIG_SINGBOX_WITH_QUIC),with_quic) \
 	$(if $(CONFIG_SINGBOX_WITH_TAILSCALE),with_tailscale) \
+	$(if $(CONFIG_SINGBOX_WITH_USBIP),with_usbip) \
 	$(if $(CONFIG_SINGBOX_WITH_UTLS),with_utls) \
 	$(if $(CONFIG_SINGBOX_WITH_V2RAY_API),with_v2ray_api) \
 	$(if $(CONFIG_SINGBOX_WITH_WIREGUARD),with_wireguard) \


### PR DESCRIPTION
Release: https://github.com/SagerNet/sing-box/releases/tag/v1.14.0

New optional features (disabled by default):
- with_cloudflared
- with_openvpn
- with_openconnect
- with_usbip

Snell protocol support is included by default
(see https://sing-box.sagernet.org/changelog/#1140).

**NOTE:** Backports to stable release branches can be considered later, once 1.14.x has mature

## 📦 Package Details

**Maintainer:**  @brvphoenix 
---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12.5
- **OpenWrt Target/Subtarget:** mediatek/filogic
- **OpenWrt Device:** Xiaomi Mi Router AX3000T

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [x] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>