### PR TITLE
miniupnpd: restore nftables mappings on reload

### DIFF
--- a/net/miniupnpd/Makefile
+++ b/net/miniupnpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=miniupnpd
 PKG_VERSION:=2.3.9
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE_URL:=https://github.com/miniupnp/miniupnp/releases/download/miniupnpd_$(subst .,_,$(PKG_VERSION))
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
@@ -114,7 +114,11 @@ endef
 
 define Package/miniupnpd-nftables/install
 	$(call Package/miniupnpd/install/Default,$1)
+	$(INSTALL_DIR) $(1)/etc/uci-defaults
+	$(INSTALL_DIR) $(1)/usr/share/miniupnpd
 	$(INSTALL_DIR) $(1)/usr/share/nftables.d
+	$(INSTALL_BIN) ./files/miniupnpd.defaults.nftables $(1)/etc/uci-defaults/99-miniupnpd
+	$(INSTALL_DATA) ./files/firewall4.include $(1)/usr/share/miniupnpd/firewall.include
 	$(CP) ./files/nftables.d/* $(1)/usr/share/nftables.d/
 endef
 

--- a/net/miniupnpd/files/firewall4.include
+++ b/net/miniupnpd/files/firewall4.include
@@ -1,0 +1,27 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0
+#
+# Re-install the port mappings of miniupnpd after a firewall (re)load.
+#
+# The mappings live in the upnp_forward, upnp_prerouting and upnp_postrouting chains
+# declared by the nftables.d snippets this package ships, and those chains are part of
+# the main "inet fw4" table, which fw4 rebuilds from its templates on every start and
+# reload. So they end up present but empty while the daemon keeps running and has no way
+# of noticing, and existing mappings silently stop working. Restarting the daemon makes
+# it re-read its lease files, which is what puts the mappings back.
+#
+# fw4 runs this file as a forked shell while it still holds /var/run/fw4.lock, so the
+# restart must not be synchronous: the daemon's start_service() runs "fw4 reload" when
+# the upnp_forward chain is missing, and that inner invocation would then block on the
+# lock fw4 is still holding. Detaching the restart also keeps the daemon's start-up out
+# of fw4's critical section.
+
+[ -x /etc/init.d/miniupnpd ] || exit 0
+/etc/init.d/miniupnpd running || exit 0
+
+# Not using the fw4 table, nothing to do.
+nft -s -t -n list chain inet fw4 upnp_forward >/dev/null 2>&1 || exit 0
+
+( sleep 1; /etc/init.d/miniupnpd restart ) >/dev/null 2>&1 &
+
+exit 0

--- a/net/miniupnpd/files/miniupnpd.defaults.nftables
+++ b/net/miniupnpd/files/miniupnpd.defaults.nftables
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+uci -q batch <<-EOT
+	delete firewall.miniupnpd
+	set firewall.miniupnpd=include
+	set firewall.miniupnpd.type=script
+	set firewall.miniupnpd.path=/usr/share/miniupnpd/firewall.include
+	commit firewall
+EOT
+
+exit 0


### PR DESCRIPTION
The nftables variant installs its forwarding/NAT rules into the `upnp_forward`, `upnp_prerouting` and `upnp_postrouting` chains. Those chains are declared inside the main `inet fw4` table by the `usr/share/nftables.d/` snippets this package ships, so every firewall start/reload rebuilds them from the templates and leaves them present but empty. The daemon keeps running and has no way of noticing that the rules it installed are gone, so all existing port mappings silently stop working until a client happens to re-request them or the daemon is restarted.

Nothing else recovers from this either:

- `/etc/hotplug.d/iface/20-firewall` issues `fw4 -q reload` on ifup/ifupdate, while `/etc/hotplug.d/iface/50-miniupnpd` exits early both for any action other than `ifup` and when the external device name is unchanged.
- the daemon itself never re-installs rules it already reported as active.

The iptables variant is not affected, because its rules live in a `MINIUPNPD` chain of its own which firewall3 does not flush — that is why `files/firewall3.include` only has to re-add the jump rules and never touches the daemon. For nftables the equivalent hook was added by f1c69d0e ("miniupnpd: rework firewall4 integration") and removed again by 4c934aea / #21931 ("miniupnpd: remove uci-defaults and fw4-include files for nftables variant"), which left the nftables variant with no way to recover at all. Note that `files/miniupnpd.defaults.nftables` is currently gone from the tree while `files/miniupnpd.defaults.iptables` is still there and still installed by `Package/miniupnpd-iptables/install`.

Re-introduce the hook for the nftables variant. The daemon is restarted rather than left alone because a restart is what makes it re-read its lease files.

## Why the restart is detached and delayed

The removal in #21931 was justified with "*produces a firewall error on service miniupnpd restart*". That is this: fw4 runs script includes in a forked shell while it still holds `/var/run/fw4.lock` (`/sbin/fw4` runs `ACTION=includes` inside `{ flock -x 1000; ... } 1000>$LOCK`), and `start_service()` contains

```sh
nft -s -t -n list chain inet fw4 upnp_forward >/dev/null 2>&1 || fw4 reload
```

which fires only when the `upnp_forward` chain is missing. A synchronous restart would therefore put the daemon's whole start-up inside fw4's critical section, and that safeguard would block on the lock fw4 is still holding. Running the restart detached, one second later, avoids that. fw4 sources the include from that forked shell (`. '$path'`) after closing fd 1000, so the child holds no lock fd; only the daemon's own `fw4 reload` fallback would take the lock.

For the same reason the file ends with `exit 0` rather than `return 0`: fw4 does not source includes into its own process. `run_includes()` in `main.uc` calls `system(['sh', '-c', ...], 30000)` once per script include, and only `warn()`s on a non-zero status before continuing the loop — so an include can neither terminate fw4 nor skip the includes registered after it.

There are no other behavioural guards: the checks that remain only establish that the daemon is managed by this init script and that the system is actually using the fw4 table. At the point fw4 runs the include the table has just been rebuilt, so the `upnp_forward` chain is always present and always empty, and a lease-file check would only ever skip a restart when there is nothing to restore. The hook therefore restarts the daemon whenever the firewall is (re)loaded and the daemon is running.

A restart re-reads both lease files — `reload_from_lease_file()` for the IPv4 mappings and `reload_from_lease_file6()` (`ENABLE_UPNPPINHOLE`) for the IPv6 pinholes — so both are restored. Everything that reaches a lease file is covered by that, including the mappings created through IGD, NAT-PMP and PCP MAP. The exception is PCP PEER, which never writes a lease file and is still lost across a restart; that remains a pre-existing limitation.

## fw4 include options

Only `type` and `path` are valid for a script include. `family` and `reload` are accepted by fw3 but marked `UNSUPPORTED` by fw4's `parse_include()`, which warns and ignores them, so the uci-defaults does not set them even though `miniupnpd.defaults.iptables` does.

## Run tested

bcm53xx / ImmortalWrt 25.12.2, `fw4` + `miniupnpd-nftables` built from this tree:

- before: a plain `fw4 reload` emptied both chains, left the daemon PID unchanged, and killed the active mappings; a 120 s watch showed no recovery at all. Simulated `ACTION=ifup` / `ACTION=ifupdate` on the WAN interface left the mappings at zero as well.
- with this patch: one `fw4 reload` restarts the daemon once (confirmed in the daemon's own log: a single `shutting down` / `starting` pair) and re-installs all nine mappings within about two seconds, with no fw4 lock error, and the contents of `upnp_forward` are byte-identical to what they were before the reload.
- a real WAN reconnect (`ifup wan`, which triggers both an ifup and an ifupdate reload) restored all mappings the same way.
- `/sbin/hotplug-call iface` with `ACTION=ifupdate` — the entry point that changes no configuration file at all — also restarts the daemon exactly once and restores the mappings.
- the include is sourced by a forked shell rather than executed as a program, so the file does not need the executable bit and `INSTALL_DATA` is correct.

## Relation to other open work

#28765 also touches this package but does not address the wiped-chains case: its `50-miniupnpd` keeps the same early-exit logic. It does touch the `Package/miniupnpd-nftables/install` block, so one of the two will need a small rebase. Its uci-defaults is installed as `99-miniupnpd-upnpd-migration`, which does not clash with the `99-miniupnpd` used here. It also renames the `upnp_lease_file` UCI option to `lease_file` in a different section; this script no longer reads any lease path, so that rename does not affect it.

Signed-off-by is in the commit.

