### PR TITLE
kmod-amneziawg: add AmneziaWG kernel module package

### DIFF
--- a/net/amneziawg/Makefile
+++ b/net/amneziawg/Makefile
@@ -1,0 +1,55 @@
+#
+# Copyright (C) 2026 Karen Khachatryan <karen0734@gmail.com>
+#
+
+include $(TOPDIR)/rules.mk
+include $(INCLUDE_DIR)/kernel.mk
+
+PKG_NAME:=amneziawg
+PKG_VERSION:=3.1.20260906
+PKG_RELEASE:=1
+
+PKG_SOURCE:=amneziawg-linux-kernel-module-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/amnezia-vpn/amneziawg-linux-kernel-module/tar.gz/refs/tags/v$(PKG_VERSION)?
+PKG_HASH:=e32fa46f1b6f9e319c5261f0b0765c3a9261e40cb7c4616fd73500da961a2932
+PKG_BUILD_DIR:=$(KERNEL_BUILD_DIR)/amneziawg-linux-kernel-module-$(PKG_VERSION)
+
+PKG_LICENSE:=GPL-2.0-only
+PKG_LICENSE_FILES:=COPYING
+PKG_MAINTAINER:=Karen Khachatryan <karen0734@gmail.com>
+
+PKG_BUILD_PARALLEL:=1
+
+MAKE_PATH:=src
+PKG_EXTMOD_SUBDIRS:=src
+
+include $(INCLUDE_DIR)/package.mk
+
+define KernelPackage/amneziawg
+  SUBMENU:=Network Support
+  TITLE:=AmneziaWG VPN Kernel Module
+  FILES:=$(PKG_BUILD_DIR)/$(MAKE_PATH)/amneziawg.ko
+  AUTOLOAD:=$(call AutoProbe,amneziawg)
+  DEPENDS:= \
+    +kmod-udptunnel4 \
+    +IPV6:kmod-udptunnel6 \
+    +kmod-crypto-lib-chacha20poly1305 \
+    +kmod-crypto-lib-curve25519
+endef
+
+define KernelPackage/amneziawg/description
+  AmneziaWG is a WireGuard-derived VPN protocol with configurable traffic
+  obfuscation. This package provides the AmneziaWG Linux kernel module.
+endef
+
+MAKE_OPTS:= \
+	M="$(PKG_BUILD_DIR)/$(MAKE_PATH)" \
+	WIREGUARD_VERSION="$(PKG_VERSION)"
+
+define Build/Compile
+	+$(KERNEL_MAKE) $(PKG_JOBS) \
+		$(MAKE_OPTS) \
+		modules
+endef
+
+$(eval $(call KernelPackage,amneziawg))


### PR DESCRIPTION
## AmneziaWG OpenWrt integration — 1/3

This PR adds the `kmod-amneziawg` package.

It is the first part of a complete AmneziaWG integration for OpenWrt:

1. **kmod-amneziawg** — kernel module (this PR)
2. **amneziawg-tools** — userspace tools
3. **luci-proto-amneziawg** — LuCI protocol integration

The related PRs will be linked here once submitted.

## Maintenance approach

I maintain the complete integration here:

https://github.com/karen07/amneziawg-openwrt-package

The repository is built around a generator:

https://github.com/karen07/amneziawg-openwrt-package/blob/main/generate.py

The goal is to avoid maintaining a large, manually diverging copy of the
OpenWrt WireGuard integration.

`generate.py` is the source of truth for the generated packages.

For `amneziawg-tools` and `luci-proto-amneziawg`, the generator starts from
the corresponding upstream OpenWrt / LuCI WireGuard packages, performs the
mechanical WireGuard-to-AmneziaWG transformations, and then applies only the
AmneziaWG-specific changes.

For review, the generation process can be stopped at separate stages:

```text
vanilla -> files -> text -> full
```

This makes it possible to inspect separately:

- the original upstream WireGuard/OpenWrt baseline;
- file and path renames;
- identifier renames;
- the actual AmneziaWG-specific delta.

This is intended to make both review and future maintenance easier: when the
OpenWrt or LuCI WireGuard integration changes, the AmneziaWG packages can be
regenerated from the new upstream baseline instead of manually rebasing a
large copied implementation.

`kmod-amneziawg/Makefile` is also generated by the same script from the pinned
AmneziaWG kernel-module version.

The generator is maintenance and review tooling only. The generated package
files are committed to Git, so OpenWrt does not need the generator at build
time.

## Upstream tracking

The generator provides:

```sh
./generate.py check
```

to check whether a newer AmneziaWG kernel-module or tools release is available.

I currently run this check manually on a regular basis (normally daily).
When a new upstream version appears, the script stops and requires the version
change to be reviewed explicitly before regeneration, rather than silently
updating to an unreviewed upstream revision.

AmneziaWG sources are pinned to official upstream release tags.

## Build and testing workflow

The repository contains an OpenWrt SDK build workflow and a GitHub Actions
target/subtarget matrix for building the generated packages across OpenWrt
targets.

The same repository can also build and install the packages directly on an
OpenWrt device for local testing.

I use this AmneziaWG OpenWrt integration myself, so it is maintained as a
working deployment rather than only as a packaging experiment.

## Previous submissions

This is a renewed attempt to bring AmneziaWG support to OpenWrt, with a focus
on addressing the long-term maintenance and reviewability concerns raised
around previous submissions.

Related previous work:

- openwrt/packages#26971 — `kmod-amneziawg`
- openwrt/packages#26972 — `amneziawg-tools`
- openwrt/luci#6986 — previous LuCI integration discussion

The reproducible generation approach is specifically intended to keep the
WireGuard-derived parts synchronized with OpenWrt/LuCI upstream while keeping
the AmneziaWG-specific changes small and auditable.

## PR series

Once all parts are submitted, this section will link the complete series:

- **1/3** `kmod-amneziawg` — this PR
- **2/3**  openwrt/packages#30493 —`amneziawg-tools`
- **3/3** `luci-proto-amneziawg` — TODO
