### PR TITLE
frp: add enable switch configuration

### DIFF
--- a/net/frp/files/frpc.config
+++ b/net/frp/files/frpc.config
@@ -1,4 +1,5 @@
 config init
+	option enabled '1'
 	option stdout '1'
 	option stderr '1'
 #	Uncomment to run frpc as an existing user/group. Keep disabled by

--- a/net/frp/files/frpc.init
+++ b/net/frp/files/frpc.init
@@ -912,6 +912,7 @@ service_triggers() {
 
 start_service() {
 	local init_cfg=
+	local enabled=1
 	local stdout=1
 	local stderr=1
 	local respawn=1
@@ -919,13 +920,26 @@ start_service() {
 	local run_group=
 	local old_umask
 
-	mkdir -p /var/etc
-	_TOML_ERR=0
-	_ALLOW_UNSAFE_TOKEN_SOURCE_EXEC=0
-
 	config_load "$NAME"
 
 	config_foreach _find_init_section init
+
+	if [ -n "$init_cfg" ]; then
+		config_list_foreach "$init_cfg" conf_inc _append_conf_file
+
+		config_get_bool enabled "$init_cfg" enabled 1
+		config_get_bool stdout "$init_cfg" stdout 1
+		config_get_bool stderr "$init_cfg" stderr 1
+		config_get_bool respawn "$init_cfg" respawn 1
+		config_get run_user "$init_cfg" user
+		config_get run_group "$init_cfg" group
+	fi
+
+	[ "$enabled" -eq 0 ] && return 1
+
+	mkdir -p /var/etc
+	_TOML_ERR=0
+	_ALLOW_UNSAFE_TOKEN_SOURCE_EXEC=0
 
 	old_umask="$(umask)"
 	umask 077
@@ -947,16 +961,6 @@ start_service() {
 		_emit_common
 	} >> "$CONF_FILE" || return 1
 	[ "$_TOML_ERR" = "0" ] || return 1
-
-	if [ -n "$init_cfg" ]; then
-		config_list_foreach "$init_cfg" conf_inc _append_conf_file
-
-		config_get_bool stdout "$init_cfg" stdout 1
-		config_get_bool stderr "$init_cfg" stderr 1
-		config_get_bool respawn "$init_cfg" respawn 1
-		config_get run_user "$init_cfg" user
-		config_get run_group "$init_cfg" group
-	fi
 
 	{
 		config_foreach _emit_conf_section conf

--- a/net/frp/files/frpc.uci-defaults
+++ b/net/frp/files/frpc.uci-defaults
@@ -79,6 +79,7 @@ upgrade_init() {
 		changed=1
 	fi
 
+	set_if_empty "$init_section" enabled 1
 	set_if_empty "$init_section" stdout 1
 	set_if_empty "$init_section" stderr 1
 	set_if_empty "$init_section" respawn 1

--- a/net/frp/files/frps.config
+++ b/net/frp/files/frps.config
@@ -1,4 +1,5 @@
 config init
+	option enabled '1'
 	option stdout '1'
 	option stderr '1'
 #	Uncomment to run frps as an existing user/group. Keep disabled by

--- a/net/frp/files/frps.init
+++ b/net/frp/files/frps.init
@@ -689,6 +689,7 @@ service_triggers() {
 
 start_service() {
 	local init_cfg=
+	local enabled=1
 	local stdout=1
 	local stderr=1
 	local respawn=1
@@ -696,13 +697,28 @@ start_service() {
 	local run_group=
 	local old_umask
 
+	config_load "$NAME"
+
+	config_foreach _find_init_section init
+
+	if [ -n "$init_cfg" ]; then
+		config_list_foreach "$init_cfg" conf_inc _append_conf_file
+
+		config_get_bool enabled "$init_cfg" enabled 1
+		config_get_bool stdout "$init_cfg" stdout 1
+		config_get_bool stderr "$init_cfg" stderr 1
+		config_get_bool respawn "$init_cfg" respawn 1
+		config_get run_user "$init_cfg" user
+		config_get run_group "$init_cfg" group
+	fi
+
+	[ "$enabled" -eq 0 ] && return 1
+
 	mkdir -p /var/etc
 	_TOML_ERR=0
 	_ALLOW_UNSAFE_TOKEN_SOURCE_EXEC=0
 
-	config_load "$NAME"
 
-	config_foreach _find_init_section init
 
 	old_umask="$(umask)"
 	umask 077
@@ -725,15 +741,7 @@ start_service() {
 	} >> "$CONF_FILE" || return 1
 	[ "$_TOML_ERR" = "0" ] || return 1
 
-	if [ -n "$init_cfg" ]; then
-		config_list_foreach "$init_cfg" conf_inc _append_conf_file
 
-		config_get_bool stdout "$init_cfg" stdout 1
-		config_get_bool stderr "$init_cfg" stderr 1
-		config_get_bool respawn "$init_cfg" respawn 1
-		config_get run_user "$init_cfg" user
-		config_get run_group "$init_cfg" group
-	fi
 
 	{
 		config_foreach _emit_http_plugin http_plugin

--- a/net/frp/files/frps.uci-defaults
+++ b/net/frp/files/frps.uci-defaults
@@ -90,6 +90,7 @@ upgrade_init() {
 		changed=1
 	fi
 
+	set_if_empty "$init_section" enabled 1
 	set_if_empty "$init_section" stdout 1
 	set_if_empty "$init_section" stderr 1
 	set_if_empty "$init_section" respawn 1


### PR DESCRIPTION
## 📦 Package Details

Support uci config options to enable/disable frpc
Signed-off-by: Kissingers Zhou [kissinger@foxmail.com](mailto:kissinger@foxmail.com)

**Description:**
Add uci config options to enable/disable frpc and frps services independently. This allows users to control service startup via /etc/config/frpc and /etc/config/frps without modifying init scripts manually.
Such as:
const startupConf = [
	[form.Flag, 'enabled', _('Enable'), null,
	{
		enabled: '1',
		disabled: '0',
		default: '1',
		rmempty: false,
		retain: true,
		remove: writeFlagDisabled,
	}],

---

## 🧪 Run Testing Details

- **OpenWrt Version: Master laster bulid**
- **OpenWrt Target/Subtarget:MediaTek MT7986A**
- **OpenWrt Device: Redme AX 6000**

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
