### PR TITLE
pdns-recursor: security update to 5.2.13

### DIFF
--- a/net/pdns-recursor/Makefile
+++ b/net/pdns-recursor/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pdns-recursor
-PKG_VERSION:=5.2.5
+PKG_VERSION:=5.2.13
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://downloads.powerdns.com/releases/
-PKG_HASH:=a8a657a7abd6e9d237cdd26753f7dcf5ccd5b8c48ac8120b08d2b8d57a1d856a
+PKG_HASH:=ee0eacc776aa48ef0be92f6b910048ee8606d1715133649806356ec38fed1e86
 
 PKG_MAINTAINER:=Peter van Dijk <peter.van.dijk@powerdns.com>, Remi Gacogne <remi.gacogne@powerdns.com>
 PKG_LICENSE:=GPL-2.0-only


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me + @Habbie 

**Description:**
This PR updates PowerDNS Recursor to 5.2.13, the latest release on the 5.2.x LTS branch.
This includes security fixes for the following issues and more: CVE-2026-24027, CVE-2026-0398, CVE-2026-33256, CVE-2026-33257, CVE-2026-33258, CVE-2026-33259, CVE-2026-33260, CVE-2026-33261, CVE-2026-33262, CVE-2026-33601, CVE-2026-33600, CVE-2026-33612, CVE-2026-40012, CVE-2026-42005, CVE-2026-42390, CVE-2026-42389, CVE-2026-42388, CVE-2026-42387, CVE-2026-52690, CVE-2026-52688, CVE-2026-52686, CVE-2026-52682.

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
