### PR TITLE
librespeed-cli: fix upload speed being overestimated

### DIFF
--- a/utils/librespeed-cli/Makefile
+++ b/utils/librespeed-cli/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=librespeed-cli
 PKG_VERSION:=1.0.13
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/librespeed/speedtest-cli/tar.gz/v${PKG_VERSION}?

--- a/utils/librespeed-cli/patches/0013-fix-send-Content-Length-on-upload-requests-instead-o.patch
+++ b/utils/librespeed-cli/patches/0013-fix-send-Content-Length-on-upload-requests-instead-o.patch
@@ -1,0 +1,194 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: maddie <maddie@users.noreply.github.com>
+Date: Mon, 17 Aug 2026 13:13:01 +0800
+Subject: [PATCH] fix: send Content-Length on upload requests instead of
+ chunked (#143)
+
+The upload body goes through an io.TeeReader, which hides its length, so Go
+switched to Transfer-Encoding: chunked. Servers with hand-written HTTP
+parsers that never chunk-decode (librespeed-rs) read the raw stream in
+fixed-size blocks; once the finite payload is sent the stream does not end
+(the client keeps the connection open) and the block fill stalls, so the
+server never answers. The request then never completes and the upload stops
+after a single payload: 1 MiB / 15 s default duration = 0.55 Mbps
+(librespeed/speedtest-cli#122).
+
+Set an explicit Content-Length for the fixed-size payload, which every
+server handles. The --no-preallocate stream from crypto/rand stays chunked,
+which is safe: it never ends, so a raw-block reader keeps making progress.
+
+Regression test runs Upload against a raw TCP server replicating the
+librespeed-rs body handling and asserts the request carries Content-Length
+and the upload consumes more than one payload. It fails without the fix
+(server sees Content-Length 0).
+Signed-off-by: Josef Schlehofer <pepe.schlehofer@gmail.com>
+Upstream-Status: Backport [https://github.com/librespeed/speedtest-cli/commit/51fd8608256922e3c48ed0621fb001b5ad2720a0]
+
+---
+ defs/server.go      |  12 +++++
+ defs/server_test.go | 126 ++++++++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 138 insertions(+)
+
+--- a/defs/server.go
++++ b/defs/server.go
+@@ -452,6 +452,18 @@ func (s *Server) Upload(noPrealloc, sile
+ 		uploadReq.Header.Set("User-Agent", UserAgent)
+ 		uploadReq.Header.Set("Accept-Encoding", "identity")
+ 
++		if !noPrealloc {
++			// Send Content-Length instead of Transfer-Encoding: chunked. The
++			// TeeReader around the payload hides its length, so Go would
++			// otherwise switch to chunked encoding. Hand-written HTTP servers
++			// that do not decode chunked bodies (e.g. librespeed-rs) then block
++			// waiting for an EOF that never comes while the client keeps the
++			// connection open, hanging the upload after a single payload (see
++			// librespeed/speedtest-cli#122). A fixed length is the standard,
++			// universally supported form.
++			uploadReq.ContentLength = int64(uploadSize)
++		}
++
+ 		resp, err := http.DefaultClient.Do(uploadReq)
+ 		if err != nil {
+ 			if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+--- a/defs/server_test.go
++++ b/defs/server_test.go
+@@ -1,9 +1,14 @@
+ package defs
+ 
+ import (
++	"bufio"
+ 	"io"
++	"net"
+ 	"net/http"
+ 	"net/http/httptest"
++	"strconv"
++	"strings"
++	"sync/atomic"
+ 	"testing"
+ 	"time"
+ )
+@@ -118,3 +123,124 @@ func TestUploadNoPreallocReturnsWhenServ
+ 		return err
+ 	})
+ }
++
++// --- Upload against a server with librespeed-rs body semantics ---
++
++// librespeedRSLikeServer mimics the hand-written HTTP body handling of
++// librespeed/speedtest-rust: a Content-Length body is read exactly and
++// answered; a chunked body is read as a raw stream in fixed 1024-byte blocks
++// and never chunk-decoded. With a finite payload the chunked path blocks once
++// the data runs out while the client keeps the connection open — the stall
++// behind librespeed/speedtest-cli#122. It records the Content-Length header
++// and total body bytes of every request it answers.
++func librespeedRSLikeServer(t *testing.T) (*Server, *atomic.Int64, *atomic.Int64) {
++	t.Helper()
++
++	ln, err := net.Listen("tcp", "127.0.0.1:0")
++	if err != nil {
++		t.Fatalf("listen: %v", err)
++	}
++
++	var contentLength atomic.Int64
++	var bodyBytes atomic.Int64
++
++	go func() {
++		for {
++			conn, err := ln.Accept()
++			if err != nil {
++				return
++			}
++			go func(conn net.Conn) {
++				defer conn.Close()
++				br := bufio.NewReader(conn)
++				for {
++					status, err := br.ReadString('\n')
++					if err != nil {
++						return
++					}
++					if !strings.HasPrefix(strings.ToLower(status), "post ") {
++						return
++					}
++					cl := int64(0)
++					chunked := false
++					for {
++						line, err := br.ReadString('\n')
++						if err != nil {
++							return
++						}
++						line = strings.TrimRight(line, "\r\n")
++						if line == "" {
++							break
++						}
++						k, v, _ := strings.Cut(line, ":")
++						switch strings.ToLower(strings.TrimSpace(k)) {
++						case "content-length":
++							cl, _ = strconv.ParseInt(strings.TrimSpace(v), 10, 64)
++						case "transfer-encoding":
++							chunked = strings.EqualFold(strings.TrimSpace(v), "chunked")
++						}
++					}
++					contentLength.Store(cl)
++					switch {
++					case cl > 0:
++						// Fixed: read exactly cl bytes, then answer.
++						n, err := io.CopyN(io.Discard, br, cl)
++						if err != nil {
++							return
++						}
++						bodyBytes.Add(n)
++					case chunked:
++						// Chunked: read the raw stream in fixed blocks, never
++						// chunk-decoded (librespeed-rs behaviour). With a
++						// finite payload this blocks until the peer goes away.
++						buf := make([]byte, 1024)
++						for {
++							if _, err := io.ReadFull(br, buf); err != nil {
++								break
++							}
++							bodyBytes.Add(1024)
++						}
++						return
++					default:
++						return
++					}
++					if _, err := conn.Write([]byte("HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")); err != nil {
++						return
++					}
++				}
++			}(conn)
++		}
++	}()
++
++	return &Server{Server: "http://" + ln.Addr().String(), UploadURL: "/"}, &contentLength, &bodyBytes
++}
++
++// TestUploadSendsContentLength is the regression test for
++// librespeed/speedtest-cli#122: Upload must send an explicit Content-Length
++// so servers that never chunk-decode (librespeed-rs) answer instead of
++// blocking on a body that never ends. Without the fix the request goes out
++// chunked and the upload stalls after a single payload.
++func TestUploadSendsContentLength(t *testing.T) {
++	s, contentLength, bodyBytes := librespeedRSLikeServer(t)
++
++	const (
++		uploadSize = 1024 * 1024
++		duration   = 500 * time.Millisecond
++		requests   = 2
++	)
++
++	_, total, err := s.Upload(false, true, false, false, requests, uploadSize, duration)
++	if err != nil {
++		t.Fatalf("Upload returned error: %v", err)
++	}
++
++	if got := contentLength.Load(); got != uploadSize {
++		t.Errorf("server saw Content-Length %d, want %d (chunked encoding would stall it)", got, int64(uploadSize))
++	}
++	if got := bodyBytes.Load(); got <= uploadSize {
++		t.Errorf("server consumed %d bytes, want more than one %d-byte payload (upload stalled)", got, int64(uploadSize))
++	}
++	if total <= uploadSize {
++		t.Errorf("counter reported %d bytes, want more than one payload", total)
++	}
++}

--- a/utils/librespeed-cli/patches/0014-fix-set-upload-Content-Length-to-the-payload-size-no.patch
+++ b/utils/librespeed-cli/patches/0014-fix-set-upload-Content-Length-to-the-payload-size-no.patch
@@ -1,0 +1,89 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: maddie <maddie@users.noreply.github.com>
+Date: Mon, 17 Aug 2026 13:19:10 +0800
+Subject: [PATCH] fix: set upload Content-Length to the payload size, not the
+ KiB option (#144)
+
+#143 set Content-Length to the raw --upload-size option value, but
+SetUploadSize scales it by 1024, so a default 1024 KiB payload went out as
+ContentLength=1024 with a 1 MiB body. The transport rejects the mismatch
+("ContentLength=1024 with Body length 1048576"), the request fails, and
+the upload stalls at one payload again (1 MiB / 5 s = 1.61 Mbps).
+
+Use the generated payload's actual length instead. The regression test now
+uses the CLI's real unit semantics (1024 KiB -> 1 MiB payload) and asserts
+the server sees Content-Length 1048576; the previous test passed by
+accident because it fed an already-scaled uploadSize in.
+Signed-off-by: Josef Schlehofer <pepe.schlehofer@gmail.com>
+Upstream-Status: Backport [https://github.com/librespeed/speedtest-cli/commit/f56897bba3e5d98a504f36e7d759aeb62108fa6f]
+
+---
+ defs/server.go      |  6 ++++--
+ defs/server_test.go | 29 +++++++++++++++++------------
+ 2 files changed, 21 insertions(+), 14 deletions(-)
+
+--- a/defs/server.go
++++ b/defs/server.go
+@@ -460,8 +460,10 @@ func (s *Server) Upload(noPrealloc, sile
+ 			// waiting for an EOF that never comes while the client keeps the
+ 			// connection open, hanging the upload after a single payload (see
+ 			// librespeed/speedtest-cli#122). A fixed length is the standard,
+-			// universally supported form.
+-			uploadReq.ContentLength = int64(uploadSize)
++			// universally supported form. Use the payload's actual size:
++			// SetUploadSize scales the CLI's KiB option by 1024, so the request
++			// length must match the generated blob, not the option value.
++			uploadReq.ContentLength = int64(len(counter.Payload()))
+ 		}
+ 
+ 		resp, err := http.DefaultClient.Do(uploadReq)
+--- a/defs/server_test.go
++++ b/defs/server_test.go
+@@ -217,30 +217,35 @@ func librespeedRSLikeServer(t *testing.T
+ 
+ // TestUploadSendsContentLength is the regression test for
+ // librespeed/speedtest-cli#122: Upload must send an explicit Content-Length
+-// so servers that never chunk-decode (librespeed-rs) answer instead of
+-// blocking on a body that never ends. Without the fix the request goes out
+-// chunked and the upload stalls after a single payload.
++// matching the generated payload so servers that never chunk-decode
++// (librespeed-rs) answer instead of blocking on a body that never ends.
++// Without the fix the request goes out chunked and the upload stalls after a
++// single payload; with a wrong length the transport errors out the same way.
+ func TestUploadSendsContentLength(t *testing.T) {
+ 	s, contentLength, bodyBytes := librespeedRSLikeServer(t)
+ 
++	// Same units as the CLI: --upload-size N means N KiB. SetUploadSize
++	// scales by 1024, so the payload and the Content-Length must be 1 MiB,
++	// not 1024.
+ 	const (
+-		uploadSize = 1024 * 1024
+-		duration   = 500 * time.Millisecond
+-		requests   = 2
++		uploadSizeKiB = 1024
++		payloadBytes  = uploadSizeKiB * 1024
++		duration      = 500 * time.Millisecond
++		requests      = 2
+ 	)
+ 
+-	_, total, err := s.Upload(false, true, false, false, requests, uploadSize, duration)
++	_, total, err := s.Upload(false, true, false, false, requests, uploadSizeKiB, duration)
+ 	if err != nil {
+ 		t.Fatalf("Upload returned error: %v", err)
+ 	}
+ 
+-	if got := contentLength.Load(); got != uploadSize {
+-		t.Errorf("server saw Content-Length %d, want %d (chunked encoding would stall it)", got, int64(uploadSize))
++	if got := contentLength.Load(); got != payloadBytes {
++		t.Errorf("server saw Content-Length %d, want %d (chunked encoding or a wrong length stalls the upload)", got, int64(payloadBytes))
+ 	}
+-	if got := bodyBytes.Load(); got <= uploadSize {
+-		t.Errorf("server consumed %d bytes, want more than one %d-byte payload (upload stalled)", got, int64(uploadSize))
++	if got := bodyBytes.Load(); got <= payloadBytes {
++		t.Errorf("server consumed %d bytes, want more than one %d-byte payload (upload stalled)", got, int64(payloadBytes))
+ 	}
+-	if total <= uploadSize {
++	if total <= payloadBytes {
+ 		t.Errorf("counter reported %d bytes, want more than one payload", total)
+ 	}
+ }


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @paper42

**Description:**
Backports librespeed/speedtest-cli#143 and #144 into the 1.0.13 patch
series. Fixes #30379.

A version bump to 1.0.14 would need its own go.mod downgrade: it moved
the go directive to 1.25 and raised five dependencies past Go 1.23, which
is what 010-build-with-go-1.23.patch already handles for 1.0.13.

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 24.10.2
- **OpenWrt Target/Subtarget:** mvebu/cortexa72
- **OpenWrt Device:** SDK build only; the fix itself was reproduced
  against a byte-counting sink, where the unpatched client reports 6.3x
  the bytes the server receives and the patched one matches exactly.

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc.
- [x] It is structured in a way that it is potentially upstreamable
