### PR TITLE
csshnpd: bump to c1.1.1 release

### DIFF
--- a/net/csshnpd/Makefile
+++ b/net/csshnpd/Makefile
@@ -4,12 +4,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=csshnpd
-PKG_VERSION:=1.1.0
+PKG_VERSION:=1.1.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-c$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/atsign-foundation/noports/releases/download/c$(PKG_VERSION)
-PKG_HASH:=dc90a7d19562d4e4d3a8dc49911a9b2649484214923f71170aed42fe6a7d47ec
+PKG_HASH:=5535badb78cd26607945ec5ee0f4c6db0fee595e2ae6f2cd4996da164d682665
 
 PKG_MAINTAINER:=Chris Swan <chris@atsign.com>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @cpswan 

**Description:**
fixed srv segfault on connection teardown (pthread_join clobbered tid)
C daemon filters device atSign out of the manager atSign list
handle the case where the only manager atSign is the device atSign
sshnpd + srv code review findings (24 fixes: bounds checks, leak fixes, error-path hardening, log hygiene)
bump atsdk to at_c v0.4.1 for the atauth/onboarding

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT, r35751
- **OpenWrt Target/Subtarget:** x86_64
- **OpenWrt Device:** x86_64 VM

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.
