### PR TITLE
amneziawg-tools: add AmneziaWG userspace tools package

### DIFF
--- a/net/amneziawg-tools/Makefile
+++ b/net/amneziawg-tools/Makefile
@@ -1,0 +1,60 @@
+#
+# Copyright (C) 2016-2019 Jason A. Donenfeld <Jason@zx2c4.com>
+# Copyright (C) 2016 Baptiste Jonglez <openwrt@bitsofnetworks.org>
+# Copyright (C) 2016-2017 Dan Luedtke <mail@danrl.com>
+# Copyright (C) 2026 Karen Khachatryan <karen0734@gmail.com>
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=amneziawg-tools
+
+PKG_VERSION:=3.1.20260812
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/amnezia-vpn/amneziawg-tools/tar.gz/refs/tags/v$(PKG_VERSION)?
+PKG_HASH:=dbd8ce0748d835d18f30bb76720246b7bfc80bd09cd17c379b1c59f683a18493
+
+PKG_LICENSE:=GPL-2.0-only
+PKG_LICENSE_FILES:=COPYING
+PKG_MAINTAINER:=Karen Khachatryan <karen0734@gmail.com>
+
+PKG_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+MAKE_PATH:=src
+MAKE_VARS += PLATFORM=linux
+
+define Package/amneziawg-tools
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=VPN
+  URL:=https://amnezia.org/
+  TITLE:=AmneziaWG userspace control program (awg)
+  DEPENDS:= \
+	  +!BUSYBOX_CONFIG_IP:ip \
+	  +!BUSYBOX_CONFIG_FEATURE_IP_LINK:ip \
+	  +kmod-amneziawg
+endef
+
+define Package/amneziawg-tools/description
+  AmneziaWG is a WireGuard-derived VPN protocol with configurable traffic
+  obfuscation and DPI-evasion parameters.
+
+  This package provides the userspace control program for AmneziaWG,
+  `awg(8)`, a netifd protocol helper, and a re-resolve watchdog script.
+endef
+
+define Package/amneziawg-tools/install
+	$(INSTALL_DIR) $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/wg $(1)/usr/bin/awg
+	$(INSTALL_BIN) ./files/amneziawg_watchdog $(1)/usr/bin/
+	$(INSTALL_DIR) $(1)/lib/netifd/proto/
+	$(INSTALL_BIN) ./files/amneziawg.sh $(1)/lib/netifd/proto/
+endef
+
+$(eval $(call BuildPackage,amneziawg-tools))

--- a/net/amneziawg-tools/files/amneziawg.sh
+++ b/net/amneziawg-tools/files/amneziawg.sh
@@ -1,0 +1,279 @@
+#!/bin/sh
+# Copyright 2016-2017 Dan Luedtke <mail@danrl.com>
+# Copyright (C) 2026 Karen Khachatryan <karen0734@gmail.com>
+# Licensed to the public under the Apache License 2.0.
+# shellcheck disable=SC2317
+
+AWG=/usr/bin/awg
+if [ ! -x $AWG ]; then
+	logger -t "amneziawg" "error: missing amneziawg-tools (${AWG})"
+	exit 0
+fi
+
+[ -n "$INCLUDE_ONLY" ] || {
+	. /lib/functions.sh
+	. ../netifd-proto.sh
+	init_proto "$@"
+}
+
+proto_amneziawg_init_config() {
+	renew_handler=1
+	peer_detect=1
+
+	proto_config_add_string "private_key"
+	proto_config_add_int "listen_port"
+	proto_config_add_int "mtu"
+	proto_config_add_string "fwmark"
+	proto_config_add_string "addresses"
+
+	# AmneziaWG specific parameters
+	proto_config_add_int "awg_jc"
+	proto_config_add_int "awg_jmin"
+	proto_config_add_int "awg_jmax"
+	proto_config_add_int "awg_s1"
+	proto_config_add_int "awg_s2"
+	proto_config_add_int "awg_s3"
+	proto_config_add_int "awg_s4"
+	proto_config_add_string "awg_h1"
+	proto_config_add_string "awg_h2"
+	proto_config_add_string "awg_h3"
+	proto_config_add_string "awg_h4"
+	proto_config_add_string "awg_i1"
+	proto_config_add_string "awg_i2"
+	proto_config_add_string "awg_i3"
+	proto_config_add_string "awg_i4"
+	proto_config_add_string "awg_i5"
+	proto_config_add_string "awg_header_protection_key"
+	proto_config_add_string "awg_content_padding_addition"
+	proto_config_add_string "awg_rekey_after_time"
+	proto_config_add_string "awg_rekey_timeout"
+	proto_config_add_string "awg_reject_after_time"
+	proto_config_add_string "awg_keepalive_timeout"
+	proto_config_add_string "awg_max_handshake_attempts"
+	proto_config_add_boolean "awg_random_trailers"
+	proto_config_add_boolean "awg_disable_cookies"
+
+	available=1
+	no_proto_task=1
+}
+
+ensure_key_is_generated() {
+	local private_key
+	private_key="$(uci get network."$1".private_key)"
+
+	if [ "$private_key" = "generate" ] || [ -z "$private_key" ]; then
+		private_key="$("${AWG}" genkey)"
+		uci -q set network."$1".private_key="$private_key" && \
+			uci -q commit network
+	fi
+}
+
+proto_amneziawg_setup() {
+	local config="$1"
+
+	local private_key listen_port mtu fwmark addresses ip6prefix nohostroute tunlink
+
+	# AmneziaWG specific parameters
+	local awg_jc
+	local awg_jmin
+	local awg_jmax
+	local awg_s1
+	local awg_s2
+	local awg_s3
+	local awg_s4
+	local awg_h1
+	local awg_h2
+	local awg_h3
+	local awg_h4
+	local awg_i1
+	local awg_i2
+	local awg_i3
+	local awg_i4
+	local awg_i5
+	local awg_header_protection_key
+	local awg_content_padding_addition
+	local awg_rekey_after_time
+	local awg_rekey_timeout
+	local awg_reject_after_time
+	local awg_keepalive_timeout
+	local awg_max_handshake_attempts
+	local awg_random_trailers
+	local awg_disable_cookies
+
+	ensure_key_is_generated "${config}"
+
+	config_load network
+	config_get private_key "${config}" "private_key"
+	config_get listen_port "${config}" "listen_port"
+	config_get addresses "${config}" "addresses"
+	config_get mtu "${config}" "mtu"
+	config_get fwmark "${config}" "fwmark"
+	config_get ip6prefix "${config}" "ip6prefix"
+	config_get nohostroute "${config}" "nohostroute"
+	config_get tunlink "${config}" "tunlink"
+
+	# AmneziaWG specific parameters
+	config_get awg_jc "${config}" "awg_jc"
+	config_get awg_jmin "${config}" "awg_jmin"
+	config_get awg_jmax "${config}" "awg_jmax"
+	config_get awg_s1 "${config}" "awg_s1"
+	config_get awg_s2 "${config}" "awg_s2"
+	config_get awg_s3 "${config}" "awg_s3"
+	config_get awg_s4 "${config}" "awg_s4"
+	config_get awg_h1 "${config}" "awg_h1"
+	config_get awg_h2 "${config}" "awg_h2"
+	config_get awg_h3 "${config}" "awg_h3"
+	config_get awg_h4 "${config}" "awg_h4"
+	config_get awg_i1 "${config}" "awg_i1"
+	config_get awg_i2 "${config}" "awg_i2"
+	config_get awg_i3 "${config}" "awg_i3"
+	config_get awg_i4 "${config}" "awg_i4"
+	config_get awg_i5 "${config}" "awg_i5"
+	config_get awg_header_protection_key "${config}" "awg_header_protection_key"
+	config_get awg_content_padding_addition "${config}" "awg_content_padding_addition"
+	config_get awg_rekey_after_time "${config}" "awg_rekey_after_time"
+	config_get awg_rekey_timeout "${config}" "awg_rekey_timeout"
+	config_get awg_reject_after_time "${config}" "awg_reject_after_time"
+	config_get awg_keepalive_timeout "${config}" "awg_keepalive_timeout"
+	config_get awg_max_handshake_attempts "${config}" "awg_max_handshake_attempts"
+	config_get_bool awg_random_trailers "${config}" "awg_random_trailers" ""
+	config_get_bool awg_disable_cookies "${config}" "awg_disable_cookies" ""
+
+	# Add the link only if it didn't already exist
+	ip -br link show "${config}" >/dev/null 2>&1 || ip link add dev "${config}" type amneziawg
+
+	[ -n "${mtu}" ] && ip link set mtu "${mtu}" dev "${config}"
+
+	proto_init_update "${config}" 1
+
+	# Build AmneziaWG configuration entirely in memory
+	local awg_config="[Interface]\n"
+	awg_config="${awg_config}PrivateKey=${private_key}\n"
+	[ -n "${listen_port}" ]	&& awg_config="${awg_config}ListenPort=${listen_port}\n"
+	[ -n "${fwmark}" ]		&& awg_config="${awg_config}FwMark=${fwmark}\n"
+
+	# AmneziaWG specific parameters
+	[ -n "${awg_jc}" ] && awg_config="${awg_config}Jc=${awg_jc}\n"
+	[ -n "${awg_jmin}" ] && awg_config="${awg_config}Jmin=${awg_jmin}\n"
+	[ -n "${awg_jmax}" ] && awg_config="${awg_config}Jmax=${awg_jmax}\n"
+	[ -n "${awg_s1}" ] && awg_config="${awg_config}S1=${awg_s1}\n"
+	[ -n "${awg_s2}" ] && awg_config="${awg_config}S2=${awg_s2}\n"
+	[ -n "${awg_s3}" ] && awg_config="${awg_config}S3=${awg_s3}\n"
+	[ -n "${awg_s4}" ] && awg_config="${awg_config}S4=${awg_s4}\n"
+	[ -n "${awg_h1}" ] && awg_config="${awg_config}H1=${awg_h1}\n"
+	[ -n "${awg_h2}" ] && awg_config="${awg_config}H2=${awg_h2}\n"
+	[ -n "${awg_h3}" ] && awg_config="${awg_config}H3=${awg_h3}\n"
+	[ -n "${awg_h4}" ] && awg_config="${awg_config}H4=${awg_h4}\n"
+	[ -n "${awg_i1}" ] && awg_config="${awg_config}I1=${awg_i1}\n"
+	[ -n "${awg_i2}" ] && awg_config="${awg_config}I2=${awg_i2}\n"
+	[ -n "${awg_i3}" ] && awg_config="${awg_config}I3=${awg_i3}\n"
+	[ -n "${awg_i4}" ] && awg_config="${awg_config}I4=${awg_i4}\n"
+	[ -n "${awg_i5}" ] && awg_config="${awg_config}I5=${awg_i5}\n"
+	[ -n "${awg_header_protection_key}" ] && awg_config="${awg_config}HeaderProtectionKey=${awg_header_protection_key}\n"
+	[ -n "${awg_content_padding_addition}" ] && awg_config="${awg_config}ContentPaddingAddition=${awg_content_padding_addition}\n"
+	[ -n "${awg_rekey_after_time}" ] && awg_config="${awg_config}RekeyAfterTime=${awg_rekey_after_time}\n"
+	[ -n "${awg_rekey_timeout}" ] && awg_config="${awg_config}RekeyTimeout=${awg_rekey_timeout}\n"
+	[ -n "${awg_reject_after_time}" ] && awg_config="${awg_config}RejectAfterTime=${awg_reject_after_time}\n"
+	[ -n "${awg_keepalive_timeout}" ] && awg_config="${awg_config}KeepaliveTimeout=${awg_keepalive_timeout}\n"
+	[ -n "${awg_max_handshake_attempts}" ] && awg_config="${awg_config}MaxHandshakeAttempts=${awg_max_handshake_attempts}\n"
+	[ -n "${awg_random_trailers}" ] && awg_config="${awg_config}RandomTrailers=${awg_random_trailers}\n"
+	[ -n "${awg_disable_cookies}" ] && awg_config="${awg_config}DisableCookies=${awg_disable_cookies}\n"
+
+	# Collect peer configs into awg_config as well
+	local peer_config
+	peer_config=""
+	proto_amneziawg_setup_peer_collect() {
+		local section="$1"
+		local peer_block
+
+		config_get_bool route_allowed_ips "$section" "route_allowed_ips" 0
+		config_get_bool disabled "$section" "disabled" 0
+		[ "$disabled" = 1 ] && return;
+		config_get peer_key "$section" "public_key"
+		config_get peer_eph "$section" "endpoint_host"
+		config_get peer_port "$section" "endpoint_port" "51820"
+		config_get peer_a_ips "$section" "allowed_ips"
+		config_get peer_p_ka "$section" "persistent_keepalive"
+		config_get peer_psk "$section" "preshared_key"
+
+
+		[ "${peer_eph##*:}" != "$peer_eph" ] && peer_eph="[$peer_eph]"
+		peer_port=${peer_port:-51820}
+
+		peer_block="\n[Peer]\n"
+		[ -n "${peer_key}" ]	&& peer_block="${peer_block}PublicKey=${peer_key}\n"
+		[ -n "${peer_psk}" ]	&& peer_block="${peer_block}PresharedKey=${peer_psk}\n"
+		[ -n "${peer_eph}" ]	&& peer_block="${peer_block}Endpoint=${peer_eph}${peer_port:+:$peer_port}\n"
+		[ -n "${peer_a_ips}" ]	&& peer_block="${peer_block}AllowedIPs=${peer_a_ips// /, }\n"
+		[ -n "${peer_p_ka}" ]	&& peer_block="${peer_block}PersistentKeepalive=${peer_p_ka}\n"
+
+		[ -n "$peer_key" ] && peer_config="$peer_config$peer_block\n"
+		if [ $route_allowed_ips -ne 0 ]; then
+			for allowed_ip in $peer_a_ips; do
+				case "${allowed_ip}" in
+					*:*/*) proto_add_ipv6_route "${allowed_ip%%/*}" "${allowed_ip##*/}" ;;
+					*.*/*) proto_add_ipv4_route "${allowed_ip%%/*}" "${allowed_ip##*/}" ;;
+					*:*) proto_add_ipv6_route "${allowed_ip%%/*}" "128" ;;
+					*.*) proto_add_ipv4_route "${allowed_ip%%/*}" "32" ;;
+				esac
+			done
+		fi
+
+	}
+
+	config_foreach proto_amneziawg_setup_peer_collect "amneziawg_${config}"
+
+	# Combine interface + peer config into one variable
+	awg_config="${awg_config}${peer_config}"
+
+	# Apply configuration directly using awg syncconf via stdin
+	printf "%b" "$awg_config" | ${AWG} syncconf "${config}" /dev/stdin
+	local AWG_RETURN=$?
+
+	if [ ${AWG_RETURN} -ne 0 ]; then
+		echo "Could not sync AmneziaWG configuration"
+		sleep 5
+		proto_setup_failed "${config}"
+		exit 1
+	fi
+
+	# Assign addresses
+	for address in ${addresses}; do
+		case "${address}" in
+			*:*/*) proto_add_ipv6_address "${address%%/*}" "${address##*/}" ;;
+			*.*/*) proto_add_ipv4_address "${address%%/*}" "${address##*/}" ;;
+			*:*)   proto_add_ipv6_address "${address%%/*}" "128" ;;
+			*.*)   proto_add_ipv4_address "${address%%/*}" "32" ;;
+		esac
+	done
+
+	for prefix in ${ip6prefix}; do
+		proto_add_ipv6_prefix "$prefix"
+	done
+
+	# Endpoint dependency tracking
+	if [ "${nohostroute}" != "1" ]; then
+		awg show "${config}" endpoints | \
+		sed -E 's/\[?([0-9.:a-f]+)\]?:([0-9]+)/\1 \2/' | \
+		while IFS=$'\t ' read -r key address port; do
+			[ -n "${port}" ] || continue
+			proto_add_host_dependency "${config}" "${address}" "${tunlink}"
+		done
+	fi
+
+	proto_send_update "${config}"
+}
+
+proto_amneziawg_renew() {
+	local interface="$1"
+	proto_amneziawg_setup "$interface"
+}
+
+proto_amneziawg_teardown() {
+	local config="$1"
+	ip link del dev "${config}" >/dev/null 2>&1
+}
+
+[ -n "$INCLUDE_ONLY" ] || {
+	add_protocol amneziawg
+}

--- a/net/amneziawg-tools/files/amneziawg_watchdog
+++ b/net/amneziawg-tools/files/amneziawg_watchdog
@@ -1,0 +1,68 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0
+#
+# Copyright (C) 2018 Aleksandr V. Piskunov <aleksandr.v.piskunov@gmail.com>.
+# Copyright (C) 2015-2018 Jason A. Donenfeld <Jason@zx2c4.com>. All Rights Reserved.
+#
+# This watchdog script tries to re-resolve hostnames for inactive AmneziaWG peers.
+# Use it for peers with a frequently changing dynamic IP.
+# persistent_keepalive must be set, recommended value is 25 seconds.
+#
+# Run this script from cron every minute:
+# echo '* * * * * /usr/bin/amneziawg_watchdog' >> /etc/crontabs/root
+
+
+. /lib/functions.sh
+
+check_peer_activity() {
+  local cfg=$1
+  local iface=$2
+  local disabled
+  local public_key
+  local endpoint_host
+  local endpoint_port
+  local persistent_keepalive
+  local last_handshake
+  local idle_seconds
+
+  config_get_bool disabled "${cfg}" "disabled" 0
+  config_get public_key "${cfg}" "public_key"
+  config_get endpoint_host "${cfg}" "endpoint_host"
+  config_get endpoint_port "${cfg}" "endpoint_port"
+
+  if [ "${disabled}" -eq 1 ]; then
+    # skip disabled peers
+    return 0
+  fi
+
+  persistent_keepalive=$(awg show ${iface} persistent-keepalive | grep ${public_key} | awk '{print $2}')
+
+  # only process peers with endpoints and keepalive set
+  [ -z ${endpoint_host} ] && return 0;
+  [ -z ${persistent_keepalive} -o ${persistent_keepalive} = "off" ] && return 0;
+
+  # skip IP addresses
+  # check taken from packages/net/ddns-scripts/files/dynamic_dns_functions.sh
+  local IPV4_REGEX="[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}"
+  local IPV6_REGEX="\(\([0-9A-Fa-f]\{1,4\}:\)\{1,\}\)\(\([0-9A-Fa-f]\{1,4\}\)\{0,1\}\)\(\(:[0-9A-Fa-f]\{1,4\}\)\{1,\}\)"
+  local IPV4=$(echo ${endpoint_host} | grep -m 1 -o "$IPV4_REGEX$")    # do not detect ip in 0.0.0.0.example.com
+  local IPV6=$(echo ${endpoint_host} | grep -m 1 -o "$IPV6_REGEX")
+  [ -n "${IPV4}" -o -n "${IPV6}" ] && return 0;
+
+  # re-resolve endpoint hostname if not responding for too long
+  last_handshake=$(awg show ${iface} latest-handshakes | grep ${public_key} | awk '{print $2}')
+  [ -z ${last_handshake} ] && return 0;
+  idle_seconds=$(($(date +%s)-${last_handshake}))
+  [ ${idle_seconds} -lt 150 ] && return 0;
+  logger -t "amneziawg_monitor" "${iface} endpoint ${endpoint_host}:${endpoint_port} is not responding for ${idle_seconds} seconds, trying to re-resolve hostname"
+  awg set ${iface} peer ${public_key} endpoint "${endpoint_host}:${endpoint_port}"
+}
+
+# query ubus for all active amneziawg interfaces
+eval $(ubus -S call network.interface dump | jsonfilter -e 'awg_ifaces=@.interface[@.up=true && @.proto="amneziawg"].interface')
+
+# check every peer in every active amneziawg interface
+config_load network
+for iface in $awg_ifaces; do
+  config_foreach check_peer_activity "amneziawg_${iface}" "${iface}"
+done


### PR DESCRIPTION
## AmneziaWG OpenWrt integration — 2/3

This PR adds the `amneziawg-tools` userspace package.

It is the second part of a complete AmneziaWG integration for OpenWrt:

1. **kmod-amneziawg** — kernel module: openwrt/packages#30492
2. **amneziawg-tools** — userspace tools (this PR)
3. **luci-proto-amneziawg** — LuCI protocol integration (to be submitted)

Depends on: openwrt/packages#30492

## Maintenance and provenance

I maintain the complete OpenWrt integration here:

https://github.com/karen07/amneziawg-openwrt-package

The repository is built around a generator:

https://github.com/karen07/amneziawg-openwrt-package/blob/main/generate.py

The goal is to avoid maintaining a large, manually diverging copy of the
corresponding WireGuard OpenWrt integration.

For `amneziawg-tools`, the generator currently uses the OpenWrt 25.12
WireGuard package as its baseline.

This is intentional: OpenWrt 25.12 is the stable WireGuard integration that
still uses the shell-based netifd protocol handler, which is also the
implementation currently used and tested by this AmneziaWG port.

OpenWrt master has since migrated the WireGuard protocol handler to ucode.
The AmneziaWG protocol helper in this submission remains shell-based.
Shell protocol handlers are still supported by netifd.

A future migration of the AmneziaWG protocol helper to the current ucode
WireGuard baseline can be handled separately without changing the upstream
AmneziaWG userspace tooling itself.

## Reproducible generation

`generate.py` is the source of truth for the generated packages.

The generation process is split into deterministic stages:

```text
vanilla -> files -> text -> full
```

These stages separate:

- the original OpenWrt 25.12 WireGuard package;
- file and path renames;
- mechanical WireGuard-to-AmneziaWG identifier renames;
- the actual AmneziaWG-specific changes.

The important review boundary is `text -> full`.

At the `text` stage, the package has already been mechanically transformed
from WireGuard to AmneziaWG. The `full` stage then adds only the
AmneziaWG-specific integration.

This makes the actual AmneziaWG delta directly reviewable instead of requiring
reviewers to inspect a large copied WireGuard implementation as a whole.

Example comparison:

[WireGuard-derived baseline -> AmneziaWG-specific changes](https://github.com/karen07/amneziawg-openwrt-package/compare/4b62c027761f554c3bafc28c897df510965eb653..main)

For this PR, the relevant files in that comparison are under
`amneziawg-tools/`.

The generator is maintenance and review tooling only. The generated files are
committed to Git, so OpenWrt does not depend on the generator at package build
time.

## Upstream tracking

The AmneziaWG userspace source is pinned to an official upstream release tag:

https://github.com/amnezia-vpn/amneziawg-tools

The generator also provides:

```sh
./generate.py check
```

to check whether a newer AmneziaWG kernel-module or tools release is
available.

I run this check manually on a regular basis, normally daily.

When a new upstream version is detected, it is not applied silently. The
version change must be reviewed explicitly before regeneration.

## Build and testing workflow

I use this AmneziaWG OpenWrt integration myself.

The maintenance repository also contains GitHub Actions / OpenWrt SDK build
workflows for building the generated packages across OpenWrt
target/subtarget combinations.

The same repository can also be used to build and install the packages
directly on an OpenWrt device for local testing.

This is intended to be a maintained integration rather than a one-off
packaging attempt.

## Previous submission

A previous `amneziawg-tools` submission exists as openwrt/packages#26972.

I reviewed the feedback from that submission while preparing this version.

The reproducible generation approach is intended to make the package
provenance explicit and keep the WireGuard-derived part separate from the
actual AmneziaWG-specific changes.

## PR series

- **1/3** openwrt/packages#30492 — `kmod-amneziawg`
- **2/3** `amneziawg-tools` — this PR
- **3/3** `luci-proto-amneziawg` — to be submitted
