### PR TITLE
xfrpc: update to 5.09.982

### DIFF
--- a/net/xfrpc/Makefile
+++ b/net/xfrpc/Makefile
@@ -8,13 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=xfrpc
-PKG_VERSION:=5.06.909
+PKG_VERSION:=5.09.982
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/liudf0716/xfrpc/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=7742bedbe929f5bfb386af2025de744aa38bc6f531e1f86a1fbb7318e3ec8f72
-PKG_BUILD_DIR:=$(BUILD_DIR)/xfrpc-$(PKG_VERSION)
+PKG_HASH:=62fa59540bcfea04289b67fdb37916904f4dac62ac799ddf8cd634949a556edc
 
 PKG_MAINTAINER:=Dengfeng Liu <liudf0716@gmail.com>
 PKG_LICENSE:=GPL-3.0-or-later


### PR DESCRIPTION
Update `xfrpc` from 5.06.909 to 5.09.982.

### Key Changes & Improvements
- **wireProtocol v2**: Add frp `transport.wireProtocol` v2 support (JSON messages + AES-256-GCM AEAD on control stream, compatible with frps >= 0.69).
- **TOML configuration**: Modern frp-compatible TOML configuration support via `tomlc17`.
- **OIDC auth**: Add OAuth2 client_credentials flow for OIDC authentication.
- **Encryption & Compression**: AES-128-CFB wire encryption and Snappy compression support.
- **QUIC maturity**: Complete ngtcp2 ↔ quic-go interop and work stream data relay handling for large payloads.
- **Security hardening**: Thorough bounds checking against received message buffer, OIDC/QUIC TLS host verification, and safe argument passing.
- **Build fixes**: Fix 32-bit architecture compilation (`uint64_t` cast before 64-bit shifts) and dual-backend support for OpenWrt wolfSSL/OpenSSL combinations.
- **Deprecations**: Removed deprecated legacy IOD and FTP proxy types.

Tested on x86_64, i386 (-m32), and aarch64.
