### PR TITLE
cryptsetup: fix Argon2 with OpenWrt's OpenSSL, update to 2.8.8

### DIFF
--- a/utils/cryptsetup/Makefile
+++ b/utils/cryptsetup/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cryptsetup
-PKG_VERSION:=2.8.7
-PKG_RELEASE:=2
+PKG_VERSION:=2.8.8
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/linux/utils/cryptsetup/v$(subst $(space),.,$(wordlist 1, 2, $(subst .,$(space),$(PKG_VERSION))))
-PKG_HASH:=e776f0d381e86ca61042c457069491fe8e0ac286780c7c3b1e4f9921abc961da
+PKG_HASH:=3acfa685f2dd7fcc832e0b77bc7093aa7da554a51ce8dafbb4138eaa854eee35
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=GPL-2.0-or-later LGPL-2.1-or-later

--- a/utils/cryptsetup/Makefile
+++ b/utils/cryptsetup/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cryptsetup
 PKG_VERSION:=2.8.7
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/linux/utils/cryptsetup/v$(subst $(space),.,$(wordlist 1, 2, $(subst .,$(space),$(PKG_VERSION))))

--- a/utils/cryptsetup/patches/010-configure-detect-openssl-without-argon2.patch
+++ b/utils/cryptsetup/patches/010-configure-detect-openssl-without-argon2.patch
@@ -1,0 +1,51 @@
+From dbf4c3773b2433b6324f4ec74feb746ca6e7bfb1 Mon Sep 17 00:00:00 2001
+From: Daniel Golle <daniel@makrotopia.org>
+Date: Thu, 10 Sep 2026 15:16:59 +0100
+Subject: [PATCH] Use internal Argon2 when OpenSSL is built without Argon2
+
+OpenSSL can be configured with no-argon2, and no-blake2 implies it
+because Argon2 is built on BLAKE2b. Such a build still installs the
+OSSL_KDF_PARAM_ARGON2_* macros in core_names.h, so configure concludes
+that OpenSSL provides Argon2 and drops the bundled implementation.
+EVP_KDF_fetch() then fails at runtime and every LUKS2 keyslot using
+Argon2 fails to open. Check OPENSSL_NO_ARGON2 as well and fall back to
+the internal Argon2 implementation.
+
+Signed-off-by: Daniel Golle <daniel@makrotopia.org>
+---
+ configure.ac | 8 +++++++-
+ meson.build  | 3 +++
+ 2 files changed, 10 insertions(+), 1 deletion(-)
+
+--- a/configure.ac
++++ b/configure.ac
+@@ -345,7 +345,13 @@ AC_DEFUN([CONFIGURE_OPENSSL], [
+ 
+ 	saved_LIBS=$LIBS
+ 	AC_CHECK_DECLS([OSSL_get_max_threads], [], [], [#include <openssl/thread.h>])
+-	AC_CHECK_DECLS([OSSL_KDF_PARAM_ARGON2_VERSION], [use_internal_argon2=0], [], [#include <openssl/core_names.h>])
++	dnl OpenSSL built with no-argon2 (implied by no-blake2) still installs the parameter name macros.
++	AC_CHECK_DECLS([OSSL_KDF_PARAM_ARGON2_VERSION], [use_internal_argon2=0], [], [[
++#include <openssl/opensslconf.h>
++#ifdef OPENSSL_NO_ARGON2
++#error Argon2 is disabled in this OpenSSL build
++#endif
++#include <openssl/core_names.h>]])
+ 	LIBS=$saved_LIBS
+ ])
+ 
+--- a/meson.build
++++ b/meson.build
+@@ -518,9 +518,12 @@ elif get_option('crypto-backend') == 'op
+             dependencies: crypto_backend_library))
+     # LibreSSL defines OSSL_KDF_PARAM_ARGON2_VERSION in core_names.h but does
+     # not implement the EVP_KDF API. Check for both the symbol and the function.
++    # OpenSSL built with no-argon2 (implied by no-blake2) keeps the macros too.
+     _have_ossl_argon2 = (
+         cc.has_header_symbol('openssl/core_names.h', 'OSSL_KDF_PARAM_ARGON2_VERSION',
+             dependencies: crypto_backend_library) and
++        not cc.has_header_symbol('openssl/opensslconf.h', 'OPENSSL_NO_ARGON2',
++            dependencies: crypto_backend_library) and
+         cc.has_function('EVP_KDF_fetch',
+             dependencies: crypto_backend_library))
+     conf.set10('HAVE_DECL_OSSL_KDF_PARAM_ARGON2_VERSION', _have_ossl_argon2)


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @dangowrt
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**

Since openwrt/packages@fbac2e7861fb30661eef52a45223bb3a3a0d6d17 cryptsetup is built with the OpenSSL crypto backend. OpenWrt's `libopenssl` is configured with `no-blake2`, which OpenSSL's `Configure` cascades into `no-argon2` because Argon2 is implemented on top of BLAKE2b, so the shipped library has no Argon2 KDF at all (`openssl list -disabled` shows `ARGON2`). cryptsetup's configure script detects OpenSSL Argon2 solely through the `OSSL_KDF_PARAM_ARGON2_VERSION` macro in `core_names.h`, which every OpenSSL 3.2+ build installs regardless of that option, so it drops its bundled Argon2 implementation. At runtime `EVP_KDF_fetch("argon2id")` fails and every LUKS2 keyslot using Argon2 (the default) fails immediately with `Keyslot open failed`; `cryptsetup benchmark` reports `argon2id N/A`.

The first commit adds a patch that makes the configure check (and its meson equivalent) also honour `OPENSSL_NO_ARGON2`, so the bundled Argon2 implementation is used again with OpenWrt's OpenSSL. The patch is written to be submitted upstream; the detection is unchanged in cryptsetup 2.8.8 and in the upstream `main` branch.

The second commit updates cryptsetup to 2.8.8, a stable bug-fix release (TOCTOU in header restore, BITLK metadata hardening, a 32-bit integer overflow in the anti-forensic size calculation, a memory corruption in reencrypt init, keyed discards for integritysetup). Release notes: https://gitlab.com/cryptsetup/cryptsetup/-/blob/v2.8.8/docs/v2.8.8-ReleaseNotes

---

## 🧪 Run Testing Details

- **OpenWrt Version:** SNAPSHOT r36162-ac2ed40b48
- **OpenWrt Target/Subtarget:** mediatek/mt7623
- **OpenWrt Device:** Bananapi BPI-R2

Built with the matching mt7623 SDK. The fixed package was installed on the device and opened an existing LUKS2 argon2id volume on `/dev/md/pfusch:0` that failed to open with the unpatched 2.8.7-r1 package; `cryptsetup --debug benchmark --pbkdf argon2id` now reports the `[cryptsetup libargon2]` backend and a working argon2id benchmark instead of `N/A`. The 2.8.8 build was additionally exercised under qemu-arm user emulation: argon2id and PBKDF2 benchmarks, `luksFormat --type luks2 --pbkdf argon2id` on a file image and `open --test-passphrase` of that image.

---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [x] It can be applied using `git am`
- [x] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [x] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
