### PR TITLE
chrony: update to 4.9

### DIFF
--- a/net/chrony/Makefile
+++ b/net/chrony/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=chrony
-PKG_VERSION:=4.8
-PKG_RELEASE:=3
+PKG_VERSION:=4.9
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://chrony-project.org/releases/
-PKG_HASH:=33ea8eb2a4daeaa506e8fcafd5d6d89027ed6f2f0609645c6f149b560d301706
+PKG_HASH:=4924c6f530105bcd5b9e9e33c48a2ae1bfd889222c8480bc41601110efc864d0
 
 PKG_MAINTAINER:=Miroslav Lichvar <mlichvar0@gmail.com>
 PKG_LICENSE:=GPL-2.0-only


### PR DESCRIPTION

## 📦 Package Details

**Maintainer:** me

**Description:**
Release notes: https://chrony-project.org/news.html#_27_aug_2026_chrony_4_9_released

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12.5
- **OpenWrt Target/Subtarget:** ramips/mt7621
- **OpenWrt Device:** Cudy WR1300

Tested as an NTP server and client, and NTS client. 
---

## ✅ Formalities

- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

No patches