### PR TITLE
openwisp-config: upgrade to 1.3.0

### DIFF
--- a/admin/openwisp-config/Makefile
+++ b/admin/openwisp-config/Makefile
@@ -5,14 +5,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openwisp-config
-PKG_VERSION:=1.2.1
+PKG_VERSION:=1.3.0
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Federico Capoano <f.capoano@openwisp.io>
 PKG_LICENSE:=GPL-3.0-or-later
 
 PKG_SOURCE_URL:=https://github.com/openwisp/openwisp-config.git
-PKG_MIRROR_HASH:=f709f3aaf2e9ad61b2df378b7e6cfae7050d5f1d8c4c4bc038e92809c843c4b7
+PKG_MIRROR_HASH:=0113649c065afff16c8c7364ce8dc36d78707720e04170164db03118c026f0df
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_VERSION:=$(PKG_VERSION)
 

--- a/admin/openwisp-config/Makefile
+++ b/admin/openwisp-config/Makefile
@@ -11,10 +11,9 @@ PKG_RELEASE:=1
 PKG_MAINTAINER:=Federico Capoano <f.capoano@openwisp.io>
 PKG_LICENSE:=GPL-3.0-or-later
 
-PKG_SOURCE_URL:=https://github.com/openwisp/openwisp-config.git
-PKG_MIRROR_HASH:=0113649c065afff16c8c7364ce8dc36d78707720e04170164db03118c026f0df
-PKG_SOURCE_PROTO:=git
-PKG_SOURCE_VERSION:=$(PKG_VERSION)
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/openwisp/$(PKG_NAME)/tar.gz/$(PKG_VERSION)?
+PKG_HASH:=f7f7d8cec2d37eff4f570e45204ad10543e109d71a2794f649bcb58f4973dfb6
 
 include $(INCLUDE_DIR)/package.mk
 


### PR DESCRIPTION
Upgrades openwisp-config package to 1.3.0

Signed-off-by: Gagan Deep pandafy.dev@gmail.com

## 📦 Package Details

**Maintainer:** @nemesifier
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**

OpenWrt config management agent of [OpenWISP](https://openwisp.org/).

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.10
- **OpenWrt Target/Subtarget:** x86
- **OpenWrt Device:** x86

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

