### PR TITLE
net/fwblack: add new package

### DIFF
--- a/net/fwblack/Makefile
+++ b/net/fwblack/Makefile
@@ -1,0 +1,110 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=fwblack
+PKG_VERSION:=1.0.2
+PKG_RELEASE:=1
+
+PKG_SOURCE:=fw-black-luci-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/EdgeBites/fw-black-luci/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=2b011a8203de2ea10c955fbd817c5e3b9b222bbe8c04b3f5da211e036886abcd
+
+PKG_MAINTAINER:=Calin Vlad <calin@edgebites.com>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+PKGARCH:=all
+
+include $(INCLUDE_DIR)/package.mk
+
+define Build/Prepare
+endef
+
+define Build/Configure
+endef
+
+define Build/Compile
+endef
+
+define Package/fwblack
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=Firewall
+  TITLE:=DNS-based nftables blocklist daemon
+  URL:=https://github.com/EdgeBites/fw-black-luci
+  DEPENDS:=+nftables +firewall4
+  PKGARCH:=all
+endef
+
+define Package/fwblack/description
+  Blocks unwanted domains/trackers at the router by watching active
+  connections, reverse-resolving them, and dropping TCP 80/443 toward
+  matches. nftables set-based, dual-stack, procd-managed, UCI-configured.
+endef
+
+define Package/fwblack/conffiles
+/etc/config/fwblack
+/etc/fwblack/blocklist.cfg
+endef
+
+define Package/fwblack/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/usr/sbin/fw-black $(1)/usr/sbin/fw-black
+
+	$(INSTALL_DIR) $(1)/usr/libexec/fwblack
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/usr/libexec/fwblack/ips.sh $(1)/usr/libexec/fwblack/ips.sh
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/usr/libexec/fwblack/resips.sh $(1)/usr/libexec/fwblack/resips.sh
+
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/etc/init.d/fwblack $(1)/etc/init.d/fwblack
+
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_CONF) $(PKG_BUILD_DIR)/files/etc/config/fwblack $(1)/etc/config/fwblack
+
+	$(INSTALL_DIR) $(1)/etc/fwblack
+	$(INSTALL_CONF) $(PKG_BUILD_DIR)/files/etc/fwblack/blocklist.cfg $(1)/etc/fwblack/blocklist.cfg
+
+	$(INSTALL_DIR) $(1)/usr/share/nftables.d/ruleset-post
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/files/usr/share/nftables.d/ruleset-post/fwblack.nft $(1)/usr/share/nftables.d/ruleset-post/fwblack.nft
+
+	$(INSTALL_DIR) $(1)/etc/uci-defaults
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/etc/uci-defaults/99-fwblack $(1)/etc/uci-defaults/99-fwblack
+
+	$(INSTALL_DIR) $(1)/etc/sysupgrade.conf.d
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/files/etc/sysupgrade.conf.d/fwblack $(1)/etc/sysupgrade.conf.d/fwblack
+endef
+
+define Package/fwblack/postinst
+#!/bin/sh
+# Migrate legacy /etc/fw.black layout on first install/upgrade.
+# (Keep in sync with files/etc/uci-defaults/99-fwblack.)
+if [ -z "$${IPKG_INSTROOT}" ]; then
+	if [ -f /etc/fw.black/blocklist.cfg ] && [ ! -e /etc/fwblack/.migrated ]; then
+		mkdir -p /etc/fwblack
+		if [ ! -f /etc/fwblack/blocklist.cfg ]; then
+			cp /etc/fw.black/blocklist.cfg /etc/fwblack/blocklist.cfg
+		elif ! cmp -s /etc/fw.black/blocklist.cfg /etc/fwblack/blocklist.cfg 2>/dev/null; then
+			cp /etc/fwblack/blocklist.cfg /etc/fwblack/blocklist.cfg.ppkg-default
+			cp /etc/fw.black/blocklist.cfg /etc/fwblack/blocklist.cfg
+		fi
+		touch /etc/fwblack/.migrated
+	fi
+	# Remove legacy fw4 include if it shadows the packaged one.
+	if [ -f /etc/nftables.d/ruleset-post/fwblack.nft ]; then
+		rm -f /etc/nftables.d/ruleset-post/fwblack.nft
+	fi
+	/etc/init.d/fwblack enable 2>/dev/null || true
+fi
+exit 0
+endef
+
+define Package/fwblack/prerm
+#!/bin/sh
+if [ -z "$${IPKG_INSTROOT}" ]; then
+	/etc/init.d/fwblack stop 2>/dev/null || true
+	/etc/init.d/fwblack disable 2>/dev/null || true
+	nft delete table inet fwblack 2>/dev/null || true
+fi
+exit 0
+endef
+
+$(eval $(call BuildPackage,fwblack))

--- a/net/fwblack/pre-test.sh
+++ b/net/fwblack/pre-test.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# pre-test.sh - ensure nftables tooling for the CI runtime test.
+# (Our fwblack DEPENDS already pulls it via firewall4; this covers
+# minimal CI images. Works with both apk and opkg based systems.)
+if ! command -v nft >/dev/null 2>&1; then
+	if command -v apk >/dev/null 2>&1; then
+		apk add nftables
+	elif command -v opkg >/dev/null 2>&1; then
+		opkg update && opkg install nftables
+	fi
+fi

--- a/net/fwblack/test-version.sh
+++ b/net/fwblack/test-version.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# test-version.sh - version check override for fwblack.
+# The generic CI version check is skipped when this file exists.
+# NOTE: plain grep without -q here - matches stay visible in CI logs.
+case "$PKG_NAME" in
+fwblack)
+	/usr/sbin/fw-black --version | grep -F "$PKG_VERSION"
+	;;
+*)
+	echo "Untested package: $PKG_NAME" >&2
+	exit 1
+	;;
+esac

--- a/net/fwblack/test.sh
+++ b/net/fwblack/test.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+# test.sh - functional CI test for fwblack (openwrt/packages CI).
+# Runs on the installed system. $1 = package name, $2 = upstream version
+# (PKG_NAME/PKG_VERSION are also provided as environment variables).
+# NOTE: plain grep without -q here - matches stay visible in CI logs.
+name="${1:-$PKG_NAME}"
+version="${2:-$PKG_VERSION}"
+
+case "$name" in
+"fwblack")
+	# Shell syntax (BusyBox ash) of every script incl. init and uci-defaults.
+	ash -n /usr/sbin/fw-black && echo "ash-ok fw-black"
+	ash -n /usr/libexec/fwblack/ips.sh && echo "ash-ok ips.sh"
+	ash -n /usr/libexec/fwblack/resips.sh && echo "ash-ok resips.sh"
+	ash -n /etc/init.d/fwblack && echo "ash-ok init"
+	# nftables ruleset parses.
+	nft -c -f /usr/share/nftables.d/ruleset-post/fwblack.nft && echo "nft-ok"
+	# UCI defaults present with expected content.
+	uci show fwblack | grep "fwblack.global.interval='300'"
+	uci show fwblack | grep "fwblack.global.blocklist='/etc/fwblack/blocklist.cfg'"
+	# Blocklist conffile ships with effective entries.
+	test -s /etc/fwblack/blocklist.cfg && echo "blocklist-present"
+	# Version flag reports this package version.
+	/usr/sbin/fw-black --version | grep -F "$version"
+	;;
+*)
+	echo "Untested package: $name" >&2
+	exit 1
+	;;
+esac


### PR DESCRIPTION
DNS-based nftables blocklist daemon for OpenWrt (IPv4+IPv6, firewall4/nftables, procd/UCI).

Upstream: https://github.com/EdgeBites/fw-black-luci, v1.0.2 tarball (codeload) with PKG_HASH verified. Daemon-only; LuCI app (luci-app-fwblack) to follow separately in openwrt/luci.

Tests:
- ash -n clean on all scripts, nft -c -f OK
- Upstream CI green (shellcheck -S warning -s sh, make stub parse, JSON/VERSION/hygiene, OpenWrt rootfs smoke with nft load + v4/v6 inserts + fw4 reload idempotent)
- Functional test.sh / test-version.sh / pre-test.sh included (no grep -q, exit 1 on unknown package)

Maintainer: Calin Vlad <calin@edgebites.com>, MIT.