### PR TITLE
igmpproxy: support new phyint options in init script

### DIFF
--- a/net/igmpproxy/Makefile
+++ b/net/igmpproxy/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=igmpproxy
 PKG_VERSION:=0.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/pali/igmpproxy/releases/download/${PKG_VERSION}/

--- a/net/igmpproxy/files/igmpproxy.config
+++ b/net/igmpproxy/files/igmpproxy.config
@@ -6,9 +6,14 @@ config phyint
 	option network wan
 	option zone wan
 	option direction upstream
+#	option ratelimit 0 # the default value
+#	option threshold 1 # the default value
 	list altnet 192.168.1.0/24
+#	list whitelist 239.0.0.0/8
+#	list blacklist 239.255.255.250/32
 
 config phyint
 	option network lan
 	option zone lan
+#	option fw_drop_ssdp 1
 	option direction downstream

--- a/net/igmpproxy/files/igmpproxy.init
+++ b/net/igmpproxy/files/igmpproxy.init
@@ -23,11 +23,15 @@ igmp_header() {
 }
 
 igmp_add_phyint() {
-	local network direction altnets device up
+	local network direction ratelimit threshold altnets whitelists blacklists device up
 
 	config_get network $1 network
 	config_get direction $1 direction
+	config_get ratelimit $1 ratelimit 0
+	config_get threshold $1 threshold 1
 	config_get altnets $1 altnet
+	config_get whitelists $1 whitelist
+	config_get blacklists $1 blacklist
 
 	local status="$(ubus -S call "network.interface.$network" status)"
 	[ -n "$status" ] || return
@@ -45,12 +49,26 @@ igmp_add_phyint() {
 
 	[ "$direction" = "upstream" ] && has_upstream=1
 
-	echo -e "\nphyint $device $direction ratelimit 0 threshold 1" >> /var/etc/igmpproxy.conf
+	echo -e "\nphyint $device $direction ratelimit $ratelimit threshold $threshold" >> /var/etc/igmpproxy.conf
 
 	if [ -n "$altnets" ]; then
 		local altnet
 		for altnet in $altnets; do
 			echo -e "\taltnet $altnet" >> /var/etc/igmpproxy.conf
+		done
+	fi
+
+	if [ -n "$whitelists" ]; then
+		local whitelist
+		for whitelist in $whitelists; do
+			echo -e "\twhitelist $whitelist" >> /var/etc/igmpproxy.conf
+		done
+	fi
+
+	if [ -n "$blacklists" ]; then
+		local blacklist
+		for blacklist in $blacklists; do
+			echo -e "\tblacklist $blacklist" >> /var/etc/igmpproxy.conf
 		done
 	fi
 }
@@ -65,22 +83,24 @@ igmp_add_network() {
 igmp_add_firewall_routing() {
 	config_get direction $1 direction
 	config_get zone $1 zone
+	config_get_bool fw_drop_ssdp $1 fw_drop_ssdp 1
 
 	if [ "$direction" != "downstream" ] || [ -z "$zone" ]; then
 		return 0
 	fi
 
-# First drop SSDP packets then accept all other multicast
-
-	json_add_object ""
-	json_add_string type rule
-	json_add_string src "$upstream"
-	json_add_string dest "$zone"
-	json_add_string family ipv4
-	json_add_string proto udp
-	json_add_string dest_ip "239.255.255.250"
-	json_add_string target DROP
-	json_close_object
+	if [ "$fw_drop_ssdp" = "1" ]; then
+		json_add_object ""
+		json_add_string type rule
+		json_add_string src "$upstream"
+		json_add_string dest "$zone"
+		json_add_string family ipv4
+		json_add_string proto udp
+		# SSDP IPv4 site-local address (https://en.wikipedia.org/wiki/Simple_Service_Discovery_Protocol)
+		json_add_string dest_ip "239.255.255.250"
+		json_add_string target DROP
+		json_close_object
+	fi
 
 	json_add_object ""
 	json_add_string type rule


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @nbd168

**Description:**
- made ratelimit and threshold configurable
- added whitelist and blacklist
- made SSDP firewall dropping configurable
- increase pkg release
- added commented examples in the sample config for the new options

---

## 🧪 Run Testing Details

- **OpenWrt Version:** x86
- **OpenWrt Target/Subtarget:** 64
- **OpenWrt Device:** qemu

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [x] It is structured in a way that it is potentially upstreamable
