### PR TITLE
mariadb: init - check file versions

### DIFF
--- a/utils/mariadb/files/mysqld.init
+++ b/utils/mariadb/files/mysqld.init
@@ -146,8 +146,17 @@ start_service() {
 	done
 
 	# Migration from old versions
+	file_version=''
+	for f in mariadb_upgrade_info mysql_upgrade_info .version; do
+		if [ -f "$datadir"/$f ]; then
+			file_version=$(cat "$datadir/$f")
+			# removing trailing suffix
+			file_version=${file_version%%-*}
+			break
+		fi
+	done
 	# shellcheck disable=SC2154
-	if [ "$(cat "$datadir"/.version 2> /dev/null)" \!= "$version" ] && [ "$autoupgrade" -gt 0 ]; then
+	if [ "${file_version}" != "$version" ] && [ "$autoupgrade" -gt 0 ]; then
 		# Check for correct owner
 		local owner="$(stat --format %U:%G "$datadir" 2> /dev/null)"
 		if [ -n "$owner" ] && [ "$owner" != "$my_user:$my_group" ]; then
@@ -168,8 +177,7 @@ start_service() {
 			exit 1
 		}
 		# Upgrade the database
-		mysql_upgrade --upgrade-system-tables --socket=/tmp/mysql_upgrade.sock
-		echo "$version" > "$datadir"/.version
+		mariadb-upgrade --upgrade-system-tables --socket=/tmp/mysql_upgrade.sock
 		# Stop the upgrade instance
 		kill "$PID"
 		i=0


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @miska
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**

mariadb-upgrade has had its own upgrade version file in the datadir, called mysql_upgrade in <= 10.11 and mariadb-upgrade there after.

The mariadb-install-db creates this file, and also the mariadb-upgrade executable creates this file also.

This removes the need to maintain the .version info though this is used as a last check of the upgrade.
---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [X] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [X] It can be applied using `git am`
- [X] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [N/A] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
