### PR TITLE
pdns: security update to 4.9.17

### DIFF
--- a/net/pdns/Makefile
+++ b/net/pdns/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pdns
-PKG_VERSION:=4.9.7
-PKG_RELEASE:=2
+PKG_VERSION:=4.9.17
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://downloads.powerdns.com/releases/
-PKG_HASH:=782875d210de20cee9f22f33ffc59ef1cdc6693c30efcb21f3ce8bf528fb09d4
+PKG_HASH:=fa20c27d754b026cb4c5c9b51c2da0d940b82a50f93f9366016b0ce9cc526a04
 
 PKG_MAINTAINER:=Peter van Dijk <peter.van.dijk@powerdns.com>, Remi Gacogne <remi.gacogne@powerdns.com>
 PKG_LICENSE:=GPL-2.0-only


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** me + @Habbie 

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->
This PR updates the PowerDNS authoritative server to 4.9.17, the latest release in the 4.9.x LTS branch.
This fixes several security issues, including but not limited to: CVE-2026-33257, CVE-2026-33260, CVE-2026-33611, CVE-2026-33610, CVE-2026-33609, CVE-2026-33608, CVE-2026-42002, CVE-2026-42001, CVE-2026-42000, CVE-2026-41999, CVE-2026-42396, CVE-2026-42005, CVE-2026-52682.

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
