### PR TITLE
Tq remove dist info

### DIFF
--- a/lang/python/python-package-install.sh
+++ b/lang/python/python-package-install.sh
@@ -97,6 +97,16 @@ while IFS='|' read -r cmd path file_mode dir_mode; do
 		rm -fR -- "$dest"/$path
 		;;
 
+	-\?)
+		log "Optionally removing: \"$path\""
+
+		if ! path_exists "$dest" "$path"; then
+			log "\"$dest/$path\" not found"
+		else
+			rm -fR -- "$dest"/$path
+		fi
+		;;
+
 	=)
 		log "Setting recursive permissions \"${file_mode:-(none)}\"/\"${dir_mode:-(none)}\" on \"$path\""
 

--- a/lang/python/python3-package.mk
+++ b/lang/python/python3-package.mk
@@ -125,6 +125,7 @@ endef
 
 define Py3Package/filespec/Default
 +|$(PYTHON3_PKG_DIR)
+-?|$(PYTHON3_PKG_DIR)/*.dist-info
 endef
 
 # $(1) => package name


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @commodo 

**Description:**
By default remove the .dist-info files

---

## 🧪 Run Testing Details

- **OpenWrt Version:** 25.12.5
- **OpenWrt Target/Subtarget:** omap
- **OpenWrt Device:** custom

---

## ✅ Formalities

- [ x] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
